### PR TITLE
Providing meaningful error message if you forget many=True.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -12,6 +12,7 @@ response content is handled by parsers and renderers.
 """
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
+from django.db.models.query import QuerySet
 from django.db.models.fields import FieldDoesNotExist
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
@@ -81,7 +82,7 @@ class BaseSerializer(Field):
         if not kwargs.pop('many_init', False):
             if not issubclass(cls, ListSerializer):
                 instance = kwargs.get('instance', args[0] if args else None)
-                if isinstance(instance, (list, tuple, models.QuerySet)):
+                if isinstance(instance, (list, tuple, QuerySet)):
                     msg = (
                         'You have passed a %s as `instance` argument but did '
                         'not set `many=True`.' % instance.__class__.__name__)

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -163,7 +163,7 @@ class BaseSerializer(Field):
             if self.instance is not None and not getattr(self, '_errors', None):
                 try:
                     self._data = self.to_representation(self.instance)
-                except Exception as exc:
+                except AttributeError as exc:
                     if isinstance(self.instance, (list, tuple, QuerySet)):
                         msg = (
                             'The reason for this exception might be that you '

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -44,16 +44,39 @@ class TestSerializer:
             serializer.data
 
     def test_missing_many_kwarg(self):
-        self.Serializer([], many=True)
-        with pytest.raises(AssertionError):
-            self.Serializer([])
-        with pytest.raises(AssertionError):
-            self.Serializer(())
-        with pytest.raises(AssertionError):
-            self.Serializer(QuerySet())
-        self.Serializer(None)
-        self.Serializer(object())
-        self.Serializer({})
+        serializer = self.Serializer([], many=True)
+        assert serializer.data == []
+
+        expect_failure = (
+            (),
+            [],
+            QuerySet()
+        )
+
+        for failure in expect_failure:
+            serializer = self.Serializer(failure)
+            with pytest.raises(AttributeError):
+                serializer.data
+
+            # Check that message was correctly annotated.
+            try:
+                serializer.data
+            except Exception as exc:
+                assert 'many=True' in str(exc)
+
+        serializer = self.Serializer(None)
+        assert serializer.data
+
+        serializer = self.Serializer(object())
+        with pytest.raises(AttributeError):
+            serializer.data
+
+        # Check that message was NOT annotated. object() is not list but does
+        # not has the required `char` and `integer` attributes.
+        try:
+            serializer.data
+        except Exception as exc:
+            assert 'many=True' not in str(exc)
 
 
 class TestValidateMethod:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,3 +1,4 @@
+from django.db.models.query import QuerySet
 from rest_framework import serializers
 import pytest
 
@@ -41,6 +42,18 @@ class TestSerializer:
         serializer = self.Serializer(instance)
         with pytest.raises(AttributeError):
             serializer.data
+
+    def test_missing_many_kwarg(self):
+        self.Serializer([], many=True)
+        with pytest.raises(AssertionError):
+            self.Serializer([])
+        with pytest.raises(AssertionError):
+            self.Serializer(())
+        with pytest.raises(AssertionError):
+            self.Serializer(QuerySet())
+        self.Serializer(None)
+        self.Serializer(object())
+        self.Serializer({})
 
 
 class TestValidateMethod:


### PR DESCRIPTION
Closes #1914.

We check the instance for beeing either a `list`, `tuple` or `QuerySet`. That should address most cases. We cannot use ducktyping by checking for existence of `__iter__` or similiar things. This would include too many kind of objects e.g. `dict`s  are perfectly fine non-many objects.