### PR TITLE
Use `ReturnDict` and `ReturnList` for nested serializers

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -363,6 +363,8 @@ class Serializer(BaseSerializer):
             attribute = field.get_attribute(instance)
             if attribute is None:
                 value = None
+            elif isinstance(field, Serializer):
+                value = field.__class__(attribute).data
             else:
                 value = field.to_representation(attribute)
             transform_method = getattr(self, 'transform_' + field.field_name, None)
@@ -479,9 +481,11 @@ class ListSerializer(BaseSerializer):
         List of object instances -> List of dicts of primitive datatypes.
         """
         iterable = data.all() if (hasattr(data, 'all')) else data
-        return [
-            self.child.to_representation(item) for item in iterable
-        ]
+        if isinstance(self.child, Serializer):
+            serializer = self.child.__class__
+            return [serializer(item).data for item in iterable]
+        else:
+            return [self.child.to_representation(item) for item in iterable]
 
     def update(self, instance, validated_data):
         raise NotImplementedError(

--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.utils.serializer_helpers import ReturnDict
 
 
 class TestNestedSerializer:
@@ -38,6 +39,20 @@ class TestNestedSerializer:
         }
         serializer = self.Serializer()
         assert serializer.data == expected_data
+
+    def test_nested_field_uses_return_dict(self):
+        input_data = {
+            'nested': {
+                'one': '1',
+                'two': '2',
+            }
+        }
+        serializer = self.Serializer(input_data)
+        assert isinstance(serializer.data['nested'], ReturnDict)
+
+    def test_empty_nested_field_uses_return_dict(self):
+        serializer = self.Serializer()
+        assert isinstance(serializer.data['nested'], ReturnDict)
 
 # """
 # Tests to cover nested serializers.


### PR DESCRIPTION
This PR just contains some initial ideas for implementing this without moving the `ReturnDict`/`ReturnList` wrapping back into `.to_representation()`.  That said a lot of tests are failing and I'm not sure this is the right path so wanted to seek guidance from the community before going to far ahead on this.  

## Explanation

I am working on a set of plugins for DRF that will allow it to work out of the box with `Ember Data` (ED), a data persistence library that is commonly used with Ember.js.  ED accepts two forms of serialized data, one of which it refers to as the ActiveModel style serialization. 

ActiveModelJson expects a JSON payload that looks like this:

```
dealerships: [
    {
        id: 1,
        title: 'The Car Depot',
        car_ids: [1, 2, 3, 4],
    }
    ...
],
```

Or like this:

```
dealership: [
   id: 1,
   title: 'The Car Depot',
   cars: [ {
        id: 1,
        title: 'Toyata',
        dealership_id: 1,
    },
    ...
   ]
]
```

In order to convert to this format in a DRF serializer, the renderer must be able to check whether a particular field is a model relation and if so change it from `plural_words` to `plural_word_ids` or from `singular_word` to `singular_word_id`.  Note that you cannot just check if the property contains an array or integer as that would result in converting integer fields and arbitrary lists by accident.

[This code](https://github.com/g-cassie/ember-drf/blob/master/ember_drf/utils.py#L31-L74) worked until about a week ago when the `ReturnDict`/`ReturnList` wrapping was moved into the `.data` property.  Now that ReturnDict/Lists do not nest, I do not see any way of achieving the same behaviour using a renderer alone.  At the same time I think the changes I am trying to make are the kind of purely aesthetic changes which should be implemented in the Renderer.  

This is a big blocker for my project so anything I can do to move this along quickly would be greatly appreciated.
