### PR TITLE
Emit warnings when settings have wrong type

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -145,3 +145,7 @@ class Throttled(APIException):
             self.detail += ' ' + force_text(
                 self.extra_detail % {'wait': self.wait}
             )
+
+
+class RESTFrameworkSettingHasUnexpectedClassWarning(Warning):
+    pass

--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -145,4 +145,3 @@ class Throttled(APIException):
             self.detail += ' ' + force_text(
                 self.extra_detail % {'wait': self.wait}
             )
-

--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -146,6 +146,3 @@ class Throttled(APIException):
                 self.extra_detail % {'wait': self.wait}
             )
 
-
-class RESTFrameworkSettingHasUnexpectedClassWarning(Warning):
-    pass

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -19,11 +19,10 @@ back to the defaults.
 """
 from __future__ import unicode_literals
 from collections import Iterable
-import warnings
+from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 from django.utils import importlib, six
 from rest_framework import ISO_8601
-from rest_framework.exceptions import RESTFrameworkSettingHasUnexpectedClassWarning
 
 
 USER_SETTINGS = getattr(settings, 'REST_FRAMEWORK', None)
@@ -197,17 +196,14 @@ class APISettings(object):
             if issubclass(val.__class__, Iterable) \
                     and (not issubclass(default.__class__, Iterable)
                          or isinstance(val, six.string_types)):
-                warnings.warn(
-                    "The `{attr}` setting must be iterable".format(**locals()),
-                    RESTFrameworkSettingHasUnexpectedClassWarning,
-                    stacklevel=3
+                raise ImproperlyConfigured(
+                    'The "{attr}" setting must be a list or a tuple'
+                    .format(attr=attr)
                 )
             elif isinstance(default, six.string_types) and not \
                     isinstance(val, six.string_types):
-                warnings.warn(
-                    "The `{attr}` setting must be a string".format(**locals()),
-                    RESTFrameworkSettingHasUnexpectedClassWarning,
-                    stacklevel=3
+                raise ImproperlyConfigured(
+                    'The "{attr}" setting must be a string'.format(attr=attr)
                 )
 
         # Coerce import strings into classes

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -196,14 +196,14 @@ class APISettings(object):
             default = self.defaults[attr]
             if issubclass(val.__class__, Iterable) \
                     and (not issubclass(default.__class__, Iterable)
-                         or isinstance(val, basestring)):
+                         or isinstance(val, six.string_types)):
                 warnings.warn(
                     "The `{attr}` setting must be iterable".format(**locals()),
                     RESTFrameworkSettingHasUnexpectedClassWarning,
                     stacklevel=3
                 )
-            elif isinstance(default, basestring) and not \
-                    isinstance(val, basestring):
+            elif isinstance(default, six.string_types) and not \
+                    isinstance(val, six.string_types):
                 warnings.warn(
                     "The `{attr}` setting must be a string".format(**locals()),
                     RESTFrameworkSettingHasUnexpectedClassWarning,

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -197,13 +197,20 @@ class APISettings(object):
                     and (not issubclass(default.__class__, Iterable)
                          or isinstance(val, six.string_types)):
                 raise ImproperlyConfigured(
-                    'The "{attr}" setting must be a list or a tuple'
-                    .format(attr=attr)
+                    'The "{settings_key}" setting must be a list or tuple, but '
+                    'got type "{type_name}" with value "{value}".'.format(
+                        settings_key=attr, type_name=val.__class__.__name__,
+                        value=val
+                    )
                 )
             elif isinstance(default, six.string_types) and not \
                     isinstance(val, six.string_types):
                 raise ImproperlyConfigured(
-                    'The "{attr}" setting must be a string'.format(attr=attr)
+                    'The "{settings_key}" setting must be a string, but '
+                    'got type "{type_name}" with value "{value}".'.format(
+                        settings_key=attr, type_name=val.__class__.__name__,
+                        value=val
+                    )
                 )
 
         # Coerce import strings into classes

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -18,9 +18,11 @@ REST framework settings, checking for user settings first, then falling
 back to the defaults.
 """
 from __future__ import unicode_literals
+import warnings
 from django.conf import settings
 from django.utils import importlib, six
 from rest_framework import ISO_8601
+from rest_framework.exceptions import RESTFrameworkSettingHasUnexpectedClassWarning
 
 
 USER_SETTINGS = getattr(settings, 'REST_FRAMEWORK', None)
@@ -187,6 +189,17 @@ class APISettings(object):
         except KeyError:
             # Fall back to defaults
             val = self.defaults[attr]
+        else:
+            expected_class = self.defaults[attr].__class__
+            if val.__class__ != expected_class:
+                warnings.warn(
+                    "The `{val}` setting has the class {val.__class__}, "
+                    "but the expected class was {expected_class}".format(
+                        **locals()
+                    ),
+                    RESTFrameworkSettingHasUnexpectedClassWarning,
+                    stacklevel=3
+                )
 
         # Coerce import strings into classes
         if val and attr in self.import_strings:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -19,9 +19,10 @@ class TestSettings(TestCase):
         with self.assertRaises(ImportError):
             settings.DEFAULT_RENDERER_CLASSES
 
-    def test_bad_setting_class_raises_warning(self):
+    def test_bad_iterable_setting_class_raises_warning(self):
         """
-        Make sure warnings are emitted when settings have an unexpected class.
+        Make sure warnings are emitted when settings which should be iterable
+        are not.
         """
         settings = APISettings({
             'DEFAULT_RENDERER_CLASSES': 'rest_framework.renderers.JSONRenderer'
@@ -30,6 +31,25 @@ class TestSettings(TestCase):
         with warnings.catch_warnings(record=True) as w:
             # Trigger a warning.
             settings.DEFAULT_RENDERER_CLASSES
+            # Verify that a warning is thrown
+            assert len(w) == 1
+            assert issubclass(
+                w[-1].category, RESTFrameworkSettingHasUnexpectedClassWarning
+            )
+
+    def test_bad_string_setting_class_raises_warning(self):
+        """
+        Make sure warnings are emitted when settings which should be strings are
+        not.
+        """
+        settings = APISettings({
+            'DEFAULT_METADATA_CLASS': []
+        })
+
+        with warnings.catch_warnings(record=True) as w:
+            # Trigger a warning.
+            settings.DEFAULT_METADATA_CLASS
+
             # Verify that a warning is thrown
             assert len(w) == 1
             assert issubclass(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
+from django.core.exceptions import ImproperlyConfigured
+import pytest
 import warnings
 from django.test import TestCase
-from rest_framework.exceptions import \
-    RESTFrameworkSettingHasUnexpectedClassWarning
 from rest_framework.settings import APISettings
 
 
@@ -21,37 +21,35 @@ class TestSettings(TestCase):
 
     def test_bad_iterable_setting_class_raises_warning(self):
         """
-        Make sure warnings are emitted when settings which should be iterable
-        are not.
+        Make sure errors are raised when settings which should be iterable are
+        not.
         """
         settings = APISettings({
             'DEFAULT_RENDERER_CLASSES': 'rest_framework.renderers.JSONRenderer'
         })
 
-        with warnings.catch_warnings(record=True) as w:
-            # Trigger a warning.
+        # Trigger the exception
+        with pytest.raises(ImproperlyConfigured) as exc_info:
             settings.DEFAULT_RENDERER_CLASSES
-            # Verify that a warning is thrown
-            assert len(w) == 1
-            assert issubclass(
-                w[-1].category, RESTFrameworkSettingHasUnexpectedClassWarning
-            )
+        expected_error = (
+            u'The "DEFAULT_RENDERER_CLASSES" setting must be a list or a tuple'
+        )
+        assert exc_info.value[0] == expected_error
 
     def test_bad_string_setting_class_raises_warning(self):
         """
-        Make sure warnings are emitted when settings which should be strings are
+        Make sure errors are raised when settings which should be strings are
         not.
         """
         settings = APISettings({
             'DEFAULT_METADATA_CLASS': []
         })
 
-        with warnings.catch_warnings(record=True) as w:
-            # Trigger a warning.
+        # Trigger the exception
+        with pytest.raises(ImproperlyConfigured) as exc_info:
             settings.DEFAULT_METADATA_CLASS
 
-            # Verify that a warning is thrown
-            assert len(w) == 1
-            assert issubclass(
-                w[-1].category, RESTFrameworkSettingHasUnexpectedClassWarning
-            )
+        expected_error = (
+            u'The "DEFAULT_METADATA_CLASS" setting must be a string'
+        )
+        assert exc_info.value[0] == expected_error

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -35,7 +35,7 @@ class TestSettings(TestCase):
             u'tuple, but got type "unicode" with value '
             u'"rest_framework.renderers.JSONRenderer".'
         )
-        assert exc_info.value[0] == expected_error
+        assert exc_info.value.args[0] == expected_error
 
     def test_bad_string_setting_class_raises_warning(self):
         """
@@ -54,4 +54,4 @@ class TestSettings(TestCase):
             u'The "DEFAULT_METADATA_CLASS" setting must be a string, but got '
             u'type "list" with value "[]".'
         )
-        assert exc_info.value[0] == expected_error
+        assert exc_info.value.args[0] == expected_error

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 from django.core.exceptions import ImproperlyConfigured
 import pytest
 from django.test import TestCase
-import six
+from django.utils import six
 from rest_framework.settings import APISettings
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 from django.core.exceptions import ImproperlyConfigured
 import pytest
-import warnings
 from django.test import TestCase
 from rest_framework.settings import APISettings
 
@@ -32,7 +31,9 @@ class TestSettings(TestCase):
         with pytest.raises(ImproperlyConfigured) as exc_info:
             settings.DEFAULT_RENDERER_CLASSES
         expected_error = (
-            u'The "DEFAULT_RENDERER_CLASSES" setting must be a list or a tuple'
+            u'The "DEFAULT_RENDERER_CLASSES" setting must be a list or '
+            u'tuple, but got type "unicode" with value '
+            u'"rest_framework.renderers.JSONRenderer".'
         )
         assert exc_info.value[0] == expected_error
 
@@ -50,6 +51,7 @@ class TestSettings(TestCase):
             settings.DEFAULT_METADATA_CLASS
 
         expected_error = (
-            u'The "DEFAULT_METADATA_CLASS" setting must be a string'
+            u'The "DEFAULT_METADATA_CLASS" setting must be a string, but got '
+            u'type "list" with value "[]".'
         )
         assert exc_info.value[0] == expected_error

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -35,9 +35,9 @@ class TestSettings(TestCase):
         # Construct the expected error message
         text_type_name = str(six.text_type.__name__)
         expected_error = (
-            u'The "DEFAULT_RENDERER_CLASSES" setting must be a list or '
-            u'tuple, but got type "{text_type_name}" with value '
-            u'"rest_framework.renderers.JSONRenderer".'.format(
+            'The "DEFAULT_RENDERER_CLASSES" setting must be a list or '
+            'tuple, but got type "{text_type_name}" with value '
+            '"rest_framework.renderers.JSONRenderer".'.format(
                 text_type_name=text_type_name
             )
         )
@@ -57,7 +57,7 @@ class TestSettings(TestCase):
             settings.DEFAULT_METADATA_CLASS
 
         expected_error = (
-            u'The "DEFAULT_METADATA_CLASS" setting must be a string, but got '
-            u'type "list" with value "[]".'
+            'The "DEFAULT_METADATA_CLASS" setting must be a string, but got '
+            'type "list" with value "[]".'
         )
         assert exc_info.value.args[0] == expected_error

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from django.core.exceptions import ImproperlyConfigured
 import pytest
 from django.test import TestCase
+import six
 from rest_framework.settings import APISettings
 
 
@@ -30,10 +31,15 @@ class TestSettings(TestCase):
         # Trigger the exception
         with pytest.raises(ImproperlyConfigured) as exc_info:
             settings.DEFAULT_RENDERER_CLASSES
+
+        # Construct the expected error message
+        text_type_name = str(six.text_type.__name__)
         expected_error = (
             u'The "DEFAULT_RENDERER_CLASSES" setting must be a list or '
-            u'tuple, but got type "unicode" with value '
-            u'"rest_framework.renderers.JSONRenderer".'
+            u'tuple, but got type "{text_type_name}" with value '
+            u'"rest_framework.renderers.JSONRenderer".'.format(
+                text_type_name=text_type_name
+            )
         )
         assert exc_info.value.args[0] == expected_error
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
+import warnings
 from django.test import TestCase
+from rest_framework.exceptions import \
+    RESTFrameworkSettingHasUnexpectedClassWarning
 from rest_framework.settings import APISettings
 
 
@@ -15,3 +18,20 @@ class TestSettings(TestCase):
         })
         with self.assertRaises(ImportError):
             settings.DEFAULT_RENDERER_CLASSES
+
+    def test_bad_setting_class_raises_warning(self):
+        """
+        Make sure warnings are emitted when settings have an unexpected class.
+        """
+        settings = APISettings({
+            'DEFAULT_RENDERER_CLASSES': 'rest_framework.renderers.JSONRenderer'
+        })
+
+        with warnings.catch_warnings(record=True) as w:
+            # Trigger a warning.
+            settings.DEFAULT_RENDERER_CLASSES
+            # Verify that a warning is thrown
+            assert len(w) == 1
+            assert issubclass(
+                w[-1].category, RESTFrameworkSettingHasUnexpectedClassWarning
+            )


### PR DESCRIPTION

Fixes https://github.com/tomchristie/django-rest-framework/issues/2177.

When there is a bad setting the user sees the yellow error page if they're in debug mode, or the server error page if they're not.

![image](https://cloud.githubusercontent.com/assets/862794/5667584/c840d606-9760-11e4-959f-c571f722a689.png)
