### PR TITLE
Document how to translate DRF error messages (version 3.1)

### DIFF
--- a/docs/topics/internationalisation.md
+++ b/docs/topics/internationalisation.md
@@ -9,12 +9,40 @@ This guide assumes you are already familiar with how to translate a Django app. 
 
 #### To translate REST framework error messages:
 
-1. Pick an app where you want the translations to be, for example `myapp`
+1. Make a new folder where you want to store the translated errors. Add this 
+path to your [`LOCALE_PATHS`][django-locale-paths] setting. 
 
-2. Add a symlink from that app to the installed `rest_framework`
+  ---
+
+  **Note:** For the rest of 
+this document we will assume the path you created was 
+`/home/www/project/conf/locale/`, and that you have updated your `settings.py` to include the setting:
+
   ```
-  ln -s /home/user/.virtualenvs/myproject/lib/python2.7/site-packages/rest_framework/ rest_framework
+  LOCALE_PATHS = (
+      '/home/www/project/conf/locale/',
+  )
   ```
+
+  ---
+
+2. Now create a subfolder for the language you want to translate. The folder should be named using [locale 
+name][django-locale-name] notation.  E.g. `de`, `pt_BR`, `es_AR`, etc.
+
+  ```
+  mkdir /home/www/project/conf/locale/pt_BR/LC_MESSAGES
+  ```
+
+3. Now copy the base translations file from the REST framework source code 
+into your translations folder
+
+  ```
+  cp /home/user/.virtualenvs/myproject/lib/python2.7/site-packages/rest_framework/locale/en_US/LC_MESSAGES/django.po
+  /home/www/project/conf/locale/pt_BR/LC_MESSAGES
+  ```
+  
+  This should create the file 
+  `/home/www/project/conf/locale/pt_BR/LC_MESSAGES/django.po`
   
   ---
 
@@ -27,17 +55,17 @@ This guide assumes you are already familiar with how to translate a Django app. 
   ---
   
   
+4. Edit `/home/www/project/conf/locale/pt_BR/LC_MESSAGES/django.po` and 
+translate all the error messages.
 
-3. Run Django's `makemessages` command in the normal way, but add the `--symlink` option.  For example, if you want to translate into Brazilian Portuguese you would run
-  ```
-  manage.py makemessages --symlink -l pt_BR
-  ```
-  
-4. Translate the `django.po` file which is created as normal.  This will be in the folder `myapp/locale/pt_BR/LC_MESSAGES`.
+5. Run `manage.py compilemessages -l pt_BR` to make the translations 
+available for Django to use. You should see a message
 
-5. Run `manage.py compilemessages` as normal
+    ```
+    processing file django.po in /home/www/project/conf/locale/pt_BR/LC_MESSAGES
+    ```
 
-6. Restart your server
+6. Restart your server.
 
 
 
@@ -59,3 +87,5 @@ REST framework will use the same preferences to select which language to display
 
 [django-translation]: https://docs.djangoproject.com/en/1.7/topics/i18n/translation
 [django-language-preference]: https://docs.djangoproject.com/en/1.7/topics/i18n/translation/#how-django-discovers-language-preference
+[django-locale-paths]: https://docs.djangoproject.com/en/1.7/ref/settings/#std:setting-LOCALE_PATHS
+[django-locale-name]: https://docs.djangoproject.com/en/1.7/topics/i18n/#term-locale-name

--- a/docs/topics/internationalisation.md
+++ b/docs/topics/internationalisation.md
@@ -70,7 +70,8 @@ available for Django to use. You should see a message
 
 
 ## How Django chooses which language to use
-REST framework will use the same preferences to select which language to display as Django does.  You can find more info in the [django docs on discovering language preferences][django-language-preference].  For reference, these are
+REST framework will use the same preferences to select which language to 
+display as Django does.  You can find more info in the [Django docs on discovering language preferences][django-language-preference].  For reference, these are
 
 1. First, it looks for the language prefix in the requested URL
 2. Failing that, it looks for the `LANGUAGE_SESSION_KEY` key in the current user’s session.

--- a/docs/topics/internationalisation.md
+++ b/docs/topics/internationalisation.md
@@ -40,4 +40,22 @@ This guide assumes you are already familiar with how to translate a Django app. 
 6. Restart your server
 
 
+
+## How Django chooses which language to use
+REST framework will use the same preferences to select which language to display as Django does.  You can find more info in the [django docs on discovering language preferences][django-language-preference].  For reference, these are
+
+1. First, it looks for the language prefix in the requested URL
+2. Failing that, it looks for the `LANGUAGE_SESSION_KEY` key in the current user’s session.
+3. Failing that, it looks for a cookie
+4. Failing that, it looks at the `Accept-Language` HTTP header.
+5. Failing that, it uses the global `LANGUAGE_CODE` setting.
+
+---
+
+**Note:** You'll need to include the `django.middleware.locale.LocaleMiddleware` to enable any of the per-request language preferences.
+
+---
+
+
 [django-translation]: https://docs.djangoproject.com/en/1.7/topics/i18n/translation
+[django-language-preference]: https://docs.djangoproject.com/en/1.7/topics/i18n/translation/#how-django-discovers-language-preference

--- a/docs/topics/internationalisation.md
+++ b/docs/topics/internationalisation.md
@@ -1,0 +1,34 @@
+# Internationalisation
+REST framework ships with translatable error messages. You can make these appear in your language enabling [Django's standard translation mechanisms](https://docs.djangoproject.com/en/1.7/topics/i18n/translation) and by translating the messages into your language.
+
+## How to translate REST Framework errors
+
+
+This guide assumes you are already familiar with how to translate a Django app. If you're not, start by reading [Django's translation docs](https://docs.djangoproject.com/en/1.7/topics/i18n/translation).
+
+
+#### To translate REST framework error messages:
+
+1. Pick an app where you want the translations to be, for example `myapp`
+
+2. Add a symlink from that app to the installed `rest_framework`
+  ```
+  ln -s /home/user/.virtualenvs/myproject/lib/python2.7/site-packages/rest_framework/ rest_framework
+  ```
+  
+  To find out where `rest_framework` is installed, run 
+
+  ```
+  python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
+  ```
+
+3. Run Django's `makemessages` command in the normal way, but add the `--symlink` option. For example, if you want to translate into Brazilian Portuguese you would run
+  ```
+  manage.py makemessages --symlink -l pt_BR
+  ```
+  
+4. Translate the `django.po` file which is created as normal. This will be in the folder `myapp/locale/pt_BR/LC_MESSAGES`.
+
+5. Run `manage.py compilemessages` as normal
+
+6. Restart your server

--- a/docs/topics/internationalisation.md
+++ b/docs/topics/internationalisation.md
@@ -1,10 +1,10 @@
 # Internationalisation
-REST framework ships with translatable error messages. You can make these appear in your language enabling [Django's standard translation mechanisms](https://docs.djangoproject.com/en/1.7/topics/i18n/translation) and by translating the messages into your language.
+REST framework ships with translatable error messages.  You can make these appear in your language enabling [Django's standard translation mechanisms][django-translation] and by translating the messages into your language.
 
 ## How to translate REST Framework errors
 
 
-This guide assumes you are already familiar with how to translate a Django app. If you're not, start by reading [Django's translation docs](https://docs.djangoproject.com/en/1.7/topics/i18n/translation).
+This guide assumes you are already familiar with how to translate a Django app.  If you're not, start by reading [Django's translation docs][django-translation].
 
 
 #### To translate REST framework error messages:
@@ -16,19 +16,28 @@ This guide assumes you are already familiar with how to translate a Django app. 
   ln -s /home/user/.virtualenvs/myproject/lib/python2.7/site-packages/rest_framework/ rest_framework
   ```
   
-  To find out where `rest_framework` is installed, run 
+  ---
+
+  **Note:** To find out where `rest_framework` is installed, run 
 
   ```
   python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
   ```
 
-3. Run Django's `makemessages` command in the normal way, but add the `--symlink` option. For example, if you want to translate into Brazilian Portuguese you would run
+  ---
+  
+  
+
+3. Run Django's `makemessages` command in the normal way, but add the `--symlink` option.  For example, if you want to translate into Brazilian Portuguese you would run
   ```
   manage.py makemessages --symlink -l pt_BR
   ```
   
-4. Translate the `django.po` file which is created as normal. This will be in the folder `myapp/locale/pt_BR/LC_MESSAGES`.
+4. Translate the `django.po` file which is created as normal.  This will be in the folder `myapp/locale/pt_BR/LC_MESSAGES`.
 
 5. Run `manage.py compilemessages` as normal
 
 6. Restart your server
+
+
+[django-translation]: https://docs.djangoproject.com/en/1.7/topics/i18n/translation

--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -36,7 +36,7 @@ class APIException(Exception):
     Subclasses should provide `.status_code` and `.default_detail` properties.
     """
     status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-    default_detail = _('A server error occurred')
+    default_detail = _('A server error occurred.')
 
     def __init__(self, detail=None):
         if detail is not None:
@@ -107,7 +107,7 @@ class MethodNotAllowed(APIException):
 
 class NotAcceptable(APIException):
     status_code = status.HTTP_406_NOT_ACCEPTABLE
-    default_detail = _('Could not satisfy the request Accept header')
+    default_detail = _('Could not satisfy the request Accept header.')
 
     def __init__(self, detail=None, available_renderers=None):
         if detail is not None:

--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -36,7 +36,7 @@ class APIException(Exception):
     Subclasses should provide `.status_code` and `.default_detail` properties.
     """
     status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-    default_detail = _('A server error occured')
+    default_detail = _('A server error occurred')
 
     def __init__(self, detail=None):
         if detail is not None:

--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -91,7 +91,7 @@ class PermissionDenied(APIException):
 
 class NotFound(APIException):
     status_code = status.HTTP_404_NOT_FOUND
-    default_detail = _('Not found')
+    default_detail = _('Not found.')
 
 
 class MethodNotAllowed(APIException):

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -640,7 +640,7 @@ class IntegerField(Field):
         'invalid': _('A valid integer is required.'),
         'max_value': _('Ensure this value is less than or equal to {max_value}.'),
         'min_value': _('Ensure this value is greater than or equal to {min_value}.'),
-        'max_string_length': _('String value too large')
+        'max_string_length': _('String value too large.')
     }
     MAX_STRING_LENGTH = 1000  # Guard against malicious string inputs.
 
@@ -674,7 +674,7 @@ class FloatField(Field):
         'invalid': _("A valid number is required."),
         'max_value': _('Ensure this value is less than or equal to {max_value}.'),
         'min_value': _('Ensure this value is greater than or equal to {min_value}.'),
-        'max_string_length': _('String value too large')
+        'max_string_length': _('String value too large.')
     }
     MAX_STRING_LENGTH = 1000  # Guard against malicious string inputs.
 
@@ -710,7 +710,7 @@ class DecimalField(Field):
         'max_digits': _('Ensure that there are no more than {max_digits} digits in total.'),
         'max_decimal_places': _('Ensure that there are no more than {max_decimal_places} decimal places.'),
         'max_whole_digits': _('Ensure that there are no more than {max_whole_digits} digits before the decimal point.'),
-        'max_string_length': _('String value too large')
+        'max_string_length': _('String value too large.')
     }
     MAX_STRING_LENGTH = 1000  # Guard against malicious string inputs.
 
@@ -793,7 +793,7 @@ class DecimalField(Field):
 
 class DateTimeField(Field):
     default_error_messages = {
-        'invalid': _('Datetime has wrong format. Use one of these formats instead: {format}'),
+        'invalid': _('Datetime has wrong format. Use one of these formats instead: {format}.'),
         'date': _('Expected a datetime but got a date.'),
     }
     format = api_settings.DATETIME_FORMAT
@@ -858,7 +858,7 @@ class DateTimeField(Field):
 
 class DateField(Field):
     default_error_messages = {
-        'invalid': _('Date has wrong format. Use one of these formats instead: {format}'),
+        'invalid': _('Date has wrong format. Use one of these formats instead: {format}.'),
         'datetime': _('Expected a date but got a datetime.'),
     }
     format = api_settings.DATE_FORMAT
@@ -916,7 +916,7 @@ class DateField(Field):
 
 class TimeField(Field):
     default_error_messages = {
-        'invalid': _('Time has wrong format. Use one of these formats instead: {format}'),
+        'invalid': _('Time has wrong format. Use one of these formats instead: {format}.'),
     }
     format = api_settings.TIME_FORMAT
     input_formats = api_settings.TIME_INPUT_FORMATS
@@ -1093,8 +1093,7 @@ class FileField(Field):
 class ImageField(FileField):
     default_error_messages = {
         'invalid_image': _(
-            'Upload a valid image. The file you uploaded was either not an '
-            'image or a corrupted image.'
+            'Upload a valid image. The file you uploaded was either not an image or a corrupted image.'
         ),
     }
 
@@ -1119,7 +1118,7 @@ class ListField(Field):
     child = None
     initial = []
     default_error_messages = {
-        'not_a_list': _('Expected a list of items but got type `{input_type}`')
+        'not_a_list': _('Expected a list of items but got type `{input_type}`.')
     }
 
     def __init__(self, *args, **kwargs):

--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -119,7 +119,7 @@ class GenericAPIView(views.APIView):
             if page == 'last':
                 page_number = paginator.num_pages
             else:
-                raise Http404(_("Page is not 'last', and cannot be converted to an int."))
+                raise Http404(_("Choose a valid page number. Page numbers must be a whole number, or must be the string 'last'."))
         try:
             page = paginator.page(page_number)
         except InvalidPage as exc:

--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -119,7 +119,7 @@ class GenericAPIView(views.APIView):
             if page == 'last':
                 page_number = paginator.num_pages
             else:
-                raise Http404(_("Page is not 'last', nor can it be converted to an int."))
+                raise Http404(_("Page is not 'last', and cannot be converted to an int."))
         try:
             page = paginator.page(page_number)
         except InvalidPage as exc:

--- a/rest_framework/locale/en_US/LC_MESSAGES/django.po
+++ b/rest_framework/locale/en_US/LC_MESSAGES/django.po
@@ -2,13 +2,13 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-12-31 12:48+0000\n"
+"POT-Creation-Date: 2014-12-31 13:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,7 +30,7 @@ msgid "Must include \"username\" and \"password\""
 msgstr ""
 
 #: rest_framework/exceptions.py:39
-msgid "A server error occurred"
+msgid "A server error occurred."
 msgstr ""
 
 #: rest_framework/exceptions.py:74
@@ -55,7 +55,7 @@ msgid "Method '%s' not allowed."
 msgstr ""
 
 #: rest_framework/exceptions.py:105
-msgid "Could not satisfy the request Accept header"
+msgid "Could not satisfy the request Accept header."
 msgstr ""
 
 #: rest_framework/exceptions.py:117
@@ -92,7 +92,7 @@ msgstr ""
 msgid "This field may not be blank."
 msgstr ""
 
-#: rest_framework/fields.py:548 rest_framework/fields.py:1250
+#: rest_framework/fields.py:548 rest_framework/fields.py:1249
 msgid "Ensure this field has no more than {max_length} characters."
 msgstr ""
 
@@ -133,7 +133,7 @@ msgstr ""
 
 #: rest_framework/fields.py:640 rest_framework/fields.py:674
 #: rest_framework/fields.py:710
-msgid "String value too large"
+msgid "String value too large."
 msgstr ""
 
 #: rest_framework/fields.py:671 rest_framework/fields.py:704
@@ -155,7 +155,7 @@ msgid ""
 msgstr ""
 
 #: rest_framework/fields.py:793
-msgid "Datetime has wrong format. Use one of these formats instead: {format}"
+msgid "Datetime has wrong format. Use one of these formats instead: {format}."
 msgstr ""
 
 #: rest_framework/fields.py:794
@@ -163,7 +163,7 @@ msgid "Expected a datetime but got a date."
 msgstr ""
 
 #: rest_framework/fields.py:858
-msgid "Date has wrong format. Use one of these formats instead: {format}"
+msgid "Date has wrong format. Use one of these formats instead: {format}."
 msgstr ""
 
 #: rest_framework/fields.py:859
@@ -171,14 +171,15 @@ msgid "Expected a date but got a datetime."
 msgstr ""
 
 #: rest_framework/fields.py:916
-msgid "Time has wrong format. Use one of these formats instead: {format}"
+msgid "Time has wrong format. Use one of these formats instead: {format}."
 msgstr ""
 
 #: rest_framework/fields.py:972 rest_framework/fields.py:1016
 msgid "`{input}` is not a valid choice."
 msgstr ""
 
-#: rest_framework/fields.py:1017 rest_framework/serializers.py:474
+#: rest_framework/fields.py:1017 rest_framework/fields.py:1118
+#: rest_framework/serializers.py:474
 msgid "Expected a list of items but got type `{input_type}`."
 msgstr ""
 
@@ -204,15 +205,15 @@ msgid ""
 msgstr ""
 
 #: rest_framework/fields.py:1093
-msgid "Upload a valid image. The file you uploaded was either not an "
-msgstr ""
-
-#: rest_framework/fields.py:1119
-msgid "Expected a list of items but got type `{input_type}`"
+msgid ""
+"Upload a valid image. The file you uploaded was either not an image or a "
+"corrupted image."
 msgstr ""
 
 #: rest_framework/generics.py:122
-msgid "Page is not 'last', and cannot be converted to an int."
+msgid ""
+"Choose a valid page number. Page numbers must be a whole number, or must be "
+"the string 'last'."
 msgstr ""
 
 #: rest_framework/generics.py:126

--- a/rest_framework/locale/en_US/LC_MESSAGES/django.po
+++ b/rest_framework/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-12-31 13:02+0000\n"
+"POT-Creation-Date: 2015-01-02 11:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,24 +50,28 @@ msgid "You do not have permission to perform this action."
 msgstr ""
 
 #: rest_framework/exceptions.py:94
+msgid "Not found."
+msgstr ""
+
+#: rest_framework/exceptions.py:99
 #, python-format
 msgid "Method '%s' not allowed."
 msgstr ""
 
-#: rest_framework/exceptions.py:105
+#: rest_framework/exceptions.py:110
 msgid "Could not satisfy the request Accept header."
 msgstr ""
 
-#: rest_framework/exceptions.py:117
+#: rest_framework/exceptions.py:122
 #, python-format
 msgid "Unsupported media type '%s' in request."
 msgstr ""
 
-#: rest_framework/exceptions.py:128
+#: rest_framework/exceptions.py:133
 msgid "Request was throttled."
 msgstr ""
 
-#: rest_framework/exceptions.py:130
+#: rest_framework/exceptions.py:135
 #, python-format
 msgid "Expected available in %(wait)d second."
 msgid_plural "Expected available in %(wait)d seconds."
@@ -84,127 +88,127 @@ msgstr ""
 msgid "This field may not be null."
 msgstr ""
 
-#: rest_framework/fields.py:484 rest_framework/fields.py:512
+#: rest_framework/fields.py:480 rest_framework/fields.py:508
 msgid "`{input}` is not a valid boolean."
 msgstr ""
 
-#: rest_framework/fields.py:547
+#: rest_framework/fields.py:543
 msgid "This field may not be blank."
 msgstr ""
 
-#: rest_framework/fields.py:548 rest_framework/fields.py:1249
+#: rest_framework/fields.py:544 rest_framework/fields.py:1252
 msgid "Ensure this field has no more than {max_length} characters."
 msgstr ""
 
-#: rest_framework/fields.py:549
+#: rest_framework/fields.py:545
 msgid "Ensure this field has at least {min_length} characters."
 msgstr ""
 
-#: rest_framework/fields.py:584
+#: rest_framework/fields.py:587
 msgid "Enter a valid email address."
 msgstr ""
 
-#: rest_framework/fields.py:601
+#: rest_framework/fields.py:604
 msgid "This value does not match the required pattern."
 msgstr ""
 
-#: rest_framework/fields.py:612
+#: rest_framework/fields.py:615
 msgid ""
 "Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens."
 msgstr ""
 
-#: rest_framework/fields.py:624
+#: rest_framework/fields.py:627
 msgid "Enter a valid URL."
 msgstr ""
 
-#: rest_framework/fields.py:637
+#: rest_framework/fields.py:640
 msgid "A valid integer is required."
 msgstr ""
 
-#: rest_framework/fields.py:638 rest_framework/fields.py:672
-#: rest_framework/fields.py:705
+#: rest_framework/fields.py:641 rest_framework/fields.py:675
+#: rest_framework/fields.py:708
 msgid "Ensure this value is less than or equal to {max_value}."
 msgstr ""
 
-#: rest_framework/fields.py:639 rest_framework/fields.py:673
-#: rest_framework/fields.py:706
+#: rest_framework/fields.py:642 rest_framework/fields.py:676
+#: rest_framework/fields.py:709
 msgid "Ensure this value is greater than or equal to {min_value}."
 msgstr ""
 
-#: rest_framework/fields.py:640 rest_framework/fields.py:674
-#: rest_framework/fields.py:710
+#: rest_framework/fields.py:643 rest_framework/fields.py:677
+#: rest_framework/fields.py:713
 msgid "String value too large."
 msgstr ""
 
-#: rest_framework/fields.py:671 rest_framework/fields.py:704
+#: rest_framework/fields.py:674 rest_framework/fields.py:707
 msgid "A valid number is required."
 msgstr ""
 
-#: rest_framework/fields.py:707
+#: rest_framework/fields.py:710
 msgid "Ensure that there are no more than {max_digits} digits in total."
 msgstr ""
 
-#: rest_framework/fields.py:708
+#: rest_framework/fields.py:711
 msgid "Ensure that there are no more than {max_decimal_places} decimal places."
 msgstr ""
 
-#: rest_framework/fields.py:709
+#: rest_framework/fields.py:712
 msgid ""
 "Ensure that there are no more than {max_whole_digits} digits before the "
 "decimal point."
 msgstr ""
 
-#: rest_framework/fields.py:793
+#: rest_framework/fields.py:796
 msgid "Datetime has wrong format. Use one of these formats instead: {format}."
 msgstr ""
 
-#: rest_framework/fields.py:794
+#: rest_framework/fields.py:797
 msgid "Expected a datetime but got a date."
 msgstr ""
 
-#: rest_framework/fields.py:858
+#: rest_framework/fields.py:861
 msgid "Date has wrong format. Use one of these formats instead: {format}."
 msgstr ""
 
-#: rest_framework/fields.py:859
+#: rest_framework/fields.py:862
 msgid "Expected a date but got a datetime."
 msgstr ""
 
-#: rest_framework/fields.py:916
+#: rest_framework/fields.py:919
 msgid "Time has wrong format. Use one of these formats instead: {format}."
 msgstr ""
 
-#: rest_framework/fields.py:972 rest_framework/fields.py:1016
+#: rest_framework/fields.py:975 rest_framework/fields.py:1019
 msgid "`{input}` is not a valid choice."
 msgstr ""
 
-#: rest_framework/fields.py:1017 rest_framework/fields.py:1118
-#: rest_framework/serializers.py:474
+#: rest_framework/fields.py:1020 rest_framework/fields.py:1121
+#: rest_framework/serializers.py:476
 msgid "Expected a list of items but got type `{input_type}`."
 msgstr ""
 
-#: rest_framework/fields.py:1047
+#: rest_framework/fields.py:1050
 msgid "No file was submitted."
 msgstr ""
 
-#: rest_framework/fields.py:1048
+#: rest_framework/fields.py:1051
 msgid "The submitted data was not a file. Check the encoding type on the form."
 msgstr ""
 
-#: rest_framework/fields.py:1049
+#: rest_framework/fields.py:1052
 msgid "No filename could be determined."
 msgstr ""
 
-#: rest_framework/fields.py:1050
+#: rest_framework/fields.py:1053
 msgid "The submitted file is empty."
 msgstr ""
 
-#: rest_framework/fields.py:1051
+#: rest_framework/fields.py:1054
 msgid ""
 "Ensure this filename has at most {max_length} characters (it has {length})."
 msgstr ""
 
-#: rest_framework/fields.py:1093
+#: rest_framework/fields.py:1096
 msgid ""
 "Upload a valid image. The file you uploaded was either not an image or a "
 "corrupted image."
@@ -275,4 +279,20 @@ msgstr ""
 
 #: rest_framework/validators.py:247
 msgid "This field must be unique for the \"{date_field}\" year."
+msgstr ""
+
+#: rest_framework/versioning.py:39
+msgid "Invalid version in 'Accept' header."
+msgstr ""
+
+#: rest_framework/versioning.py:70 rest_framework/versioning.py:112
+msgid "Invalid version in URL path."
+msgstr ""
+
+#: rest_framework/versioning.py:138
+msgid "Invalid version in hostname."
+msgstr ""
+
+#: rest_framework/versioning.py:160
+msgid "Invalid version in query parameter."
 msgstr ""

--- a/rest_framework/locale/en_US/LC_MESSAGES/django.po
+++ b/rest_framework/locale/en_US/LC_MESSAGES/django.po
@@ -1,0 +1,277 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-12-28 17:49+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: rest_framework/authtoken/serializers.py:20
+msgid "User account is disabled."
+msgstr ""
+
+#: rest_framework/authtoken/serializers.py:23
+msgid "Unable to log in with provided credentials."
+msgstr ""
+
+#: rest_framework/authtoken/serializers.py:26
+msgid "Must include \"username\" and \"password\""
+msgstr ""
+
+#: rest_framework/exceptions.py:39
+msgid "A server error occured"
+msgstr ""
+
+#: rest_framework/exceptions.py:74
+msgid "Malformed request."
+msgstr ""
+
+#: rest_framework/exceptions.py:79
+msgid "Incorrect authentication credentials."
+msgstr ""
+
+#: rest_framework/exceptions.py:84
+msgid "Authentication credentials were not provided."
+msgstr ""
+
+#: rest_framework/exceptions.py:89
+msgid "You do not have permission to perform this action."
+msgstr ""
+
+#: rest_framework/exceptions.py:94
+#, python-format
+msgid "Method '%s' not allowed."
+msgstr ""
+
+#: rest_framework/exceptions.py:105
+msgid "Could not satisfy the request Accept header"
+msgstr ""
+
+#: rest_framework/exceptions.py:117
+#, python-format
+msgid "Unsupported media type '%s' in request."
+msgstr ""
+
+#: rest_framework/exceptions.py:128
+msgid "Request was throttled."
+msgstr ""
+
+#: rest_framework/exceptions.py:130
+#, python-format
+msgid "Expected available in %(wait)d second."
+msgid_plural "Expected available in %(wait)d seconds."
+msgstr[0] ""
+msgstr[1] ""
+
+#: rest_framework/fields.py:152 rest_framework/relations.py:131
+#: rest_framework/relations.py:155 rest_framework/validators.py:77
+#: rest_framework/validators.py:155
+msgid "This field is required."
+msgstr ""
+
+#: rest_framework/fields.py:153
+msgid "This field may not be null."
+msgstr ""
+
+#: rest_framework/fields.py:484 rest_framework/fields.py:512
+msgid "`{input}` is not a valid boolean."
+msgstr ""
+
+#: rest_framework/fields.py:547
+msgid "This field may not be blank."
+msgstr ""
+
+#: rest_framework/fields.py:548 rest_framework/fields.py:1250
+msgid "Ensure this field has no more than {max_length} characters."
+msgstr ""
+
+#: rest_framework/fields.py:549
+msgid "Ensure this field has at least {min_length} characters."
+msgstr ""
+
+#: rest_framework/fields.py:584
+msgid "Enter a valid email address."
+msgstr ""
+
+#: rest_framework/fields.py:601
+msgid "This value does not match the required pattern."
+msgstr ""
+
+#: rest_framework/fields.py:612
+msgid ""
+"Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens."
+msgstr ""
+
+#: rest_framework/fields.py:624
+msgid "Enter a valid URL."
+msgstr ""
+
+#: rest_framework/fields.py:637
+msgid "A valid integer is required."
+msgstr ""
+
+#: rest_framework/fields.py:638 rest_framework/fields.py:672
+#: rest_framework/fields.py:705
+msgid "Ensure this value is less than or equal to {max_value}."
+msgstr ""
+
+#: rest_framework/fields.py:639 rest_framework/fields.py:673
+#: rest_framework/fields.py:706
+msgid "Ensure this value is greater than or equal to {min_value}."
+msgstr ""
+
+#: rest_framework/fields.py:640 rest_framework/fields.py:674
+#: rest_framework/fields.py:710
+msgid "String value too large"
+msgstr ""
+
+#: rest_framework/fields.py:671 rest_framework/fields.py:704
+msgid "A valid number is required."
+msgstr ""
+
+#: rest_framework/fields.py:707
+msgid "Ensure that there are no more than {max_digits} digits in total."
+msgstr ""
+
+#: rest_framework/fields.py:708
+msgid "Ensure that there are no more than {max_decimal_places} decimal places."
+msgstr ""
+
+#: rest_framework/fields.py:709
+msgid ""
+"Ensure that there are no more than {max_whole_digits} digits before the "
+"decimal point."
+msgstr ""
+
+#: rest_framework/fields.py:793
+msgid "Datetime has wrong format. Use one of these formats instead: {format}"
+msgstr ""
+
+#: rest_framework/fields.py:794
+msgid "Expected a datetime but got a date."
+msgstr ""
+
+#: rest_framework/fields.py:858
+msgid "Date has wrong format. Use one of these formats instead: {format}"
+msgstr ""
+
+#: rest_framework/fields.py:859
+msgid "Expected a date but got a datetime."
+msgstr ""
+
+#: rest_framework/fields.py:916
+msgid "Time has wrong format. Use one of these formats instead: {format}"
+msgstr ""
+
+#: rest_framework/fields.py:972 rest_framework/fields.py:1016
+msgid "`{input}` is not a valid choice."
+msgstr ""
+
+#: rest_framework/fields.py:1017 rest_framework/serializers.py:474
+msgid "Expected a list of items but got type `{input_type}`."
+msgstr ""
+
+#: rest_framework/fields.py:1047
+msgid "No file was submitted."
+msgstr ""
+
+#: rest_framework/fields.py:1048
+msgid "The submitted data was not a file. Check the encoding type on the form."
+msgstr ""
+
+#: rest_framework/fields.py:1049
+msgid "No filename could be determined."
+msgstr ""
+
+#: rest_framework/fields.py:1050
+msgid "The submitted file is empty."
+msgstr ""
+
+#: rest_framework/fields.py:1051
+msgid ""
+"Ensure this filename has at most {max_length} characters (it has {length})."
+msgstr ""
+
+#: rest_framework/fields.py:1093
+msgid "Upload a valid image. The file you uploaded was either not an "
+msgstr ""
+
+#: rest_framework/fields.py:1119
+msgid "Expected a list of items but got type `{input_type}`"
+msgstr ""
+
+#: rest_framework/generics.py:122
+msgid "Page is not 'last', nor can it be converted to an int."
+msgstr ""
+
+#: rest_framework/generics.py:126
+#, python-format
+msgid "Invalid page (%(page_number)s): %(message)s"
+msgstr ""
+
+#: rest_framework/relations.py:132
+msgid "Invalid pk '{pk_value}' - object does not exist."
+msgstr ""
+
+#: rest_framework/relations.py:133
+msgid "Incorrect type. Expected pk value, received {data_type}."
+msgstr ""
+
+#: rest_framework/relations.py:156
+msgid "Invalid hyperlink - No URL match"
+msgstr ""
+
+#: rest_framework/relations.py:157
+msgid "Invalid hyperlink - Incorrect URL match."
+msgstr ""
+
+#: rest_framework/relations.py:158
+msgid "Invalid hyperlink - Object does not exist."
+msgstr ""
+
+#: rest_framework/relations.py:159
+msgid "Incorrect type. Expected URL string, received {data_type}."
+msgstr ""
+
+#: rest_framework/relations.py:294
+msgid "Object with {slug_name}={value} does not exist."
+msgstr ""
+
+#: rest_framework/relations.py:295
+msgid "Invalid value."
+msgstr ""
+
+#: rest_framework/serializers.py:299
+msgid "Invalid data. Expected a dictionary, but got {datatype}."
+msgstr ""
+
+#: rest_framework/validators.py:22
+msgid "This field must be unique."
+msgstr ""
+
+#: rest_framework/validators.py:76
+msgid "The fields {field_names} must make a unique set."
+msgstr ""
+
+#: rest_framework/validators.py:219
+msgid "This field must be unique for the \"{date_field}\" date."
+msgstr ""
+
+#: rest_framework/validators.py:234
+msgid "This field must be unique for the \"{date_field}\" month."
+msgstr ""
+
+#: rest_framework/validators.py:247
+msgid "This field must be unique for the \"{date_field}\" year."
+msgstr ""

--- a/rest_framework/locale/en_US/LC_MESSAGES/django.po
+++ b/rest_framework/locale/en_US/LC_MESSAGES/django.po
@@ -2,13 +2,13 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-12-28 17:49+0000\n"
+"POT-Creation-Date: 2014-12-31 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,7 +30,7 @@ msgid "Must include \"username\" and \"password\""
 msgstr ""
 
 #: rest_framework/exceptions.py:39
-msgid "A server error occured"
+msgid "A server error occurred"
 msgstr ""
 
 #: rest_framework/exceptions.py:74
@@ -212,7 +212,7 @@ msgid "Expected a list of items but got type `{input_type}`"
 msgstr ""
 
 #: rest_framework/generics.py:122
-msgid "Page is not 'last', nor can it be converted to an int."
+msgid "Page is not 'last', and cannot be converted to an int."
 msgstr ""
 
 #: rest_framework/generics.py:126

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -640,8 +640,8 @@ class TestDateField(FieldValues):
         datetime.date(2001, 1, 1): datetime.date(2001, 1, 1),
     }
     invalid_inputs = {
-        'abc': ['Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]]'],
-        '2001-99-99': ['Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]]'],
+        'abc': ['Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]].'],
+        '2001-99-99': ['Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]].'],
         datetime.datetime(2001, 1, 1, 12, 00): ['Expected a date but got a datetime.'],
     }
     outputs = {
@@ -658,7 +658,7 @@ class TestCustomInputFormatDateField(FieldValues):
         '1 Jan 2001': datetime.date(2001, 1, 1),
     }
     invalid_inputs = {
-        '2001-01-01': ['Date has wrong format. Use one of these formats instead: DD [Jan-Dec] YYYY']
+        '2001-01-01': ['Date has wrong format. Use one of these formats instead: DD [Jan-Dec] YYYY.']
     }
     outputs = {}
     field = serializers.DateField(input_formats=['%d %b %Y'])
@@ -702,8 +702,8 @@ class TestDateTimeField(FieldValues):
         '2001-01-01T14:00+01:00' if (django.VERSION > (1, 4)) else '2001-01-01T13:00Z': datetime.datetime(2001, 1, 1, 13, 00, tzinfo=timezone.UTC())
     }
     invalid_inputs = {
-        'abc': ['Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z]'],
-        '2001-99-99T99:00': ['Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z]'],
+        'abc': ['Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z].'],
+        '2001-99-99T99:00': ['Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z].'],
         datetime.date(2001, 1, 1): ['Expected a datetime but got a date.'],
     }
     outputs = {
@@ -721,7 +721,7 @@ class TestCustomInputFormatDateTimeField(FieldValues):
         '1:35pm, 1 Jan 2001': datetime.datetime(2001, 1, 1, 13, 35, tzinfo=timezone.UTC()),
     }
     invalid_inputs = {
-        '2001-01-01T20:50': ['Datetime has wrong format. Use one of these formats instead: hh:mm[AM|PM], DD [Jan-Dec] YYYY']
+        '2001-01-01T20:50': ['Datetime has wrong format. Use one of these formats instead: hh:mm[AM|PM], DD [Jan-Dec] YYYY.']
     }
     outputs = {}
     field = serializers.DateTimeField(default_timezone=timezone.UTC(), input_formats=['%I:%M%p, %d %b %Y'])
@@ -773,8 +773,8 @@ class TestTimeField(FieldValues):
         datetime.time(13, 00): datetime.time(13, 00),
     }
     invalid_inputs = {
-        'abc': ['Time has wrong format. Use one of these formats instead: hh:mm[:ss[.uuuuuu]]'],
-        '99:99': ['Time has wrong format. Use one of these formats instead: hh:mm[:ss[.uuuuuu]]'],
+        'abc': ['Time has wrong format. Use one of these formats instead: hh:mm[:ss[.uuuuuu]].'],
+        '99:99': ['Time has wrong format. Use one of these formats instead: hh:mm[:ss[.uuuuuu]].'],
     }
     outputs = {
         datetime.time(13, 00): '13:00:00'
@@ -790,7 +790,7 @@ class TestCustomInputFormatTimeField(FieldValues):
         '1:00pm': datetime.time(13, 00),
     }
     invalid_inputs = {
-        '13:00': ['Time has wrong format. Use one of these formats instead: hh:mm[AM|PM]'],
+        '13:00': ['Time has wrong format. Use one of these formats instead: hh:mm[AM|PM].'],
     }
     outputs = {}
     field = serializers.TimeField(input_formats=['%I:%M%p'])
@@ -1028,7 +1028,7 @@ class TestListField(FieldValues):
         (['1', '2', '3'], [1, 2, 3])
     ]
     invalid_inputs = [
-        ('not a list', ['Expected a list of items but got type `str`']),
+        ('not a list', ['Expected a list of items but got type `str`.']),
         ([1, 2, 'error'], ['A valid integer is required.'])
     ]
     outputs = [


### PR DESCRIPTION
Adds the translation documentation into the `version-3.1` branch

Continuation of https://github.com/tomchristie/django-rest-framework/pull/2353.

@tomchristie A couple of new errors were added in 3.1. They're in the `django.po` on this branch, but weren't in the file on the original PR I made.