### PR TITLE
Mark Django REST Framework as incompatible with eggs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
     packages=get_packages('rest_framework'),
     package_data=get_package_data('rest_framework'),
     install_requires=[],
+    zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
I just found that sometime Django REST Framework HTML renderer may not work depending on how you install it. In my case, this was listed within a `setup.py`'s `install_require` which lead Django REST Framework to be installed as an egg.
Django doesn't load templates from eggs by default and has no way to gather the static files from an egg at all.
jezdez & dstuff confirm the way to fix that is to mark the packages as `zip_safe = False`.