### PR TITLE
Make FileUploadParser work with standard django API

### DIFF
--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -277,7 +277,7 @@ class FileUploadParser(BaseParser):
         for index, handler in enumerate(upload_handlers):
             file_obj = handler.file_complete(counters[index])
             if file_obj:
-                return DataAndFiles(None, {'file': file_obj})
+                return DataAndFiles({}, {'file': file_obj})
         raise ParseError("FileUpload parse error - "
                          "none of upload handlers can handle the stream")
 


### PR DESCRIPTION
Output from parsers ends up in a Django MergeDict and they exists elements to be dicts - not None

Right now if FileUploadParser is used then trying to access request.data['file'] will give ** TypeError: 'NoneType' object has no attribute '__getitem__'

Making  sure that the data part is an empty dict fixes this 