### PR TITLE
Fix ident format when using HTTP_X_FORWARDED_FOR

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -32,7 +32,7 @@ class BaseThrottle(object):
             if num_proxies == 0 or xff is None:
                 return remote_addr
             addrs = xff.split(',')
-            client_addr = addrs[-min(num_proxies, len(xff))]
+            client_addr = addrs[-min(num_proxies, len(addrs))]
             return client_addr.strip()
 
         return ''.join(xff.split()) if xff else remote_addr

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -35,7 +35,7 @@ class BaseThrottle(object):
             client_addr = addrs[-min(num_proxies, len(xff))]
             return client_addr.strip()
 
-        return xff if xff else remote_addr
+        return ''.join(xff.split()) if xff else remote_addr
 
     def wait(self):
         """
@@ -172,12 +172,6 @@ class AnonRateThrottle(SimpleRateThrottle):
     def get_cache_key(self, request, view):
         if request.user.is_authenticated():
             return None  # Only throttle unauthenticated requests.
-
-        ident = request.META.get('HTTP_X_FORWARDED_FOR')
-        if ident is None:
-            ident = request.META.get('REMOTE_ADDR')
-        else:
-            ident = ''.join(ident.split())
 
         return self.cache_format % {
             'scope': self.scope,


### PR DESCRIPTION
If `NUM_PROXIES` setting is set to None, `HTTP_X_FORWARDED_FOR` might be used as is, which
might contain spaces and cause errors on cache backends like memcached. Ref #2400