### PR TITLE
Remove HiddenField fields from HTML renderers

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -449,6 +449,11 @@ class HTMLFormRenderer(BaseRenderer):
         else:
             template_name = style['template_pack'].strip('/') + '/' + style['base_template']
 
+        # Remove hidden fields from serializer before rendering
+        for field in form.fields:
+            if isinstance(form.fields[field], serializers.HiddenField):
+                form.fields.pop(field)
+
         renderer_context = renderer_context or {}
         request = renderer_context['request']
         template = loader.get_template(template_name)
@@ -624,6 +629,11 @@ class BrowsableAPIRenderer(BaseRenderer):
                     serializer = view.get_serializer(instance=instance)
                 else:
                     serializer = view.get_serializer()
+
+                # Remove hidden fields from serializer before rendering
+                for field in serializer.fields:
+                    if isinstance(serializer.fields[field], serializers.HiddenField):
+                        serializer.fields.pop(field)
 
                 # Render the raw data content
                 renderer = renderer_class()


### PR DESCRIPTION
Seems like I wasn't able to reopen #2411, sorry for the noise. This is a work in progress to discuss. This change removes serializer fields of HiddenField type before rendering with `HTMLFormRenderer` or in the `BrowsableAPIRenderer` raw data form.

Thinking that perhaps I should be instead using `serializer.get_fields()` to avoid modifying the serializer that might be used afterwards the actual rendering.

Ref #2410