### PR TITLE
Remove assertions for redundant SerializerMethodField source args.

### DIFF
--- a/docs/topics/3.0-announcement.md
+++ b/docs/topics/3.0-announcement.md
@@ -699,18 +699,6 @@ The argument to `SerializerMethodField` is now optional, and defaults to `get_<f
         def get_billing_details(self, account):
             return calculate_billing(account)
 
-In order to ensure a consistent code style an assertion error will be raised if you include a redundant method name argument that matches the default method name. For example, the following code *will raise an error*:
-
-    billing_details = serializers.SerializerMethodField('get_billing_details')
-
-#### Enforcing consistent `source` usage.
-
-I've see several codebases that unnecessarily include the `source` argument, setting it to the same value as the field name. This usage is redundant and confusing, making it less obvious that `source` is usually not required.
-
-The following usage will *now raise an error*:
-
-    email = serializers.EmailField(source='email')
-
 #### The `UniqueValidator` and `UniqueTogetherValidator` classes.
 
 REST framework now provides new validators that allow you to ensure field uniqueness, while still using a completely explicit `Serializer` class instead of using `ModelSerializer`.

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -210,16 +210,6 @@ class Field(object):
         Called when a field is added to the parent serializer instance.
         """
 
-        # In order to enforce a consistent style, we error if a redundant
-        # 'source' argument has been used. For example:
-        # my_field = serializer.CharField(source='my_field')
-        assert self.source != field_name, (
-            "It is redundant to specify `source='%s'` on field '%s' in "
-            "serializer '%s', because it is the same as the field name. "
-            "Remove the `source` keyword argument." %
-            (field_name, self.__class__.__name__, parent.__class__.__name__)
-        )
-
         self.field_name = field_name
         self.parent = parent
 
@@ -1219,17 +1209,7 @@ class SerializerMethodField(Field):
         super(SerializerMethodField, self).__init__(**kwargs)
 
     def bind(self, field_name, parent):
-        # In order to enforce a consistent style, we error if a redundant
-        # 'method_name' argument has been used. For example:
-        # my_field = serializer.CharField(source='my_field')
         default_method_name = 'get_{field_name}'.format(field_name=field_name)
-        assert self.method_name != default_method_name, (
-            "It is redundant to specify `%s` on SerializerMethodField '%s' in "
-            "serializer '%s', because it is the same as the default method name. "
-            "Remove the `method_name` argument." %
-            (self.method_name, field_name, parent.__class__.__name__)
-        )
-
         # The method name should default to `get_{field_name}`.
         if self.method_name is None:
             self.method_name = default_method_name

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -81,17 +81,6 @@ class TestSource:
         assert serializer.is_valid()
         assert serializer.validated_data == {'other': 'abc'}
 
-    def test_redundant_source(self):
-        class ExampleSerializer(serializers.Serializer):
-            example_field = serializers.CharField(source='example_field')
-        with pytest.raises(AssertionError) as exc_info:
-            ExampleSerializer().fields
-        assert str(exc_info.value) == (
-            "It is redundant to specify `source='example_field'` on field "
-            "'CharField' in serializer 'ExampleSerializer', because it is the "
-            "same as the field name. Remove the `source` keyword argument."
-        )
-
 
 class TestReadOnly:
     def setup(self):
@@ -1078,16 +1067,3 @@ class TestSerializerMethodField:
         assert serializer.data == {
             'example_field': 'ran get_example_field(123)'
         }
-
-    def test_redundant_method_name(self):
-        class ExampleSerializer(serializers.Serializer):
-            example_field = serializers.SerializerMethodField('get_example_field')
-
-        with pytest.raises(AssertionError) as exc_info:
-            ExampleSerializer().fields
-        assert str(exc_info.value) == (
-            "It is redundant to specify `get_example_field` on "
-            "SerializerMethodField 'example_field' in serializer "
-            "'ExampleSerializer', because it is the same as the default "
-            "method name. Remove the `method_name` argument."
-        )


### PR DESCRIPTION
As discussed in #2420, removed SerializerMethodField's assertion raised when redundant source params are passed.

It looks like this was also in the base Field class. For the sake of consistency, I removed this, too. While I think an error *could* make sense for something like a CharField on a ModelSerializer, it would be a bit of an inconsistent bit of policing. It's probably best left to the people using DRF to police their own codebases. FWIW, I'd definitely pick on redundant CharFields in my code reviews, but SerializerMethodFields are a lot more open-ended by definition.

If you wanted to take the split approach (policing for non-SerializerMethodField), I could add an optional kwarg to bind and have SerializerMethodField's __init__ pass along a value to disable the policing. Though, that could gunk some people up since we'd be changing the signature of a pretty base level class.

The 3.0 release announcement were updated. I thought about adding an entry to the changelog under 3.0.4, but since I don't see a header for 3.0.4 yet I am assuming this is done as part of the release process.

All tests passed on tox, aside from the django-master stuff that was already failing beforehand.