### PR TITLE
enabled OPTIONS and meta data of AuthToken

### DIFF
--- a/rest_framework/authtoken/views.py
+++ b/rest_framework/authtoken/views.py
@@ -1,4 +1,4 @@
-from rest_framework.views import APIView
+from rest_framework import generics
 from rest_framework import parsers
 from rest_framework import renderers
 from rest_framework.response import Response
@@ -6,11 +6,12 @@ from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.serializers import AuthTokenSerializer
 
 
-class ObtainAuthToken(APIView):
+class ObtainAuthToken(generics.GenericAPIView):
     throttle_classes = ()
     permission_classes = ()
     parser_classes = (parsers.FormParser, parsers.MultiPartParser, parsers.JSONParser,)
     renderer_classes = (renderers.JSONRenderer,)
+    serializer_class = AuthTokenSerializer
 
     def post(self, request):
         serializer = AuthTokenSerializer(data=request.data)


### PR DESCRIPTION
Utilize GenericAPIView instead of APIView to enabled OPTIONS and meta data of token based auth.

Now, when OPTIONS an 'obtain auth token' endpoint, it returns full information like this
```json
{
"name":"Obtain Auth Token",
...
"actions":{
    "POST":
    {
        "username":{"type":"string","required":true,"read_only":false,"label":"Username"},
        "password":{"type":"string","required":true,"read_only":false,"label":"Password"}}}}
```
}

which is much more friendly to consumer, Swagger, and Browerable API than before.