### PR TITLE
Preliminary Support For Django 1.8 Alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ env:
     - TOX_ENV=py26-django15
     - TOX_ENV=py27-django14
     - TOX_ENV=py26-django14
+    - TOX_ENV=py34-django18alpha
+    - TOX_ENV=py33-django18alpha
+    - TOX_ENV=py32-django18alpha
+    - TOX_ENV=py27-django18alpha
     - TOX_ENV=py34-djangomaster
     - TOX_ENV=py33-djangomaster
     - TOX_ENV=py32-djangomaster
@@ -29,6 +33,10 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: TOX_ENV=py34-django18alpha
+    - env: TOX_ENV=py33-django18alpha
+    - env: TOX_ENV=py32-django18alpha
+    - env: TOX_ENV=py27-django18alpha
     - env: TOX_ENV=py34-djangomaster
     - env: TOX_ENV=py33-djangomaster
     - env: TOX_ENV=py32-djangomaster

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Django>=1.4.11
 
 # Test requirements
 pytest-django==2.8.0
-pytest==2.5.2
+pytest==2.6.4
 pytest-cov==1.6
 flake8==2.2.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 Django>=1.4.11
 
 # Test requirements
-pytest-django==2.6
+pytest-django==2.8.0
 pytest==2.5.2
 pytest-cov==1.6
 flake8==2.2.2

--- a/tests/test_multitable_inheritance.py
+++ b/tests/test_multitable_inheritance.py
@@ -48,8 +48,8 @@ class InheritedModelSerializationTests(TestCase):
         Assert that a model with a onetoone field that is the primary key is
         not treated like a derived model
         """
-        parent = ParentModel(name1='parent name')
-        associate = AssociatedModel(name='hello', ref=parent)
+        parent = ParentModel.objects.create(name1='parent name')
+        associate = AssociatedModel.objects.create(name='hello', ref=parent)
         serializer = AssociatedModelSerializer(associate)
         self.assertEqual(set(serializer.data.keys()),
                          set(['name', 'ref']))

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
        py27-{flake8,docs},
        {py26,py27}-django14,
        {py26,py27,py32,py33,py34}-django{15,16},
-       {py27,py32,py33,py34}-django{17,master}
+       {py27,py32,py33,py34}-django{17,18alpha,master}
 
 [testenv]
 commands = ./runtests.py --fast
@@ -14,6 +14,7 @@ deps =
        django15: Django==1.5.6  # Should track minimum supported
        django16: Django==1.6.3  # Should track minimum supported
        django17: Django==1.7.2  # Should track maximum supported
+       django18alpha: https://www.djangoproject.com/download/1.8a1/tarball/
        djangomaster: https://github.com/django/django/zipball/master
        {py26,py27}-django{14,15,16,17}: django-guardian==1.2.3
        {py26,py27}-django{14,15,16}: oauth2==1.5.211

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
        {py26,py27}-django{14,15,16}: django-oauth-plus==2.2.1
        {py26,py27}-django{14,15}: django-oauth2-provider==0.2.3
        {py26,py27}-django16: django-oauth2-provider==0.2.4
-       pytest-django==2.6.1
+       pytest-django==2.8.0
        django-filter==0.7
        defusedxml==0.3
        markdown>=2.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
 
 [testenv:py27-flake8]
 deps =
-       pytest==2.5.2
+       pytest==2.6.4
        flake8==2.2.2
 commands = ./runtests.py --lintonly
 


### PR DESCRIPTION
This PR adds Django 1.8 alpha to the test matrix.

It also *begins* to address failing Django 1.8 Alpha tests:

-  Bumps `pytest` and `pytest-django` to their latest versions in both `requirements.txt` and the Tox builds to resolve `Failed: Database access not allowed, use the "django_db" mark to enable` failures which were [related to the older version of pytest-django](https://github.com/pytest-dev/pytest-django/issues/189)
- Save objects before assigning them in `InheritedModelSerializationTests.test_onetoone_primary_key_model_fields_as_expected()` to [resolve a new error raised in Django 1.8](https://docs.djangoproject.com/en/dev/releases/1.8/#assigning-unsaved-objects-to-relations-raises-an-error)

Related issue: https://github.com/tomchristie/django-rest-framework/issues/2425