### PR TITLE
Drop trailing whitespace on indented JSON output.

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -90,7 +90,9 @@ class JSONRenderer(BaseRenderer):
 
         renderer_context = renderer_context or {}
         indent = self.get_indent(accepted_media_type, renderer_context)
-        separators = SHORT_SEPARATORS if (indent is None and self.compact) else LONG_SEPARATORS
+        separators = renderer_context.get(
+            'separators',
+            SHORT_SEPARATORS if (indent is None and self.compact) else LONG_SEPARATORS)
 
         ret = json.dumps(
             data, cls=self.encoder_class,


### PR DESCRIPTION
When using JSONRenderer with indentation, it adds trailing whitespace to every
line, because it's using `LONG_SEPARATORS`. 

I checked for open issues and checked master, and it seems like this is still
an issue in the latest versions.

I thought a simple way of fixing this would be something like adding custom
separators support to the renderer context, since that would also be backwards
compatible.

Sorry, in advance, if I was supposed to make an issue first for discussion.