### PR TITLE
Fix timedelta JSON serialization on Python 2.6.

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -33,6 +33,14 @@ def unicode_to_repr(value):
     return value
 
 
+def total_seconds(timedelta):
+    # TimeDelta.total_seconds() is only available in Python 2.7
+    if hasattr(timedelta, 'total_seconds'):
+        return timedelta.total_seconds()
+    else:
+        return (timedelta.days * 86400.0) + float(timedelta.seconds) + (timedelta.microseconds / 1000000.0)
+
+
 # OrderedDict only available in Python 2.7.
 # This will always be the case in Django 1.7 and above, as these versions
 # no longer support Python 2.6.

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -6,7 +6,7 @@ from django.db.models.query import QuerySet
 from django.utils import six, timezone
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
-from rest_framework.compat import OrderedDict
+from rest_framework.compat import OrderedDict, total_seconds
 from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
 import datetime
 import decimal
@@ -41,7 +41,7 @@ class JSONEncoder(json.JSONEncoder):
                 representation = representation[:12]
             return representation
         elif isinstance(obj, datetime.timedelta):
-            return six.text_type(obj.total_seconds())
+            return six.text_type(total_seconds(obj))
         elif isinstance(obj, decimal.Decimal):
             # Serializers will coerce decimals to strings by default.
             return float(obj)


### PR DESCRIPTION
Timedelta serialisation does not work on Python 2.6.

`timedelta.total_seconds()` is only supported since Python 2.7 (https://docs.python.org/2.7/library/datetime.html#datetime.timedelta.total_seconds), so we need a fallback for python 2.6.