### PR TITLE
Update Django-Filter references

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ The following packages are optional:
 * [Markdown][markdown] (2.1.0+) - Markdown support for the browsable API.
 * [PyYAML][yaml] (3.10+) - YAML content-type support.
 * [defusedxml][defusedxml] (0.3+) - XML content-type support.
-* [django-filter][django-filter] (0.5.4+) - Filtering support.
+* [django-filter][django-filter] (0.9.2+) - Filtering support.
 * [django-oauth-plus][django-oauth-plus] (2.0+) and [oauth2][oauth2] (1.5.211+) - OAuth 1.0a support.
 * [django-oauth2-provider][django-oauth2-provider] (0.2.3+) - OAuth 2.0 support.
 * [django-guardian][django-guardian] (1.1.1+) - Object level permissions support.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ markdown>=2.1.0
 PyYAML>=3.10
 defusedxml>=0.3
 django-guardian==1.2.4
-django-filter>=0.5.4
+django-filter>=0.9.2
 django-oauth-plus>=2.2.1
 oauth2>=1.5.211
 django-oauth2-provider>=0.2.4

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
        {py26,py27}-django{14,15}: django-oauth2-provider==0.2.3
        {py26,py27}-django16: django-oauth2-provider==0.2.4
        pytest-django==2.8.0
-       {py26,py27,py32,py33,py34}-django{14,15,16,17}: django-filter==0.7
+       django-filter==0.9.2
        defusedxml==0.3
        markdown>=2.1.0
        PyYAML>=3.10


### PR DESCRIPTION
[Django-Filter 0.9.2](https://pypi.python.org/pypi/django-filter/0.9.2) adds compatibility with Django v1.8a1. 

This PR: 

* Restores Django-Filter to the `tox` run for v1.8
* Updates various references to Django-Filter to latest version.

