### PR TITLE
Improve test of whether file was parsed successfully.

### DIFF
--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -276,7 +276,7 @@ class FileUploadParser(BaseParser):
 
         for index, handler in enumerate(upload_handlers):
             file_obj = handler.file_complete(counters[index])
-            if file_obj:
+            if file_obj is not None:
                 return DataAndFiles({}, {'file': file_obj})
         raise ParseError("FileUpload parse error - "
                          "none of upload handlers can handle the stream")


### PR DESCRIPTION
[bool(file) is True iff file.name is non-empty](https://github.com/django/django/blob/master/django/core/files/base.py#L31), so if there's no filename associated (e.g. no content-disposition) it wouldn't otherwise detect that a file upload handler successfully handled a file.