### PR TITLE
Pass {} as data to DataAndFiles, as it ends up in a MergeDict

### DIFF
--- a/rest_framework/parsers.py
+++ b/rest_framework/parsers.py
@@ -250,7 +250,7 @@ class FileUploadParser(BaseParser):
                                               None,
                                               encoding)
             if result is not None:
-                return DataAndFiles(None, {'file': result[1]})
+                return DataAndFiles({}, {'file': result[1]})
 
         # This is the standard case.
         possible_sizes = [x.chunk_size for x in upload_handlers if x.chunk_size]


### PR DESCRIPTION
In the same vein as #2399.