### PR TITLE
Replaced "fields" with "raw_id_fields" in the "user" field in authtoken/admin.py

### DIFF
--- a/rest_framework/authtoken/admin.py
+++ b/rest_framework/authtoken/admin.py
@@ -4,7 +4,7 @@ from rest_framework.authtoken.models import Token
 
 class TokenAdmin(admin.ModelAdmin):
     list_display = ('key', 'user', 'created')
-    fields = ('user',)
+    raw_id_fields = ('user',)
     ordering = ('-created',)
 
 


### PR DESCRIPTION
So that the admin view doesn't timeout with databases that contain a considerable amount of users.