### PR TITLE
In the BrowsableAPIRenderer the form now can be disabled

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -253,6 +253,12 @@ The name of a URL parameter that may be used to override the default `Accept` he
 
 Default: `'format'`
 
+#### SHOW_FORM
+
+Show the form in the BrowsableAPIRenderer.
+
+Default: `True`
+
 ---
 
 ## Date and time formatting

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -510,8 +510,11 @@ class BrowsableAPIRenderer(BaseRenderer):
 
     def show_form_for_method(self, view, method, request, obj):
         """
-        Returns True if a form should be shown for this method.
+        Returns True if a form should be shown for this method, or can be show at all.
         """
+        if not api_settings.SHOW_FORM:
+            return False
+
         if method not in view.allowed_methods:
             return  # Not a valid method
 

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -92,6 +92,7 @@ DEFAULTS = {
     'FORM_CONTENTTYPE_OVERRIDE': '_content_type',
     'URL_ACCEPT_OVERRIDE': 'accept',
     'URL_FORMAT_OVERRIDE': 'format',
+    'SHOW_FORM': True,
 
     'FORMAT_SUFFIX_KWARG': 'format',
     'URL_FIELD_NAME': 'url',


### PR DESCRIPTION
Now you can disable the form on the BrowsableAPIRenderer if you want. It can improve the performance if a form for example contains a select field more than 1000 choices (in our actual system we have more than 20000 choice) +  we don't want to use the  BrowsableAPI form.
This is my first pull request so i really hope that i did everything fine, i will appreciate any advice.