### PR TITLE
test read_only field functionality is same as meta read_only_fields

### DIFF
--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -295,3 +295,32 @@ class TestCacheSerializerData:
         pickled = pickle.dumps(serializer.data)
         data = pickle.loads(pickled)
         assert data == {'field1': 'a', 'field2': 'b'}
+
+
+class TestReadOnlyMetaVsFields:
+    def setup(self):
+        class ReadOnlyMetaSerializer(serializers.Serializer):
+            foo = serializers.CharField()
+            class Meta:
+                read_only_fields = (
+                    'foo',
+                )
+
+        class ReadOnlyFieldSerializer(serializers.Serializer):
+            foo = serializers.CharField(read_only=True)
+
+        self.MetaSerializer = ReadOnlyMetaSerializer
+        self.FieldSerializer = ReadOnlyFieldSerializer
+
+    def test_deserialize_is_equivalent(self):
+        data = {
+            'foo': 'bar'
+        }
+        meta_serializer = self.MetaSerializer(data=data)
+        assert meta_serializer.is_valid()
+        field_serializer = self.FieldSerializer(data=data)
+        assert field_serializer.is_valid()
+
+        assert 'foo' in meta_serializer.validated_data
+        assert 'foo' in field_serializer.validated_data
+        assert meta_serializer.validated_data['foo'] == field_serializer.validated_data['foo']


### PR DESCRIPTION
I would expect the functionality/behaviour of these two serializers to be the same

    class ReadOnlyMetaSerializer(serializers.Serializer):
        foo = serializers.CharField()

        class Meta:
            read_only_fields = (
                'foo',
            )

    class ReadOnlyFieldSerializer(serializers.Serializer):
        foo = serializers.CharField(read_only=True)

however the second one doesn't have `foo` in its `validated_data`. This pull request just adds a test to demonstrate this.

I'm curious to know if this is expected, or a bug.
