### PR TITLE
Reload api_settings when using Django's 'override_settings'

### DIFF
--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -18,6 +18,7 @@ REST framework settings, checking for user settings first, then falling
 back to the defaults.
 """
 from __future__ import unicode_literals
+from django.test.signals import setting_changed
 from django.conf import settings
 from django.utils import importlib, six
 from rest_framework import ISO_8601
@@ -198,3 +199,13 @@ class APISettings(object):
 
 
 api_settings = APISettings(USER_SETTINGS, DEFAULTS, IMPORT_STRINGS)
+
+
+def reload_api_settings(*args, **kwargs):
+    global api_settings
+    setting, value = kwargs['setting'], kwargs['value']
+    if setting == 'REST_FRAMEWORK':
+        api_settings = APISettings(value, DEFAULTS, IMPORT_STRINGS)
+
+
+setting_changed.connect(reload_api_settings)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -5,13 +5,15 @@ from django.db import models
 from django.conf.urls import patterns, url
 from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.utils import unittest
 from django.utils.dateparse import parse_date
+from django.utils.six.moves import reload_module
 from rest_framework import generics, serializers, status, filters
 from rest_framework.compat import django_filters
 from rest_framework.test import APIRequestFactory
 from .models import BaseFilterableItem, FilterableItem, BasicModel
-from .utils import temporary_setting
+
 
 factory = APIRequestFactory()
 
@@ -404,7 +406,9 @@ class SearchFilterTests(TestCase):
         )
 
     def test_search_with_nonstandard_search_param(self):
-        with temporary_setting('SEARCH_PARAM', 'query', module=filters):
+        with override_settings(REST_FRAMEWORK={'SEARCH_PARAM': 'query'}):
+            reload_module(filters)
+
             class SearchListView(generics.ListAPIView):
                 queryset = SearchFilterModel.objects.all()
                 serializer_class = SearchFilterSerializer
@@ -421,6 +425,8 @@ class SearchFilterTests(TestCase):
                     {'id': 2, 'title': 'zz', 'text': 'bcd'}
                 ]
             )
+
+        reload_module(filters)
 
 
 class OrderingFilterModel(models.Model):
@@ -642,7 +648,9 @@ class OrderingFilterTests(TestCase):
         )
 
     def test_ordering_with_nonstandard_ordering_param(self):
-        with temporary_setting('ORDERING_PARAM', 'order', filters):
+        with override_settings(REST_FRAMEWORK={'ORDERING_PARAM': 'order'}):
+            reload_module(filters)
+
             class OrderingListView(generics.ListAPIView):
                 queryset = OrderingFilterModel.objects.all()
                 serializer_class = OrderingFilterSerializer
@@ -661,6 +669,8 @@ class OrderingFilterTests(TestCase):
                     {'id': 3, 'title': 'xwv', 'text': 'cde'},
                 ]
             )
+
+        reload_module(filters)
 
 
 class SensitiveOrderingFilterModel(models.Model):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,30 +1,5 @@
-from contextlib import contextmanager
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import NoReverseMatch
-from django.utils import six
-from rest_framework.settings import api_settings
-
-
-@contextmanager
-def temporary_setting(setting, value, module=None):
-    """
-    Temporarily change value of setting for test.
-
-    Optionally reload given module, useful when module uses value of setting on
-    import.
-    """
-    original_value = getattr(api_settings, setting)
-    setattr(api_settings, setting, value)
-
-    if module is not None:
-        six.moves.reload_module(module)
-
-    yield
-
-    setattr(api_settings, setting, original_value)
-
-    if module is not None:
-        six.moves.reload_module(module)
 
 
 class MockObject(object):


### PR DESCRIPTION
Closes #2466, however not yet entirely happy with this.

Note that various REST framework views set class attributes such as...

    renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES

Effect of this is that if `rest_framework.views` has been imported then changing `api_settings` isn't enough, as `APIView.renderer_classes` (and others) have already been set.

The two tests using `override_settings` in this pull request use `reload_module` to ensure that the required REST framework modules are reloaded to get the new settings.

Possible approaches to solve:

* `api_settings.something` returns a lazy object. (Or wrap the class declarations)
* Only access `api_settings` inside running code, not inside class declarations.
* Document the constraint, possibly adding a helper function for reloading required modules.
* Automagically reload the required modules (had a look at this and not overly keen on it)