### PR TITLE
Use the proper db_table argument when constructing meta

### DIFF
--- a/rest_framework/authtoken/south_migrations/0001_initial.py
+++ b/rest_framework/authtoken/south_migrations/0001_initial.py
@@ -40,7 +40,7 @@ class Migration(SchemaMigration):
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         },
         "%s.%s" % (User._meta.app_label, User._meta.module_name): {
-            'Meta': {'object_name': User._meta.module_name},
+            'Meta': {'object_name': User._meta.module_name, 'db_table': repr(User._meta.db_table)},
         },
         'authtoken.token': {
             'Meta': {'object_name': 'Token'},


### PR DESCRIPTION
This pull request handles the somewhat special case of using a custom user model with a custom `db_table` attribute. When migrating a pre-existing database that was using the `auth.User` model, [one guide for doing so recommends](http://django-authtools.readthedocs.org/en/latest/how-to/migrate-to-a-custom-user-model.html) creating a custom user table where `db_table = 'auth_user'` so that few database migrations are required. 

This pull request updates the `Meta` parameters passed for the custom user model to include the `db_table` from the real `settings.AUTH_USER_MODEL` model. 

Without this change, using a custom `db_table` attribute leads to errors like the following:
> FATAL ERROR - The following SQL query failed: ALTER TABLE "authtoken_token" ADD CONSTRAINT "user_id_refs_id_79b40daa" FOREIGN KEY ("user_id") REFERENCES "custom_user_user" ("id") DEFERRABLE INITIALLY DEFERRED;
The error was: relation "custom_user_user" does not exist
