### PR TITLE
Cleanup '.model' shortcut from code and docs

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -93,17 +93,13 @@ The following attributes are used to control pagination when used with list view
 
 * `filter_backends` - A list of filter backend classes that should be used for filtering the queryset.  Defaults to the same value as the `DEFAULT_FILTER_BACKENDS` setting.
 
-**Deprecated attributes**:
-
-* `model` - This shortcut may be used instead of setting either (or both) of the `queryset`/`serializer_class` attributes. The explicit style is preferred over the `.model` shortcut, and usage of this attribute is now deprecated.
-
 ### Methods
 
 **Base methods**:
 
 #### `get_queryset(self)`
 
-Returns the queryset that should be used for list views, and that should be used as the base for lookups in detail views.  Defaults to returning the queryset specified by the `queryset` attribute, or the default queryset for the model if the `model` shortcut is being used.
+Returns the queryset that should be used for list views, and that should be used as the base for lookups in detail views.  Defaults to returning the queryset specified by the `queryset` attribute.
 
 This method should always be used rather than accessing `self.queryset` directly, as `self.queryset` gets evaluated only once, and those results are cached for all subsequent requests.
 
@@ -153,7 +149,7 @@ For example:
 
 #### `get_serializer_class(self)`
 
-Returns the class that should be used for the serializer.  Defaults to returning the `serializer_class` attribute, or dynamically generating a serializer class if the `model` shortcut is being used.
+Returns the class that should be used for the serializer.  Defaults to returning the `serializer_class` attribute.
 
 May be overridden to provide dynamic behavior, such as using different serializers for read and write operations, or providing different serializers to different types of users.
 

--- a/docs/api-guide/routers.md
+++ b/docs/api-guide/routers.md
@@ -28,7 +28,7 @@ There are two mandatory arguments to the `register()` method:
 
 Optionally, you may also specify an additional argument:
 
-* `base_name` - The base to use for the URL names that are created.  If unset the basename will be automatically generated based on the `model` or `queryset` attribute on the viewset, if it has one.  Note that if the viewset does not include a `model` or `queryset` attribute then you must set `base_name` when registering the viewset.
+* `base_name` - The base to use for the URL names that are created.  If unset the basename will be automatically generated based on the `queryset` attribute of the viewset, if it has one.  Note that if the viewset does not include a `queryset` attribute then you must set `base_name` when registering the viewset.
 
 The example above would generate the following URL patterns:
 

--- a/docs/topics/3.0-announcement.md
+++ b/docs/topics/3.0-announcement.md
@@ -665,7 +665,7 @@ This code *would be valid* in `2.4.3`:
         class Meta:
             model = Account
 
-However this code *would not be valid* in `2.4.3`:
+However this code *would not be valid* in `3.0`:
 
     # Missing `queryset`
     class AccountSerializer(serializers.Serializer):

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -130,19 +130,13 @@ class SimpleRouter(BaseRouter):
         If `base_name` is not specified, attempt to automatically determine
         it from the viewset.
         """
-        # Note that `.model` attribute on views is deprecated, although we
-        # enforce the deprecation on the view `get_serializer_class()` and
-        # `get_queryset()` methods, rather than here.
-        model_cls = getattr(viewset, 'model', None)
         queryset = getattr(viewset, 'queryset', None)
-        if model_cls is None and queryset is not None:
-            model_cls = queryset.model
 
-        assert model_cls, '`base_name` argument not specified, and could ' \
+        assert queryset is not None, '`base_name` argument not specified, and could ' \
             'not automatically determine the name from the viewset, as ' \
             'it does not have a `.queryset` attribute.'
 
-        return model_cls._meta.object_name.lower()
+        return queryset.model._meta.object_name.lower()
 
     def get_routes(self, viewset):
         """

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -180,7 +180,7 @@ class TestLookupValueRegex(TestCase):
 class TestTrailingSlashIncluded(TestCase):
     def setUp(self):
         class NoteViewSet(viewsets.ModelViewSet):
-            model = RouterTestModel
+            queryset = RouterTestModel.objects.all()
 
         self.router = SimpleRouter()
         self.router.register(r'notes', NoteViewSet)
@@ -195,7 +195,7 @@ class TestTrailingSlashIncluded(TestCase):
 class TestTrailingSlashRemoved(TestCase):
     def setUp(self):
         class NoteViewSet(viewsets.ModelViewSet):
-            model = RouterTestModel
+            queryset = RouterTestModel.objects.all()
 
         self.router = SimpleRouter(trailing_slash=False)
         self.router.register(r'notes', NoteViewSet)
@@ -210,7 +210,8 @@ class TestTrailingSlashRemoved(TestCase):
 class TestNameableRoot(TestCase):
     def setUp(self):
         class NoteViewSet(viewsets.ModelViewSet):
-            model = RouterTestModel
+            queryset = RouterTestModel.objects.all()
+
         self.router = DefaultRouter()
         self.router.root_view_name = 'nameable-root'
         self.router.register(r'notes', NoteViewSet)


### PR DESCRIPTION
As far as I understand, if it was removed, then mentioning it in the docs will just confuse people.