### PR TITLE
Fix TypeError: 'NoneType' object is not iterable

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -365,7 +365,7 @@ class ManyRelatedField(Field):
     @property
     def choices(self):
         queryset = self.child_relation.queryset
-        iterable = queryset.all() if (hasattr(queryset, 'all')) else queryset
+        iterable = queryset.all() if (hasattr(queryset, 'all')) else queryset or []
         items_and_representations = [
             (item, self.child_relation.to_representation(item))
             for item in iterable


### PR DESCRIPTION
There is at least one case that ``self.child_relation.queryset`` is ``None`` (in a ``ManyToManyField`` for example) instead a empty list/QuerySet