### PR TITLE
First pass at Cython optional speedups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,30 @@ env:
     - TOX_ENV=py33-djangomaster
     - TOX_ENV=py32-djangomaster
     - TOX_ENV=py27-djangomaster
+    - TOX_ENV=py34-django17-cython
+    - TOX_ENV=py33-django17-cython
+    - TOX_ENV=py32-django17-cython
+    - TOX_ENV=py27-django17-cython
+    - TOX_ENV=py34-django16-cython
+    - TOX_ENV=py33-django16-cython
+    - TOX_ENV=py32-django16-cython
+    - TOX_ENV=py27-django16-cython
+    - TOX_ENV=py26-django16-cython
+    - TOX_ENV=py34-django15-cython
+    - TOX_ENV=py33-django15-cython
+    - TOX_ENV=py32-django15-cython
+    - TOX_ENV=py27-django15-cython
+    - TOX_ENV=py26-django15-cython
+    - TOX_ENV=py27-django14-cython
+    - TOX_ENV=py26-django14-cython
+    - TOX_ENV=py34-django18alpha-cython
+    - TOX_ENV=py33-django18alpha-cython
+    - TOX_ENV=py32-django18alpha-cython
+    - TOX_ENV=py27-django18alpha-cython
+    - TOX_ENV=py34-djangomaster-cython
+    - TOX_ENV=py33-djangomaster-cython
+    - TOX_ENV=py32-djangomaster-cython
+    - TOX_ENV=py27-djangomaster-cython
 
 matrix:
   fast_finish: true
@@ -37,6 +61,10 @@ matrix:
     - env: TOX_ENV=py33-djangomaster
     - env: TOX_ENV=py32-djangomaster
     - env: TOX_ENV=py27-djangomaster
+    - env: TOX_ENV=py34-djangomaster-cython
+    - env: TOX_ENV=py33-djangomaster-cython
+    - env: TOX_ENV=py32-djangomaster-cython
+    - env: TOX_ENV=py27-djangomaster-cython
 
 install:
   - pip install tox

--- a/rest_framework/renderers.pxd
+++ b/rest_framework/renderers.pxd
@@ -11,7 +11,7 @@ cdef class BaseRenderer(object):
     """
 
     @cython.locals(indent=int, separators=tuple)
-    cpdef object render(self, dict data, accepted_media_type=?, renderer_context=?)
+    cpdef bytes render(self, dict data, accepted_media_type=?, renderer_context=?)
 
 @cython.locals(compact=bool, ensure_ascii=bool, charset=unicode)
 cdef class JSONRenderer(BaseRenderer):

--- a/rest_framework/renderers.pxd
+++ b/rest_framework/renderers.pxd
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+cimport cython
+
+@cython.locals(media_type=unicode, format=unicode, charset=unicode, render_style=unicode)
+cdef class BaseRenderer(object):
+    """
+    All renderers should extend this class, setting the `media_type`
+    and `format` attributes, and override the `.render()` method.
+    """
+
+    @cython.locals(indent=int, separators=tuple)
+    cpdef object render(self, dict data, accepted_media_type=?, renderer_context=?)
+
+@cython.locals(compact=bool, ensure_ascii=bool, charset=unicode)
+cdef class JSONRenderer(BaseRenderer):
+    @cython.locals(base_media_type=unicode, params=dict)
+    cpdef int get_indent(self, unicode accepted_media_type, dict renderer_context)
+
+@cython.locals(callback_parameter=unicode, default_callback=unicode)
+cdef class JSONPRenderer(JSONRenderer):
+    cpdef unicode get_callback(self, dict renderer_context)

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup
-from setuptools.command.test import test as TestCommand
+try:
+    from Cython.Build import cythonize
+except ImportError:
+    ext_modules = None
+else:
+    from setuptools import Extension
+    ext_modules = cythonize(Extension('speedups', ['rest_framework/renderers.py',
+                                                   'rest_framework/__init__.py']))
+
 import re
 import os
 import sys
+
+from setuptools import setup
 
 
 def get_version(package):
@@ -43,7 +52,6 @@ def get_package_data(package):
 
 version = get_version('rest_framework')
 
-
 if sys.argv[-1] == 'publish':
     if os.system("pip freeze | grep wheel"):
         print("wheel not installed.\nUse `pip install wheel`.\nExiting.")
@@ -54,7 +62,6 @@ if sys.argv[-1] == 'publish':
     print("  git tag -a %s -m 'version %s'" % (version, version))
     print("  git push --tags")
     sys.exit()
-
 
 setup(
     name='djangorestframework',
@@ -68,6 +75,7 @@ setup(
     package_data=get_package_data('rest_framework'),
     install_requires=[],
     zip_safe=False,
+    ext_modules=ext_modules,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
@@ -82,7 +90,7 @@ setup(
 )
 
 # (*) Please direct queries to the discussion group, rather than to me directly
-#     Doing so helps ensure your question is helpful to other users.
-#     Queries directly to my email are likely to receive a canned response.
+# Doing so helps ensure your question is helpful to other users.
+# Queries directly to my email are likely to receive a canned response.
 #
 #     Many thanks for your understanding.

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py26,py27}-django14,
+       {py26,py27}-django14-cython,
        {py26,py27,py32,py33,py34}-django{15,16},
-       {py27,py32,py33,py34}-django{17,18alpha,master}
+       {py26,py27,py32,py33,py34}-django{15,16}-cython,
+       {py27,py32,py33,py34}-django{17,18alpha,master},
+       {py27,py32,py33,py34}-django{17,18alpha,master}-cython
 
 [testenv]
 commands = ./runtests.py --fast
@@ -14,6 +16,7 @@ deps =
        django15: Django==1.5.6  # Should track minimum supported
        django16: Django==1.6.3  # Should track minimum supported
        django17: Django==1.7.2  # Should track maximum supported
+       cython: Cython==0.21.2
        django18alpha: https://www.djangoproject.com/download/1.8a1/tarball/
        djangomaster: https://github.com/django/django/zipball/master
        {py26,py27}-django{14,15,16,17}: django-guardian==1.2.3


### PR DESCRIPTION
The setup.py script conditionally compiles the speedups if Cython is available.
The build includes jobs with cython and without.
I implemented speedups for the JSON and JSONP renderers.
Are we going to extract the rest of the renderers? Should I spend time in optimizing them?

One known issue is that if Python 3 is used the ```render()``` method is known to return unicode but I can't find a way to conditionally generate code based on Python version.
I left a question on [stackoverflow](http://stackoverflow.com/questions/28299202/how-to-conditionally-declare-code-according-to-python-version-in-cython) and hopefully I'll get an answer soon.

This should not be merged until #2506 is complete.

Refs #2499