### PR TITLE
blank fields shall not be required for related fields.

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -223,9 +223,9 @@ def get_relation_kwargs(field_name, relation_info):
             # If this field is read-only, then return early.
             # No further keyword arguments are valid.
             return kwargs
-        if model_field.has_default() or model_field.null:
+        if model_field.has_default() or model_field.blank:
             kwargs['required'] = False
-        if model_field.null:
+        if model_field.blank:
             kwargs['allow_null'] = True
         if model_field.validators:
             kwargs['validators'] = model_field.validators

--- a/tests/models.py
+++ b/tests/models.py
@@ -40,6 +40,17 @@ class ManyToManySource(RESTFrameworkModel):
     targets = models.ManyToManyField(ManyToManyTarget, related_name='sources')
 
 
+class ManyToManyBlankedSource(RESTFrameworkModel):
+    """
+    Some fields can be blank without being null
+    """
+    name = models.CharField(max_length=100)
+    surname = models.CharField(max_length=100, blank=True)
+    story = models.TextField(blank=True)
+    targets = models.ManyToManyField(ManyToManyTarget, blank=True,
+                                     related_name='blank_sources')
+
+
 # ForeignKey
 class ForeignKeyTarget(RESTFrameworkModel):
     name = models.CharField(max_length=100)

--- a/tests/test_relations_pk.py
+++ b/tests/test_relations_pk.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from tests.models import (
     ManyToManyTarget, ManyToManySource, ForeignKeyTarget, ForeignKeySource,
     NullableForeignKeySource, OneToOneTarget, NullableOneToOneSource,
+    ManyToManyBlankedSource,
 )
 
 
@@ -19,6 +20,12 @@ class ManyToManySourceSerializer(serializers.ModelSerializer):
     class Meta:
         model = ManyToManySource
         fields = ('id', 'name', 'targets')
+
+
+class ManyToManyBlankedSourceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ManyToManyBlankedSource
+        fields = ('id', 'name', 'surname', 'story', 'targets')
 
 
 # ForeignKey
@@ -105,6 +112,17 @@ class PKManyToManyTests(TestCase):
             {'id': 3, 'name': 'source-3', 'targets': [1, 2, 3]}
         ]
         self.assertEqual(serializer.data, expected)
+
+    def test_many_to_many_blanked_retrieve(self):
+        data = {'id': 1, 'name': 'source-1-updated'}
+        instance = ManyToManyBlankedSource(name='source-%d' % data['id'])
+        instance.save()
+        serializer = ManyToManyBlankedSourceSerializer(instance, data=data)
+        self.assertTrue(serializer.is_valid())
+        serializer.save()
+        # set default values
+        data.update({'targets': [], 'surname': '', 'story': ''})
+        self.assertEqual(serializer.data, data)
 
     def test_reverse_many_to_many_update(self):
         data = {'id': 1, 'name': 'target-1', 'sources': [1]}


### PR DESCRIPTION
django-rest-framework mark all fields, that doesn't have `null=True` as required.
To my mind, for validation purpose we must rely only on `blank=True`, and not on `null=True`, as [null](https://docs.djangoproject.com/en/1.7/ref/models/fields/#null) - for database, whereas [blank](https://docs.djangoproject.com/en/1.7/ref/models/fields/#blank) - for validation.

Here is my example:

    class MyModel(models.Model):
        name = models.CharField(max_length=50)
        favourites = models.ManyToManyField('app.AnotherModel', blank=True)

    class MySerializer(serializers.ModelSerializer):
        class Meta:
            model = MyModel


When i try to send PUT request with valid payload

    {"name": "John"}

i get error:

    {u'favourites': [u"This field is required."]}