### PR TITLE
FIX: Don't default to list in method args

### DIFF
--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -18,7 +18,7 @@ def api_view(http_method_names=None):
     Decorator that converts a function-based view into an APIView subclass.
     Takes a list of allowed methods for the view as an argument.
     """
-    http_method_names = ['GET'] if http_method_names is None else http_method_names
+    http_method_names = ['GET'] if (http_method_names is None) else http_method_names
 
     def decorator(func):
 
@@ -112,7 +112,7 @@ def detail_route(methods=None, **kwargs):
     """
     Used to mark a method on a ViewSet that should be routed for detail requests.
     """
-    methods = ['get'] if methods is None else methods
+    methods = ['get'] if (methods is None) else methods
 
     def decorator(func):
         func.bind_to_methods = methods
@@ -126,7 +126,7 @@ def list_route(methods=None, **kwargs):
     """
     Used to mark a method on a ViewSet that should be routed for list requests.
     """
-    methods = ['get'] if methods is None else methods
+    methods = ['get'] if (methods is None) else methods
 
     def decorator(func):
         func.bind_to_methods = methods

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -109,10 +109,12 @@ def permission_classes(permission_classes):
     return decorator
 
 
-def detail_route(methods=['get'], **kwargs):
+def detail_route(methods=None, **kwargs):
     """
     Used to mark a method on a ViewSet that should be routed for detail requests.
     """
+    if methods is None:
+        methods = ['get']
     def decorator(func):
         func.bind_to_methods = methods
         func.detail = True
@@ -121,10 +123,12 @@ def detail_route(methods=['get'], **kwargs):
     return decorator
 
 
-def list_route(methods=['get'], **kwargs):
+def list_route(methods=None, **kwargs):
     """
     Used to mark a method on a ViewSet that should be routed for list requests.
     """
+    if methods is None:
+        methods = ['get']
     def decorator(func):
         func.bind_to_methods = methods
         func.detail = False

--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -18,8 +18,7 @@ def api_view(http_method_names=None):
     Decorator that converts a function-based view into an APIView subclass.
     Takes a list of allowed methods for the view as an argument.
     """
-    if http_method_names is None:
-        http_method_names = ['GET']
+    http_method_names = ['GET'] if http_method_names is None else http_method_names
 
     def decorator(func):
 
@@ -113,8 +112,8 @@ def detail_route(methods=None, **kwargs):
     """
     Used to mark a method on a ViewSet that should be routed for detail requests.
     """
-    if methods is None:
-        methods = ['get']
+    methods = ['get'] if methods is None else methods
+
     def decorator(func):
         func.bind_to_methods = methods
         func.detail = True
@@ -127,8 +126,8 @@ def list_route(methods=None, **kwargs):
     """
     Used to mark a method on a ViewSet that should be routed for list requests.
     """
-    if methods is None:
-        methods = ['get']
+    methods = ['get'] if methods is None else methods
+
     def decorator(func):
         func.bind_to_methods = methods
         func.detail = False


### PR DESCRIPTION
Fixes `@list_route` and `@detail_route` so that they don't initialize their `methods` parameter as a list. In some cases the list gets cleared, and the result is that default parameter is now empty, and may get reused unexpectedly.