### PR TITLE
Into rest_framework.request.Request added support of Array params

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -323,7 +323,8 @@ class Request(object):
         if not _hasattr(self, '_data'):
             self._data, self._files = self._parse()
             if self._files:
-                self._full_data = MergeDict(self._data, self._files)
+                self._full_data = self._data.copy()
+                self._full_data.update(self._files)
             else:
                 self._full_data = self._data
 
@@ -387,7 +388,8 @@ class Request(object):
         # At this point we're committed to parsing the request as form data.
         self._data = self._request.POST
         self._files = self._request.FILES
-        self._full_data = MergeDict(self._data, self._files)
+        self._full_data = self._data.copy()
+        self._full_data.update(self._files)
 
         # Method overloading - change the method and remove the param from the content.
         if (

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -96,6 +96,18 @@ class TestContentParsing(TestCase):
         request.parsers = (FormParser(), MultiPartParser())
         self.assertEqual(list(request.DATA.items()), list(data.items()))
 
+    def test_request_data_with_form_array_content(self):
+        """
+        Ensure request.data returns content for POST request with form content
+        which contains array (list) values.
+        """
+        data = {'qwerty': ['uiop', 'blah', ]}
+        request = Request(factory.post('/', data))
+        request.parsers = (FormParser(), MultiPartParser())
+        # QueryDict().items() return only one item from list. To get all items
+        # have to use getlist() method. e.g. `request.data.getlist('qwerty')`
+        self.assertEqual(request.data, data)
+
     def test_request_DATA_with_text_content(self):
         """
         Ensure request.DATA returns content for POST request with


### PR DESCRIPTION
Into rest_framework.request.Request added support of Array params (data = {'qwerty': ['uiop', 'blah', ]} or in url "/some/url/path?qwerty[]=uiop&qwerty[]=blah").