### PR TITLE
Allow non-standard User models with Throttling

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -191,7 +191,7 @@ class UserRateThrottle(SimpleRateThrottle):
 
     def get_cache_key(self, request, view):
         if request.user.is_authenticated():
-            ident = request.user.id
+            ident = request.user.pk
         else:
             ident = self.get_ident(request)
 
@@ -239,7 +239,7 @@ class ScopedRateThrottle(SimpleRateThrottle):
         with the '.throttle_scope` property of the view.
         """
         if request.user.is_authenticated():
-            ident = request.user.id
+            ident = request.user.pk
         else:
             ident = self.get_ident(request)
 


### PR DESCRIPTION
Use pk pseudo attribute for identifying the user (in case the user model is not the default and has a different column name for the unique id)