### PR TITLE
Add trim_whitespace to CharField

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -138,11 +138,12 @@ A text representation. Optionally validates the text to be shorter than `max_len
 
 Corresponds to `django.db.models.fields.CharField` or `django.db.models.fields.TextField`.
 
-**Signature:** `CharField(max_length=None, min_length=None, allow_blank=False)`
+**Signature:** `CharField(max_length=None, min_length=None, allow_blank=False, trim_whitespace=True)`
 
 - `max_length` - Validates that the input contains no more than this number of characters.
 - `min_length` - Validates that the input contains no fewer than this number of characters.
 - `allow_blank` - If set to `True` then the empty string should be considered a valid value. If set to `False` then the empty string is considered invalid and will raise a validation error. Defaults to `False`.
+- `trim_whitespace` - If set to `True` then leading and trailing whitespace is trimmed. Defaults to `True`.
 
 The `allow_null` option is also available for string fields, although its usage is discouraged in favor of `allow_blank`. It is valid to set both `allow_blank=True` and `allow_null=True`, but doing so means that there will be two differing types of empty value permissible for string representations, which can lead to data inconsistencies and subtle application bugs.
 
@@ -524,7 +525,7 @@ As an example, let's create a field that can be used represent the class name of
             # We pass the object instance onto `to_representation`,
             # not just the field attribute.
             return obj
- 
+
         def to_representation(self, obj):
             """
             Serialize the object's class name.

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -555,6 +555,7 @@ class CharField(Field):
 
     def __init__(self, **kwargs):
         self.allow_blank = kwargs.pop('allow_blank', False)
+        self.trim_whitespace = kwargs.pop('trim_whitespace', True)
         max_length = kwargs.pop('max_length', None)
         min_length = kwargs.pop('min_length', None)
         super(CharField, self).__init__(**kwargs)
@@ -576,10 +577,20 @@ class CharField(Field):
         return super(CharField, self).run_validation(data)
 
     def to_internal_value(self, data):
-        return six.text_type(data)
+        value = six.text_type(data)
+
+        if self.trim_whitespace:
+            return value.strip()
+
+        return value
 
     def to_representation(self, value):
-        return six.text_type(value)
+        representation = six.text_type(value)
+
+        if self.trim_whitespace:
+            return representation.strip()
+
+        return representation
 
 
 class EmailField(CharField):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -410,6 +410,14 @@ class TestCharField(FieldValues):
     }
     field = serializers.CharField()
 
+    def test_trim_whitespace_default(self):
+        field = serializers.CharField()
+        assert field.to_representation(' abc ') == 'abc'
+
+    def test_trim_whitespace_disabled(self):
+        field = serializers.CharField(trim_whitespace=False)
+        assert field.to_representation(' abc ') == ' abc '
+
 
 class TestEmailField(FieldValues):
     """


### PR DESCRIPTION
If set to `True` then leading and trailing whitespace is trimmed. Defaults to `True`.