### PR TITLE
get_authenticate_header should look for unauthenticated request in all...

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -7,6 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.utils.encoding import smart_text
 from django.views.decorators.csrf import csrf_exempt
+from django.utils.six.moves import filter as ifilter
 from rest_framework import status, exceptions
 from rest_framework.compat import HttpResponseBase, View
 from rest_framework.request import Request
@@ -155,7 +156,8 @@ class APIView(View):
         """
         authenticators = self.get_authenticators()
         if authenticators:
-            return authenticators[0].authenticate_header(request)
+            headers = (authenticator.authenticate_header(request) for authenticator in authenticators)
+            return next(ifilter(lambda x: x, headers), None)
 
     def get_parser_context(self, http_request):
         """

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -138,7 +138,7 @@ class DecoratorTestCase(TestCase):
 
         request = self.factory.get('/')
         response = view(request)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_throttle_classes(self):
         class OncePerDayUserThrottle(UserRateThrottle):


### PR DESCRIPTION
...authenticators.

This would cause some odd behaviours such as when having:

    authentication_classes = (TokenAuthentication, SessionAuthentication)

an unauthenticated request would return 401 while:

    authentication_classes = (SessionAuthentication, TokenAuthentication)

would return 403.

Any thoughts are welcome.