### PR TITLE
Use twine to upload to pypi.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ django-oauth2-provider>=0.2.4
 
 # wheel for PyPI installs
 wheel==0.24.0
+# twine for secured PyPI uploads
 twine==1.4.0
 
 # MkDocs for documentation previews/deploys

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ django-oauth2-provider>=0.2.4
 
 # wheel for PyPI installs
 wheel==0.24.0
+twine==1.4.0
 
 # MkDocs for documentation previews/deploys
 mkdocs==0.11.1

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,11 @@ if sys.argv[-1] == 'publish':
     if os.system("pip freeze | grep wheel"):
         print("wheel not installed.\nUse `pip install wheel`.\nExiting.")
         sys.exit()
-    os.system("python setup.py sdist upload")
-    os.system("python setup.py bdist_wheel upload")
+    if os.system("pip freeze | grep twine")
+        print("twine not installed.\nUse `pip install twine`.\nExiting.")
+        sys.exit()
+    os.system("python setup.py sdist bdist_wheel")
+    os.system("twine upload dist/*")
     print("You probably want to also tag the version now:")
     print("  git tag -a %s -m 'version %s'" % (version, version))
     print("  git push --tags")

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ if sys.argv[-1] == 'publish':
     if os.system("pip freeze | grep wheel"):
         print("wheel not installed.\nUse `pip install wheel`.\nExiting.")
         sys.exit()
-    if os.system("pip freeze | grep twine")
+    if os.system("pip freeze | grep twine"):
         print("twine not installed.\nUse `pip install twine`.\nExiting.")
         sys.exit()
     os.system("python setup.py sdist bdist_wheel")


### PR DESCRIPTION
As explained on the twine page (https://pypi.python.org/pypi/twine):

The biggest reason to use twine is that python setup.py upload authenticates you to PyPI over http. This means anytime you use it you expose your username and password to being sniffed. Twine uses only verified TLS to upload to PyPI protecting your credentials from theft.

By using twine, we'll make the upload process more secure.