### PR TITLE
Pass a dict as data to django-filter

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -65,7 +65,11 @@ class DjangoFilterBackend(BaseFilterBackend):
         filter_class = self.get_filter_class(view, queryset)
 
         if filter_class:
-            return filter_class(request.query_params, queryset=queryset).qs
+            # Using solution by @leo-the-manic goo.gl/3LoFIj
+            return filter_class(
+                {k: v[0] if len(v) == 1 else v for k, v in request.query_params.lists()},
+                queryset=queryset
+            ).qs
 
         return queryset
 

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -65,9 +65,10 @@ class DjangoFilterBackend(BaseFilterBackend):
         filter_class = self.get_filter_class(view, queryset)
 
         if filter_class:
-            # Using solution by @leo-the-manic goo.gl/3LoFIj
+            # Inspired by @leo-the-manic goo.gl/3LoFIj
             return filter_class(
-                {k: v[0] if len(v) == 1 else v for k, v in request.query_params.lists()},
+                dict([(param[0], len(param[1]) == 1 and param[1][0] or param[1])
+                     for param in request.query_params.lists()]),
                 queryset=queryset
             ).qs
 


### PR DESCRIPTION
In order to filter with multivalue params such as 'in' lookups there are two alternatives:

* ?multiparam=1,2,3
* ?multiparam=1&multiparam=2

The second option is a better approach when facing strings. However, by definition QueryDict does only take into account the last param included.

Django-filters expect a dict as data. To be congruent with what is passed in the request we need to transform `query_params` to a `dict`.

As can be seen in the test written, adhoc programming must be done also in django-filter to allow 'in' lookups but that's another issue.

Part of the solution was taken from @leo-the-manic in http://stackoverflow.com/questions/13349573/how-to-change-a-django-querydict-to-python-dict#answer-22100334