### PR TITLE
Fixes HiddenField being rendered in HTMLFormRenderer

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -410,7 +410,7 @@ class HTMLFormRenderer(BaseRenderer):
     })
 
     def render_field(self, field, parent_style):
-        if isinstance(field, serializers.HiddenField):
+        if isinstance(field._field, serializers.HiddenField):
             return ''
 
         style = dict(self.default_style[field])


### PR DESCRIPTION
I believe the fix in #2410 didn't work. When rendering the form HTMLFormRenderer.render_field(self, field, parent_style) gets a BoundField instead of a HiddenField, so the isinstance() call always fails and the HiddenField is still rendered.

BoundField always stores the original field under self._field, so using that attribute in the isinstance() call finally avoids rendering the HiddenField.