### PR TITLE
 Allow custom PAGINATE_KWARG keyword in settings. 

### DIFF
--- a/docs/api-guide/pagination.md
+++ b/docs/api-guide/pagination.md
@@ -85,12 +85,13 @@ We could now use our pagination serializer in a view like this.
 
 The generic class based views `ListAPIView` and `ListCreateAPIView` provide pagination of the returned querysets by default.  You can customise this behaviour by altering the pagination style, by modifying the default number of results, by allowing clients to override the page size using a query parameter, or by turning pagination off completely.
 
-The default pagination style may be set globally, using the `DEFAULT_PAGINATION_SERIALIZER_CLASS`, `PAGINATE_BY`, `PAGINATE_BY_PARAM`, and `MAX_PAGINATE_BY` settings.  For example.
+The default pagination style may be set globally, using the `DEFAULT_PAGINATION_SERIALIZER_CLASS`, `PAGINATE_BY`, `PAGINATE_BY_PARAM`, `MAX_PAGINATE_BY`, and `PAGINATE_KWARG` settings.  For example.
 
     REST_FRAMEWORK = {
         'PAGINATE_BY': 10,                 # Default to 10
         'PAGINATE_BY_PARAM': 'page_size',  # Allow client to override, using `?page_size=xxx`.
         'MAX_PAGINATE_BY': 100             # Maximum limit allowed when using `?page_size=xxx`.
+        'PAGINATE_KWARG': 'p'             # Use `p` rather than `page` when paginating
     }
 
 You can also set the pagination style on a per-view basis, using the `ListAPIView` generic class-based view.

--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -60,7 +60,7 @@ class GenericAPIView(views.APIView):
     paginate_by_param = api_settings.PAGINATE_BY_PARAM
     max_paginate_by = api_settings.MAX_PAGINATE_BY
     pagination_serializer_class = api_settings.DEFAULT_PAGINATION_SERIALIZER_CLASS
-    page_kwarg = 'page'
+    page_kwarg = api_settings.PAGINATE_KWARG
 
     # The filter backend classes to use for queryset filtering
     filter_backends = api_settings.DEFAULT_FILTER_BACKENDS

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -5,13 +5,14 @@ be used for paginated responses.
 from __future__ import unicode_literals
 from rest_framework import serializers
 from rest_framework.templatetags.rest_framework import replace_query_param
+from rest_framework.settings import api_settings
 
 
 class NextPageField(serializers.Field):
     """
     Field that returns a link to the next page in paginated results.
     """
-    page_field = 'page'
+    page_field = api_settings.PAGINATE_KWARG
 
     def to_representation(self, value):
         if not value.has_next():
@@ -26,7 +27,7 @@ class PreviousPageField(serializers.Field):
     """
     Field that returns a link to the previous page in paginated results.
     """
-    page_field = 'page'
+    page_field = api_settings.PAGINATE_KWARG
 
     def to_representation(self, value):
         if not value.has_previous():

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -61,6 +61,7 @@ DEFAULTS = {
 
     # Pagination
     'PAGINATE_BY': None,
+    'PAGINATE_KWARG': 'page',
     'PAGINATE_BY_PARAM': None,
     'MAX_PAGINATE_BY': None,
 


### PR DESCRIPTION
Prior to this change, it wasn't possible to use a parameter other than
`page` in a querystring to paginate through result sets.  This is
usually fine, unless you have a resource with a `page` attribute (and we
do).

This is implemented as a global setting rather than a per-resource
setting because most people will want the pagination logic to be
consistent across their API, I think.

The only dilemma here is that I believe the setting `PAGINATE_BY_PARAM`
is unfortunately confusingly named.  I had, up until this point,
assumed it referred to the argument that did the pagination, rather than
the argument you provide to change the size of the pagination.  Given
the potential break in backward compatibility, I believe that changing
`PAGINATE_BY_PARAM` to a different name should probably happen in a
different PR, if at all.