### PR TITLE
Add import example for force_authenticate in testing

### DIFF
--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -65,6 +65,8 @@ When testing views directly using a request factory, it's often convenient to be
 
 To forcibly authenticate a request, use the `force_authenticate()` method.
 
+    from rest_framework.tests import force_authenticate
+
     factory = APIRequestFactory()
     user = User.objects.get(username='olivia')
     view = AccountDetail.as_view()


### PR DESCRIPTION
Doing a bit of testing with authentication and I noticed there was no mention of where to import the `force_authenticate` method anywhere, so I've added it to the first example where `force_authenticate` is introduced.

Fixes PEP8 W503 errors