### PR TITLE
Adjust importlib import

### DIFF
--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -20,7 +20,11 @@ back to the defaults.
 from __future__ import unicode_literals
 from django.test.signals import setting_changed
 from django.conf import settings
-from django.utils import importlib, six
+try:
+    import importlib
+except ImportError:
+    from django.utils import importlib
+from django.utils import six
 from rest_framework import ISO_8601
 
 


### PR DESCRIPTION
Clears up the warning: 

>      rest_framework/settings.py:23: RemovedInDjango19Warning: 
>          django.utils.importlib will be removed in Django 1.9.
>      from django.utils import importlib, six
