### PR TITLE
Requirements refactor.

### DIFF
--- a/docs/topics/project-management.md
+++ b/docs/topics/project-management.md
@@ -166,6 +166,16 @@ When a translator has finished translating their work needs to be downloaded fro
 
 ---
 
+## Project requirements
+
+All our test requirements are pinned to exact versions, in order to ensure that our test runs are reproducible. We maintain the requirements in the `requirements` directory. The requirements files are referenced from the `tox.ini` configuration file, ensuring we have a single source of truth for package versions used in testing.
+
+You can check if there are any packages available at a newer version, by using the `pip-review` tool.
+
+Package upgrades should generally be treated as isolated pull requests. Also note that the `pip-dump` command does not work gracefully with our requirements layout style, so any edits should be made manually.
+
+---
+
 ## Project ownership
 
 The PyPI package is owned by `@tomchristie`. As a backup `@j4mie` also has ownership of the package.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,13 @@
-# Minimum Django version
-Django>=1.4.11
+# The base set of requirements for REST framework is actually
+# just Django, but for the purposes of development and testing
+# there are a number of packages that it is useful to install.
 
-# Test requirements
-pytest-django==2.8.0
-pytest==2.6.4
-pytest-cov==1.6
-flake8==2.2.2
+# Laying these out as seperate requirements files, allows us to
+# only included the relevent sets when running tox, and ensures
+# we are only ever declaring out dependancies in one place.
 
-# Optional packages
-markdown>=2.1.0
-django-guardian==1.2.4
-django-filter>=0.9.2
-
-# wheel for PyPI installs
-wheel==0.24.0
-# twine for secured PyPI uploads
-twine==1.4.0
-
-# MkDocs for documentation previews/deploys
-mkdocs==0.11.1
+-r requirements/requirements-optionals.txt
+-r requirements/requirements-testing.txt
+-r requirements/requirements-documentation.txt
+-r requirements/requirements-codestyle.txt
+-r requirements/requirements-packaging.txt

--- a/requirements/requirements-codestyle.txt
+++ b/requirements/requirements-codestyle.txt
@@ -1,0 +1,3 @@
+# PEP8 code linting, which we run on all commits.
+flake8==2.3.0
+pep8==1.6.2

--- a/requirements/requirements-documentation.txt
+++ b/requirements/requirements-documentation.txt
@@ -1,0 +1,2 @@
+# MkDocs to build our documentation.
+mkdocs==0.11.1

--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,0 +1,4 @@
+# Optional packages which may be used with REST framework.
+markdown==2.5.2
+django-guardian==1.2.5
+django-filter==0.9.2

--- a/requirements/requirements-packaging.txt
+++ b/requirements/requirements-packaging.txt
@@ -1,0 +1,11 @@
+# Wheel for PyPI installs.
+wheel==0.24.0
+
+# Twine for secured PyPI uploads.
+twine==1.4.0
+
+# Transifex client for managing translation resources.
+transifex-client==0.10
+
+# The pip-review and pip-dump tools for package upgrades.
+pip-tools==0.3.5

--- a/requirements/requirements-packaging.txt
+++ b/requirements/requirements-packaging.txt
@@ -7,5 +7,5 @@ twine==1.4.0
 # Transifex client for managing translation resources.
 transifex-client==0.10
 
-# The pip-review and pip-dump tools for package upgrades.
+# The pip-review tool for checking package upgrades.
 pip-tools==0.3.5

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -1,0 +1,3 @@
+# PyTest for running the tests.
+pytest==2.6.4
+pytest-django==2.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -15,18 +15,17 @@ deps =
        django16: Django==1.6.3  # Should track minimum supported
        django17: Django==1.7.2  # Should track maximum supported
        django18alpha: https://www.djangoproject.com/download/1.8a1/tarball/
-       django-guardian==1.2.4
-       pytest-django==2.8.0
-       django-filter==0.9.2
-       markdown>=2.1.0
+       -rrequirements/requirements-testing.txt
+       -rrequirements/requirements-optionals.txt
 
 [testenv:py27-flake8]
 deps =
-       pytest==2.6.4
-       flake8==2.2.2
+       -rrequirements/requirements-testing.txt
+       -rrequirements/requirements-codestyle.txt
 commands = ./runtests.py --lintonly
 
 [testenv:py27-docs]
 deps =
-       mkdocs>=0.11.1
+       -rrequirements/requirements-testing.txt
+       -rrequirements/requirements-documentation.txt
 commands = mkdocs build


### PR DESCRIPTION
Layout requirements in a way that ensures we have a single source of truth on the set of packages used when running our tests.

This does away with the current split between `tox.ini` and `requirements.txt` that we have.

Closes #2563.