### PR TITLE
String format errors

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1024,8 +1024,10 @@ class ChoiceField(Field):
     def to_representation(self, value):
         if value in ('', None):
             return value
-        return self.choice_strings_to_values[six.text_type(value)]
-
+        try:
+            return self.choice_strings_to_values[six.text_type(value)]
+        except KeyError:
+            return value
 
 class MultipleChoiceField(ChoiceField):
     default_error_messages = {

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1051,10 +1051,12 @@ class MultipleChoiceField(ChoiceField):
         ])
 
     def to_representation(self, value):
-        return set([
-            self.choice_strings_to_values[six.text_type(item)] for item in value
-        ])
-
+        if value in ('', None):
+            return value
+        try:
+            return self.choice_strings_to_values[six.text_type(value)]
+        except KeyError:
+            return value
 
 # File types...
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -910,7 +910,7 @@ class DateField(Field):
         self.fail('invalid', format=humanized_format)
 
     def to_representation(self, value):
-        if self.format is None:
+        if self.format or value is None:
             return value
 
         # Applying a `DateField` to a datetime value is almost always


### PR DESCRIPTION
Was getting two separate errors. isoformat errors when datefield value was None i.e. (null=True, blank=True) on a datefield in django. Also a keyerror so I just added a KeyError exception for it. 