### PR TITLE
Fix in UniqueTogetherValidator to allow it to handle querysets

### DIFF
--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -8,6 +8,7 @@ object creation, and makes it possible to switch between using the implicit
 """
 from __future__ import unicode_literals
 from django.db import models
+from django.db.models.query import QuerySet
 from django.utils.translation import ugettext_lazy as _
 from rest_framework.compat import unicode_to_repr
 from rest_framework.exceptions import ValidationError
@@ -132,7 +133,7 @@ class UniqueTogetherValidator:
         that instance itself as a uniqueness conflict.
         """
         if self.instance is not None:
-            if isinstance(self.instance, models.QuerySet):
+            if isinstance(self.instance, QuerySet):
                 return queryset.exclude(pk__in=self.instance.values_list('pk', flat=True))
             else:
                 return queryset.exclude(pk=self.instance.pk)

--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -134,7 +134,7 @@ class UniqueTogetherValidator:
         """
         if self.instance is not None:
             if isinstance(self.instance, QuerySet):
-                return queryset.exclude(pk__in=self.instance.values_list('pk', flat=True))
+                return queryset.exclude(pk__in=self.instance.all())
             else:
                 return queryset.exclude(pk=self.instance.pk)
         return queryset


### PR DESCRIPTION
this is especially important when using a serializer with `many=True` and the model having unique multiple constrains

example failure can be found at https://github.com/miki725/django-rest-framework-bulk/issues/30

TODO

- [ ] failure test
- [ ] possibly more test cases