### PR TITLE
Fix url_path on dynamic routes for inherited viewsets. Fix #2583

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -171,9 +171,9 @@ class SimpleRouter(BaseRouter):
                 # Dynamic detail routes (@detail_route decorator)
                 for httpmethods, methodname in detail_routes:
                     method_kwargs = getattr(viewset, methodname).kwargs
-                    url_path = method_kwargs.pop("url_path", None) or methodname
                     initkwargs = route.initkwargs.copy()
                     initkwargs.update(method_kwargs)
+                    url_path = initkwargs.pop("url_path", None) or methodname
                     ret.append(Route(
                         url=replace_methodname(route.url, url_path),
                         mapping=dict((httpmethod, methodname) for httpmethod in httpmethods),
@@ -184,9 +184,9 @@ class SimpleRouter(BaseRouter):
                 # Dynamic list routes (@list_route decorator)
                 for httpmethods, methodname in list_routes:
                     method_kwargs = getattr(viewset, methodname).kwargs
-                    url_path = method_kwargs.pop("url_path", None) or methodname
                     initkwargs = route.initkwargs.copy()
                     initkwargs.update(method_kwargs)
+                    url_path = initkwargs.pop("url_path", None) or methodname
                     ret.append(Route(
                         url=replace_methodname(route.url, url_path),
                         mapping=dict((httpmethod, methodname) for httpmethod in httpmethods),

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -302,12 +302,16 @@ class DynamicListAndDetailViewSet(viewsets.ViewSet):
         return Response({'method': 'link2'})
 
 
+class SubDynamicListAndDetailViewSet(DynamicListAndDetailViewSet):
+    pass
+
+
 class TestDynamicListAndDetailRouter(TestCase):
     def setUp(self):
         self.router = SimpleRouter()
 
-    def test_list_and_detail_route_decorators(self):
-        routes = self.router.get_routes(DynamicListAndDetailViewSet)
+    def _test_list_and_detail_route_decorators(self, viewset):
+        routes = self.router.get_routes(viewset)
         decorator_routes = [r for r in routes if not (r.name.endswith('-list') or r.name.endswith('-detail'))]
 
         MethodNamesMap = namedtuple('MethodNamesMap', 'method_name url_path')
@@ -336,3 +340,9 @@ class TestDynamicListAndDetailRouter(TestCase):
             else:
                 method_map = 'get'
             self.assertEqual(route.mapping[method_map], method_name)
+
+    def test_list_and_detail_route_decorators(self):
+        self._test_list_and_detail_route_decorators(DynamicListAndDetailViewSet)
+
+    def test_inherited_list_and_detail_route_decorators(self):
+        self._test_list_and_detail_route_decorators(SubDynamicListAndDetailViewSet)


### PR DESCRIPTION
As reported in #2583, `SimpleRouter.get_routes` was popping out the `url_path` kwarg for dynamic routes, which was causing troubles in some situations.

This PR fixes this issue, removes duplicated code, and adds a test.