### PR TITLE
List resource not updated between requests

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -13,6 +13,7 @@ response content is handled by parsers and renderers.
 from __future__ import unicode_literals
 from django.db import models
 from django.db.models.fields import FieldDoesNotExist, Field as DjangoModelField
+from django.db.models import query
 from django.utils.translation import ugettext_lazy as _
 from rest_framework.compat import postgres_fields, unicode_to_repr
 from rest_framework.utils import model_meta
@@ -562,7 +563,7 @@ class ListSerializer(BaseSerializer):
         """
         # Dealing with nested relationships, data can be a Manager,
         # so, first get a queryset from the Manager if needed
-        iterable = data.all() if isinstance(data, models.Manager) else data
+        iterable = data.all() if isinstance(data, (models.Manager, query.QuerySet)) else data
         return [
             self.child.to_representation(item) for item in iterable
         ]


### PR DESCRIPTION
## The Problem

This is the test I used:

```python
import pytest
from django.contrib.auth import get_user_model
from rest_framework.test import APIClient
from reports import models

@pytest.mark.django_db
def test_get_200():
    user = get_user_model().objects.create(is_superuser=True, is_staff=True, is_active=True)
    client = APIClient()
    client.force_authenticate(user)

    models.Report.objects.create()
    response = client.get('/api/v1/reports')
    print(response.content)

    print('*' * 20)

    for _ in range(3):
        models.Report.objects.create()

    client2 = APIClient()
    client2.force_authenticate(user)
    response = client2.get('/api/v1/reports')
    print(response.content)

    assert 0
```

So two independent APIClients are created. They both request `/reports`. In between the two requests, more Report instances are created. But they don't show up in the second response.

Output:

```
danilo@adalbert:fr-frontend$ py.test test_foo.py
================================================= test session starts =================================================
platform linux2 -- Python 2.7.9 -- py-1.4.26 -- pytest-2.6.4
plugins: cache, django
collected 1 items 

test_foo.py F

====================================================== FAILURES =======================================================
____________________________________________________ test_get_200 _____________________________________________________
test_foo.py:29: in test_get_200
    assert 0
E   assert 0
------------------------------------------------ Captured stdout call -------------------------------------------------
[{"id":1,"uri":"http://testserver/api/v1/reports/1","name":"","created":"2015-02-25T13:59:51.990526Z","clientName":"","managerName":"","managerEmail":"","logo":null,"users":[],"design":null,"views":"{}"}]
********************
[{"id":1,"uri":"http://testserver/api/v1/reports/1","name":"","created":"2015-02-25T13:59:51.990526Z","clientName":"","managerName":"","managerEmail":"","logo":null,"users":[],"design":null,"views":"{}"}]
============================================== 1 failed in 5.86 seconds ===============================================
```

## The Bug

The issue does not occur in DRF 3.0.0, but all versions 3.0.1-3.0.5 are affected.

With `git bisect` I could track down the commit that introduced this bug: 8d6b0b1f2d3a5014d43f1314d96bc9197709b542 The corresponding pull request is #2241.

## Resolution Attempts

First I simply tried to revert the commit onto 3.0.5... But that caused a conflict:

```python
<<<<<<< HEAD
        # Dealing with nested relationships, data can be a Manager,
        # so, first get a queryset from the Manager if needed
        iterable = data.all() if isinstance(data, models.Manager) else data
=======
        iterable = data.all() if (hasattr(data, 'all')) else data
>>>>>>> parent of 8d6b0b1... Update serializers.py
        return [
            self.child.to_representation(item) for item in iterable
        ]
```

I'm not sure what the correct solution is, as I don't understand this code yet. I just know that the bug is gone if I replace the conflicting line with `iterable = data.all() if (hasattr(data, 'all')) else data`.

CC @tomchristie @IvanAlegre