### PR TITLE
Make Markdown Extensions a DRF setting

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -232,7 +232,7 @@ try:
         of '#' style headers to <h2>.
         """
 
-        extensions = ['headerid(level=2)']
+        extensions = settings.MARKDOWN_EXTENSIONS
         safe_mode = False
         md = markdown.Markdown(extensions=extensions, safe_mode=safe_mode)
         return md.convert(text)

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -117,7 +117,10 @@ DEFAULTS = {
     'UNICODE_JSON': True,
     'COMPACT_JSON': True,
     'COERCE_DECIMAL_TO_STRING': True,
-    'UPLOADED_FILES_USE_URL': True
+    'UPLOADED_FILES_USE_URL': True,
+
+    # Markdown
+    'MARKDOWN_EXTENSIONS': ['headerid(level=2)']
 }
 
 


### PR DESCRIPTION
**Use Custom Markdown Extensions With Django Rest Swagger:**

Django Rest Swagger allows you to [parse docstrings as markdown](http://django-rest-swagger.readthedocs.org/en/latest/misc.html#markdown).  To do this, Django Rest Swagger actually [calls DRF's `compat.apply_markdown()` function](https://github.com/marcgibbons/django-rest-swagger/blob/master/rest_framework_swagger/introspectors.py#L488-L493).  It would be nice if custom Markdown extensions were also applied.

This PR adds a new DRF setting `MARKDOWN_EXTENSIONS` such that you could add your own Markdown extensions to `compat.apply_markdown()`.  

It defaults to the currently used extensions: `['headerid(level=2)']` 
