### PR TITLE
Improved on LinkHeaderPagination example

### DIFF
--- a/docs/api-guide/pagination.md
+++ b/docs/api-guide/pagination.md
@@ -93,18 +93,18 @@ Let's modify the built-in `PageNumberPagination` style, so that instead of inclu
 
     class LinkHeaderPagination(pagination.PageNumberPagination):
         def get_paginated_response(self, data):
+            first_url = self.get_first_link()
+            prev_url = self.get_previous_link()
+            next_url = self.get_next_link()
+            last_url = self.get_last_link()
+
             link = '<{}>; rel="{}"'
 
-            first = self.get_first_link()
-            prev = self.get_previous_link()
-            next = self.get_next_link()
-            last = self.get_last_link()
-
             links = [
-                link.format(first, 'first'),
-                link.format(prev, 'prev') if prev else None,
-                link.format(next, 'next') if next else None,
-                link.format(last, 'last'),
+                link.format(first_url, 'first'),
+                link.format(prev_url, 'prev') if prev_url else None,
+                link.format(next_url, 'next') if next_url else None,
+                link.format(last_url, 'last'),
             ]
 
             headers = {

--- a/docs/api-guide/pagination.md
+++ b/docs/api-guide/pagination.md
@@ -101,35 +101,30 @@ from rest_framework.utils.urls import remove_query_param, replace_query_param
 
 class LinkHeaderPagination(pagination.PageNumberPagination):
     def get_paginated_response(self, data):
+        headers = {
+            'X-Page': self.page.number,
+            'X-Per-Page': self.page.paginator.per_page,
+            'X-Total': self.page.paginator.count,
+            'X-Total-Pages': self.page.paginator.num_pages
+        }
+
         first_url = self.get_first_link()
         prev_url = self.get_previous_link()
         next_url = self.get_next_link()
         last_url = self.get_last_link()
 
         link = '<{}>; rel="{}"'
+        links = []
 
-        links = [
-            link.format(first_url, 'first'),
-            link.format(prev_url, 'prev') if prev_url else None,
-            link.format(next_url, 'next') if next_url else None,
-            link.format(last_url, 'last'),
-        ]
+        if first_url: links.append(link.format(first_url, 'first'))
+        if prev_url: links.append(link.format(prev_url, 'prev'))
+        if next_url: links.append(link.format(next_url, 'next'))
+        if last_url: links.append(link.format(last_url, 'last'))
 
-        headers = {
-            'Link': ", ".join([link for link in links if link]),
-            'X-Total-Count': self.page.paginator.count
-        }
+        if links:
+            headers['Link'] = ", ".join(links)
 
         return Response(data, headers=headers)
-
-    def get_first_link(self):
-        url = self.request.build_absolute_uri()
-        return remove_query_param(url, self.page_query_param)
-
-    def get_last_link(self):
-        url = self.request.build_absolute_uri()
-        page_number = self.page.paginator.num_pages
-        return replace_query_param(url, self.page_query_param, page_number)
 ```
 
 ## Using your custom pagination class

--- a/docs/api-guide/pagination.md
+++ b/docs/api-guide/pagination.md
@@ -96,10 +96,9 @@ Let's modify the built-in `PageNumberPagination` style, so that instead of inclu
 ```py
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
-from rest_framework.utils.urls import remove_query_param, replace_query_param
 
 
-class LinkHeaderPagination(pagination.PageNumberPagination):
+class LinkHeaderPagination(PageNumberPagination):
     def get_paginated_response(self, data):
         headers = {
             'X-Page': self.page.number,

--- a/docs/api-guide/pagination.md
+++ b/docs/api-guide/pagination.md
@@ -86,42 +86,42 @@ Note that the `paginate_queryset` method may set state on the pagination instanc
 Let's modify the built-in `PageNumberPagination` style, so that instead of include the pagination links in the body of the response, we'll instead include a `Link` header, in a [similar style to the GitHub API][github-link-pagination].
 
 ```py
-    from rest_framework.pagination import PageNumberPagination
-    from rest_framework.response import Response
-    from rest_framework.utils.urls import remove_query_param, replace_query_param
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+from rest_framework.utils.urls import remove_query_param, replace_query_param
 
 
-    class LinkHeaderPagination(pagination.PageNumberPagination):
-        def get_paginated_response(self, data):
-            first_url = self.get_first_link()
-            prev_url = self.get_previous_link()
-            next_url = self.get_next_link()
-            last_url = self.get_last_link()
+class LinkHeaderPagination(pagination.PageNumberPagination):
+    def get_paginated_response(self, data):
+        first_url = self.get_first_link()
+        prev_url = self.get_previous_link()
+        next_url = self.get_next_link()
+        last_url = self.get_last_link()
 
-            link = '<{}>; rel="{}"'
+        link = '<{}>; rel="{}"'
 
-            links = [
-                link.format(first_url, 'first'),
-                link.format(prev_url, 'prev') if prev_url else None,
-                link.format(next_url, 'next') if next_url else None,
-                link.format(last_url, 'last'),
-            ]
+        links = [
+            link.format(first_url, 'first'),
+            link.format(prev_url, 'prev') if prev_url else None,
+            link.format(next_url, 'next') if next_url else None,
+            link.format(last_url, 'last'),
+        ]
 
-            headers = {
-                'Link': ", ".join([link for link in links if link]),
-                'X-Total-Count': self.page.paginator.count
-            }
+        headers = {
+            'Link': ", ".join([link for link in links if link]),
+            'X-Total-Count': self.page.paginator.count
+        }
 
-            return Response(data, headers=headers)
+        return Response(data, headers=headers)
 
-        def get_first_link(self):
-            url = self.request.build_absolute_uri()
-            return remove_query_param(url, self.page_query_param)
+    def get_first_link(self):
+        url = self.request.build_absolute_uri()
+        return remove_query_param(url, self.page_query_param)
 
-        def get_last_link(self):
-            url = self.request.build_absolute_uri()
-            page_number = self.page.paginator.num_pages
-            return replace_query_param(url, self.page_query_param, page_number)
+    def get_last_link(self):
+        url = self.request.build_absolute_uri()
+        page_number = self.page.paginator.num_pages
+        return replace_query_param(url, self.page_query_param, page_number)
 ```
 
 ## Using your custom pagination class

--- a/docs/api-guide/pagination.md
+++ b/docs/api-guide/pagination.md
@@ -21,9 +21,11 @@ Pagination is only performed automatically if you're using the generic views or 
 
 The default pagination style may be set globally, using the `DEFAULT_PAGINATION_CLASS` settings key. For example, to use the built-in limit/offset pagination, you would do:
 
-    REST_FRAMEWORK = {
-        'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination'
-    }
+```py
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination'
+}
+```
 
 You can also set the pagination class on an individual view by using the `pagination_class` attribute. Typically you'll want to use the same pagination style throughout your API, although you might want to vary individual aspects of the pagination, such as default or maximum page size, on a per-view basis.
 
@@ -31,28 +33,34 @@ You can also set the pagination class on an individual view by using the `pagina
 
 If you want to modify particular aspects of the pagination style, you'll want to override one of the pagination classes, and set the attributes that you want to change.
 
-    class LargeResultsSetPagination(PageNumberPagination):
-        paginate_by = 1000
-        paginate_by_param = 'page_size'
-        max_paginate_by = 10000
+```py
+class LargeResultsSetPagination(PageNumberPagination):
+    paginate_by = 1000
+    paginate_by_param = 'page_size'
+    max_paginate_by = 10000
 
-    class StandardResultsSetPagination(PageNumberPagination):
-        paginate_by = 100
-        paginate_by_param = 'page_size'
-        max_paginate_by = 1000
+class StandardResultsSetPagination(PageNumberPagination):
+    paginate_by = 100
+    paginate_by_param = 'page_size'
+    max_paginate_by = 1000
+```
 
 You can then apply your new style to a view using the `.pagination_class` attribute:
 
-    class BillingRecordsView(generics.ListAPIView):
-        queryset = Billing.objects.all()
-        serializer = BillingRecordsSerializer
-        pagination_class = LargeResultsSetPagination
+```py
+class BillingRecordsView(generics.ListAPIView):
+    queryset = Billing.objects.all()
+    serializer = BillingRecordsSerializer
+    pagination_class = LargeResultsSetPagination
+```
 
 Or apply the style globally, using the `DEFAULT_PAGINATION_CLASS` settings key. For example:
 
-    REST_FRAMEWORK = {
-        'DEFAULT_PAGINATION_CLASS': 'apps.core.pagination.StandardResultsSetPagination'
-    }
+```py
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'apps.core.pagination.StandardResultsSetPagination'
+}
+```
 
 ---
 
@@ -128,10 +136,12 @@ class LinkHeaderPagination(pagination.PageNumberPagination):
 
 To have your custom pagination class be used by default, use the `DEFAULT_PAGINATION_CLASS` setting:
 
-    REST_FRAMEWORK = {
-        'DEFAULT_PAGINATION_CLASS': 'my_project.apps.core.pagination.LinkHeaderPagination',
-        'PAGINATE_BY': 10
-    }
+```py
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'my_project.apps.core.pagination.LinkHeaderPagination',
+    'PAGINATE_BY': 10
+}
+```
 
 API responses for list endpoints will now include a `Link` header, instead of including the pagination links as part of the body of the response, for example:
 

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -287,12 +287,11 @@ class PageNumberPagination(BasePagination):
 
         return self.paginate_by
 
-    def get_next_link(self):
-        if not self.page.has_next():
+    def get_first_link(self):
+        if not self.page.has_previous():
             return None
         url = self.request.build_absolute_uri()
-        page_number = self.page.next_page_number()
-        return replace_query_param(url, self.page_query_param, page_number)
+        return remove_query_param(url, self.page_query_param)
 
     def get_previous_link(self):
         if not self.page.has_previous():
@@ -303,6 +302,20 @@ class PageNumberPagination(BasePagination):
             return remove_query_param(url, self.page_query_param)
         return replace_query_param(url, self.page_query_param, page_number)
 
+    def get_next_link(self):
+        if not self.page.has_next():
+            return None
+        url = self.request.build_absolute_uri()
+        page_number = self.page.next_page_number()
+        return replace_query_param(url, self.page_query_param, page_number)
+
+    def get_last_link(self):
+        if not self.page.has_next():
+            return None
+        url = self.request.build_absolute_uri()
+        page_number = self.page.paginator.num_pages
+        return replace_query_param(url, self.page_query_param, page_number)
+        
     def get_html_context(self):
         base_url = self.request.build_absolute_uri()
 


### PR DESCRIPTION
- Fixes Link header syntax, which if I understand [RFC5988](http://www.rfc-editor.org/rfc/rfc5988.txt) correctly, was incorrect
- [Adds first and last page `<link>`'s](http://blog.mwaysolutions.com/2014/06/05/10-best-practices-for-better-restful-api)
- [Adds `X-Page`, `X-Per-Page`, `X-Total`, `X-Total-Pages`](http://blog.mwaysolutions.com/2014/06/05/10-best-practices-for-better-restful-api)
- Adds imports and python codeblocks for easy reading