### PR TITLE
Overriding Field.__deepcopy__ for RegexField

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -612,6 +612,18 @@ class RegexField(CharField):
         validator = RegexValidator(regex, message=self.error_messages['invalid'])
         self.validators.append(validator)
 
+    def __deepcopy__(self, memo):
+        # Handling case when regex is not passed in kwargs.
+        args = self._args[:1] + copy.deepcopy(self._args[1:])
+        kwargs = dict(self._kwargs)
+
+        # deepcopy doesn't work on compiled regex pattern
+        regex = kwargs.pop('regex', None)
+        kwargs = copy.deepcopy(kwargs)
+        if regex is not None:
+            kwargs['regex'] = regex
+        return self.__class__(*args, **kwargs)
+
 
 class SlugField(CharField):
     default_error_messages = {


### PR DESCRIPTION
Problem:

`Serializers` are deepcopying a declared `RegexField`[[source]](https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/serializers.py#L324), but it'll error out with the message. `TypeError: cannot deepcopy this pattern object`.

![screen shot 2015-02-27 at 2 12 06 pm](https://cloud.githubusercontent.com/assets/1307950/6422194/a50e10bc-be8a-11e4-9c57-bf8a2dc3ae60.png)
![screen shot 2015-02-27 at 2 12 52 pm](https://cloud.githubusercontent.com/assets/1307950/6422201/c24dc80c-be8a-11e4-8bbb-6520de0910b6.png)
![screen shot 2015-02-27 at 2 58 45 pm](https://cloud.githubusercontent.com/assets/1307950/6422766/269eb1a8-be91-11e4-96e1-aad8377bd7fa.png)