### PR TITLE
Updated CreateOnlyDefault to call set_context on its default

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -114,6 +114,8 @@ class CreateOnlyDefault:
 
     def set_context(self, serializer_field):
         self.is_update = serializer_field.parent.instance is not None
+        if callable(self.default) and hasattr(self.default, 'set_context'):
+            self.default.set_context(serializer_field)
 
     def __call__(self):
         if self.is_update:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -318,7 +318,10 @@ class TestCreateOnlyDefault:
         }
 
     def test_create_only_default_callable_sets_context(self):
-        """ CreateOnlyDefault instances with a callable default should set_context on the callable if possible """
+        """
+        CreateOnlyDefault instances with a callable default should set_context
+        on the callable if possible
+        """
         class TestCallableDefault:
             def set_context(self, serializer_field):
                 self.field = serializer_field

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -317,6 +317,22 @@ class TestCreateOnlyDefault:
             'text': 'example',
         }
 
+    def test_create_only_default_callable_sets_context(self):
+        """ CreateOnlyDefault instances with a callable default should set_context on the callable if possible """
+        class TestCallableDefault:
+            def set_context(self, serializer_field):
+                self.field = serializer_field
+
+            def __call__(self):
+                return "success" if hasattr(self, 'field') else "failure"
+
+        class TestSerializer(serializers.Serializer):
+            context_set = serializers.CharField(default=serializers.CreateOnlyDefault(TestCallableDefault()))
+
+        serializer = TestSerializer(data={})
+        assert serializer.is_valid()
+        assert serializer.validated_data['context_set'] == 'success'
+
 
 # Tests for field input and output values.
 # ----------------------------------------


### PR DESCRIPTION
`CreateOnlyDefault` should call `set_context()` on it's default if it's callable. This allows you to combine `CreateOnlyDefault` with other callables that rely on `set_context()`, e.g.:

```python
created_by = UserSerializer(read_only=True, 
                            default=CreateOnlyDefault(CurrentUserDefault()))
```

I would have expected this to be the case already, so I didn't think any documentation change was necessary.