### PR TITLE
Personal fix for issue: #2566

### DIFF
--- a/rest_framework/utils/html.py
+++ b/rest_framework/utils/html.py
@@ -49,6 +49,12 @@ def parse_html_list(dictionary, prefix=''):
     for field, value in dictionary.items():
         match = regex.match(field)
         if not match:
+            try:
+                normalized_value = json.loads(value)
+            except ValueError:
+                continue
+            if field == prefix and isinstance(normalized_value, list):
+                return normalized_value
             continue
         index, key = match.groups()
         index = int(index)

--- a/rest_framework/utils/html.py
+++ b/rest_framework/utils/html.py
@@ -1,6 +1,7 @@
 """
 Helpers for dealing with HTML input.
 """
+import json
 import re
 from django.utils.datastructures import MultiValueDict
 


### PR DESCRIPTION
When an HTML form is used to submit data to DRF this function parse_html_list is called.
This functions can't parse a list of strings.

To work around this, post the data as a valid JSON list: 

```["example string 1", "test string 2"]```

This list is parsed as JSON and returned. Thus allowing a formdata with a list to be submitted.