### PR TITLE
change token max_length to 300

### DIFF
--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -18,7 +18,7 @@ class Token(models.Model):
     """
     The default authorization token model.
     """
-    key = models.CharField(max_length=40, primary_key=True)
+    key = models.CharField(max_length=300, primary_key=True)
     user = models.OneToOneField(AUTH_USER_MODEL, related_name='auth_token')
     created = models.DateTimeField(auto_now_add=True)
 


### PR DESCRIPTION
Sometimes I want to use my own token as auth token here. For example, the token from facebook. But the length of facebook token is 250+, can you change the length to 300 to make it general? 40 is too small.