### PR TITLE
Support serializing unsaved models with related fields.

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -360,6 +360,10 @@ class ManyRelatedField(Field):
         ]
 
     def get_attribute(self, instance):
+        # Can't have any relationships if not created
+        if not instance.pk:
+            return []
+
         relationship = get_attribute(instance, self.source_attrs)
         return relationship.all() if (hasattr(relationship, 'all')) else relationship
 

--- a/tests/test_relations_pk.py
+++ b/tests/test_relations_pk.py
@@ -143,6 +143,16 @@ class PKManyToManyTests(TestCase):
         ]
         self.assertEqual(serializer.data, expected)
 
+    def test_many_to_many_unsaved(self):
+        source = ManyToManySource(name='source-unsaved')
+
+        serializer = ManyToManySourceSerializer(source)
+
+        expected = {'id': None, 'name': 'source-unsaved', 'targets': []}
+        # no query if source hasn't been created yet
+        with self.assertNumQueries(0):
+            self.assertEqual(serializer.data, expected)
+
     def test_reverse_many_to_many_create(self):
         data = {'id': 4, 'name': 'target-4', 'sources': [1, 3]}
         serializer = ManyToManyTargetSerializer(data=data)
@@ -295,6 +305,16 @@ class PKForeignKeyTests(TestCase):
         serializer = ForeignKeySourceSerializer(instance, data=data)
         self.assertFalse(serializer.is_valid())
         self.assertEqual(serializer.errors, {'target': ['This field may not be null.']})
+
+    def test_foreign_key_with_unsaved(self):
+        source = ForeignKeySource(name='source-unsaved')
+        expected = {'id': None, 'name': 'source-unsaved', 'target': None}
+
+        serializer = ForeignKeySourceSerializer(source)
+
+        # no query if source hasn't been created yet
+        with self.assertNumQueries(0):
+            self.assertEqual(serializer.data, expected)
 
     def test_foreign_key_with_empty(self):
         """


### PR DESCRIPTION
- In both RelatedField and ManyRelatedField, provide an empty return
  when trying to access a relation field if the instance in question has
  no PK (so likely hasn't been inserted yet)
- Add relevant tests
- Without these changes, exceptions would be raised when trying to
  serialize the uncreated models as it is impossible to query 
  relations without a PK