### PR TITLE
Fix example of explicit format URL (for real).

### DIFF
--- a/docs/tutorial/2-requests-and-responses.md
+++ b/docs/tutorial/2-requests-and-responses.md
@@ -200,7 +200,7 @@ See the [browsable api][browsable-api] topic for more information about the brow
 
 In [tutorial part 3][tut-3], we'll start using class based views, and see how generic views reduce the amount of code we need to write.
 
-[json-url]: http://example.com/api/items/4.json
+[json-url]: http://example.com/api/items/4/.json
 [devserver]: http://127.0.0.1:8000/snippets/
 [browsable-api]: ../topics/browsable-api.md
 [tut-1]: 1-serialization.md


### PR DESCRIPTION
Do what I meant to do in #2670:

The link is displayed in the tutorial as "http://example.com/api/items/4.json" but the hyperlink itself and what the example code actually works with are (in my opinion, less pretty) URLs like "http://example.com/api/items/4/.json".