### PR TITLE
Fixed problem with imporing rest_framework.views in apps.py

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -10,7 +10,7 @@ from django.core.paginator import InvalidPage, Paginator as DjangoPaginator
 from django.template import Context, loader
 from django.utils import six
 from django.utils.six.moves.urllib import parse as urlparse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from rest_framework.compat import OrderedDict
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response


### PR DESCRIPTION
I've experienced a problem while imporing rest_framework.views in apps.py, where I would get the notorious 'django.core.exceptions.AppRegistryNotReady: The translation infrastructure cannot be initialized before the apps registry is ready. Check that you don't make non-lazy gettext calls at import time' error. I've traced it back to DRF's pagination.py, where I noticed you are making use of 'ugettext' instead of 'ugettext_lazy'. Replacing this, seems to have fixed my issue.