### PR TITLE
Fix lookup_url_kwarg handling in viewsets (Fixes #2591).

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -218,14 +218,15 @@ class SimpleRouter(BaseRouter):
 
         https://github.com/alanjds/drf-nested-routers
         """
-        base_regex = '(?P<{lookup_prefix}{lookup_field}>{lookup_value})'
+        base_regex = '(?P<{lookup_prefix}{lookup_url_kwarg}>{lookup_value})'
         # Use `pk` as default field, unset set.  Default regex should not
         # consume `.json` style suffixes and should break at '/' boundaries.
         lookup_field = getattr(viewset, 'lookup_field', 'pk')
+        lookup_url_kwarg = getattr(viewset, 'lookup_url_kwarg', None) or lookup_field
         lookup_value = getattr(viewset, 'lookup_value_regex', '[^/.]+')
         return base_regex.format(
             lookup_prefix=lookup_prefix,
-            lookup_field=lookup_field,
+            lookup_url_kwarg=lookup_url_kwarg,
             lookup_value=lookup_value
         )
 


### PR DESCRIPTION
The ``lookup_url_kwarg`` is intended to set the name of a field in the
URL regexps when using custom ``lookup_field``, but the routers ignore
it altogether.

When a ViewSet is defined with:
```python
class ProfileViewSet(ViewSet):
    lookup_field = 'user__username'
    lookup_url_kwarg = 'username'
```

Then we should get an URL along the lines of ``/profiles/(?P<username>[^./]+)/``.
However, we get ``/profiles/(?P<user__username>[^./]+)/``...

This PR fixes the bug (reported as #2591), along with an inelegant test.