### PR TITLE
fixed missing anchor closing tag

### DIFF
--- a/rest_framework/templates/rest_framework/pagination/previous_and_next.html
+++ b/rest_framework/templates/rest_framework/pagination/previous_and_next.html
@@ -7,6 +7,6 @@
 {% if next_url %}
     <li class="next"><a href="{{ next_url }}">Next &raquo;</a></li>
 {% else %}
-    <li class="next disabled"><a href="#">Next &raquo;</li>
+    <li class="next disabled"><a href="#">Next &raquo;</a></li>
 {% endif %}
 </ul>


### PR DESCRIPTION
when next_url is none, big part of page html will be rendered under the <a href='#'> as it does not have a closing tag.