### PR TITLE
[enhancement] Refactored DecimalField to allow easier subclassing

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -757,10 +757,8 @@ class DecimalField(Field):
 
     def to_internal_value(self, data):
         """
-        Validates that the input is a decimal number. Returns a Decimal
-        instance. Returns None for empty values. Ensures that there are no more
-        than max_digits in the number, and no more than decimal_places digits
-        after the decimal point.
+        Validate that the input is a decimal number and return a Decimal
+        instance.
         """
         data = smart_text(data).strip()
         if len(data) > self.MAX_STRING_LENGTH:
@@ -780,6 +778,16 @@ class DecimalField(Field):
         if value in (decimal.Decimal('Inf'), decimal.Decimal('-Inf')):
             self.fail('invalid')
 
+        return self.validate_precision(value)
+
+    def validate_precision(self, value):
+        """
+        Ensure that there are no more than max_digits in the number, and no
+        more than decimal_places digits after the decimal point.
+
+        Override this method to disable the precision validation for input
+        values or to enhance it in any way you need to.
+        """
         sign, digittuple, exponent = value.as_tuple()
         decimals = abs(exponent)
         # digittuple doesn't include any leading zeros.
@@ -805,15 +813,21 @@ class DecimalField(Field):
         if not isinstance(value, decimal.Decimal):
             value = decimal.Decimal(six.text_type(value).strip())
 
-        context = decimal.getcontext().copy()
-        context.prec = self.max_digits
-        quantized = value.quantize(
-            decimal.Decimal('.1') ** self.decimal_places,
-            context=context
-        )
+        quantized = self.quantize(value)
+
         if not self.coerce_to_string:
             return quantized
         return '{0:f}'.format(quantized)
+
+    def quantize(self, value):
+        """
+        Quantize the decimal value to the configured precision.
+        """
+        context = decimal.getcontext().copy()
+        context.prec = self.max_digits
+        return value.quantize(
+            decimal.Decimal('.1') ** self.decimal_places,
+            context=context)
 
 
 # Date & time fields...


### PR DESCRIPTION
Hello,

I did some cleanup in the DecimalField class to make the methods shorter and more focused on their responsibility, but the main goal is to allow developer do to something like this:

```python
class PermissiveDecimalField(serializers.DecimalField):
    """
    Consider the configured `max_digits` and `decimal_places` for both
    serialization and deserialization, but do not reject input values with 
    bigger precisions.
    """
    def validate_precision(self, value):
        return self.quantize(value)
```

Without this refactor, covering such a use-case is quite ugly. You have to copy paste the `to_internal_value` to benefit for the sanity checks and then override the precision validation part:

```python
class PermissiveDecimalField(serializers.DecimalField):
    """
    Consider the configured `max_digits` and `decimal_places` for both
    serialization and deserialization, but do not reject input values with 
    bigger precisions.
    """
    def to_internal_value(self, data):
        data = smart_text(data).strip()
        if len(data) > self.MAX_STRING_LENGTH:
            self.fail('max_string_length')

        try:
            value = decimal.Decimal(data)
        except decimal.DecimalException:
            self.fail('invalid')

        # Check for NaN. It is the only value that isn't equal to itself,
        # so we can use this to identify NaN values.
        if value != value:
            self.fail('invalid')

        # Check for infinity and negative infinity.
        if value in (decimal.Decimal('Inf'), decimal.Decimal('-Inf')):
            self.fail('invalid')

        return self.validate_precision(value)

    def validate_precision(self, value):
        context = decimal.getcontext().copy()
        context.prec = self.max_digits
        return value.quantize(
            decimal.Decimal('.1') ** self.decimal_places,
            context=context)
```

And if you think about it, it's not an obscure use-case at all. In my case, we are storing longitude and latitude values of up to 6 decimal places (~100 millimeters precision, which is more than enough for us) but the values can come from different geolocation sources which can have bigger precision and without this change we would have to sanitize the inputs on the client side. On each different client that you have. This way, I don't care about the infinitesimal precisions, I just grab the value, quantize it to the desired precision and store it in the database.

I like this sort of refactoring because if makes the code cleaner and the life of the developers easier. (I'm happy to do more of these if the community agrees that it's valuable). 

Any thoughts?

Thanks!