### PR TITLE
Add "owner=1" to final http example of tutorial, page 4

### DIFF
--- a/docs/tutorial/4-authentication-and-permissions.md
+++ b/docs/tutorial/4-authentication-and-permissions.md
@@ -206,7 +206,7 @@ If we try to create a snippet without authenticating, we'll get an error:
 
 We can make a successful request by including the username and password of one of the users we created earlier.
 
-    http -a tom:password POST http://127.0.0.1:8000/snippets/ code="print 789"
+    http -a tom:password POST http://127.0.0.1:8000/snippets/ code="print 789" owner=1
 
     {
         "id": 5,

--- a/docs/tutorial/5-relationships-and-hyperlinked-apis.md
+++ b/docs/tutorial/5-relationships-and-hyperlinked-apis.md
@@ -104,7 +104,7 @@ If we're going to have a hyperlinked API, we need to make sure we name our URL p
 * Our user serializer includes a field that refers to `'snippet-detail'`.
 * Our snippet and user serializers include `'url'` fields that by default will refer to `'{model_name}-detail'`, which in this case will be `'snippet-detail'` and `'user-detail'`.
 
-After adding all those names into our URLconf, our final `snippets/urls.py` file should look something like this:
+After adding all those names into our URLconf, our final `snippets/urls.py` file should look like this:
 
     from django.conf.urls import url, include
     from rest_framework.urlpatterns import format_suffix_patterns

--- a/docs/tutorial/5-relationships-and-hyperlinked-apis.md
+++ b/docs/tutorial/5-relationships-and-hyperlinked-apis.md
@@ -107,6 +107,9 @@ If we're going to have a hyperlinked API, we need to make sure we name our URL p
 After adding all those names into our URLconf, our final `snippets/urls.py` file should look something like this:
 
     from django.conf.urls import url, include
+    from rest_framework.urlpatterns import format_suffix_patterns
+    from snippets import views
+
 
     # API endpoints
     urlpatterns = format_suffix_patterns([


### PR DESCRIPTION
The http POST command on line 209 currently fails with because it lacks the required key owner.
```
$ http -a admin:password POST http://127.0.0.1:8000/snippets/ code="print 789"
HTTP/1.0 400 BAD REQUEST
Allow: GET, POST, HEAD, OPTIONS
Content-Type: application/json
Date: Sat, 14 Mar 2015 16:37:05 GMT
Server: WSGIServer/0.2 CPython/3.4.2
Vary: Accept, Cookie
X-Frame-Options: SAMEORIGIN

{
    "owner": [
        "This field is required."
    ]
}
```