### PR TITLE
Add necessary imports to final urls.py example

### DIFF
--- a/docs/tutorial/5-relationships-and-hyperlinked-apis.md
+++ b/docs/tutorial/5-relationships-and-hyperlinked-apis.md
@@ -104,9 +104,11 @@ If we're going to have a hyperlinked API, we need to make sure we name our URL p
 * Our user serializer includes a field that refers to `'snippet-detail'`.
 * Our snippet and user serializers include `'url'` fields that by default will refer to `'{model_name}-detail'`, which in this case will be `'snippet-detail'` and `'user-detail'`.
 
-After adding all those names into our URLconf, our final `snippets/urls.py` file should look something like this:
+After adding all those names into our URLconf, our final `snippets/urls.py` file should look like this:
 
     from django.conf.urls import url, include
+    from rest_framework.urlpatterns import format_suffix_patterns
+    from snippets import views
 
     # API endpoints
     urlpatterns = format_suffix_patterns([


### PR DESCRIPTION
Clarifies `urls.py` example in tutorial. This pull request is a follow up from an earlier one, #2696.
