### PR TITLE
add default value to model serializer

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -96,8 +96,11 @@ def get_field_kwargs(field_name, model_field):
         kwargs['read_only'] = True
         return kwargs
 
-    if model_field.has_default() or model_field.blank or model_field.null:
+    if model_field.blank or model_field.null:
         kwargs['required'] = False
+
+    if model_field.has_default():
+        kwargs['default'] = model_field.get_default()
 
     if model_field.null and not isinstance(model_field, models.NullBooleanField):
         kwargs['allow_null'] = True

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -108,7 +108,7 @@ class TestRegularFieldMappings(TestCase):
             TestSerializer():
                 auto_field = IntegerField(read_only=True)
                 big_integer_field = IntegerField()
-                boolean_field = BooleanField(required=False)
+                boolean_field = BooleanField(default=False, required=False)
                 char_field = CharField(max_length=100)
                 comma_separated_integer_field = CharField(max_length=100, validators=[<django.core.validators.RegexValidator object>])
                 date_field = DateField()
@@ -141,7 +141,7 @@ class TestRegularFieldMappings(TestCase):
                 length_limit_field = CharField(max_length=12, min_length=3)
                 blank_field = CharField(allow_blank=True, max_length=10, required=False)
                 null_field = IntegerField(allow_null=True, required=False)
-                default_field = IntegerField(required=False)
+                default_field = IntegerField(default=0)
                 descriptive_field = IntegerField(help_text='Some help text', label='A label')
                 choices_field = ChoiceField(choices=[('red', 'Red'), ('blue', 'Blue'), ('green', 'Green')])
         """)
@@ -152,7 +152,9 @@ class TestRegularFieldMappings(TestCase):
                 "('red', 'Red'), ('blue', 'Blue'), ('green', 'Green')",
                 "(u'red', u'Red'), (u'blue', u'Blue'), (u'green', u'Green')"
             )
-        self.assertEqual(unicode_repr(TestSerializer()), expected)
+        serializer = TestSerializer()
+        self.assertEqual(unicode_repr(serializer), expected)
+        self.assertFalse(serializer.fields["default_field"].required)
 
     def test_method_field(self):
         """


### PR DESCRIPTION
Hi, as I explained in https://github.com/tomchristie/django-rest-framework/issues/2683, the default value is not being passed in the model serializer.

I understand your argument that this is not required functionality-wise, but it is a problem when auto generation documentation (e.g. with django-rest-swagger). This was the behavior in djangorestframework==2.3.8, in which the swagger tests are run against.

I don't see any disadvantage in passing the default value to the field, instead of just marking it as non required.

Do you see any?
Please reconsider.

