### PR TITLE
Set child instance to an instance instead of QuerySet.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -545,6 +545,8 @@ class ListSerializer(BaseSerializer):
 
         for item in data:
             try:
+                if isinstance(self.instance, QuerySet):
+                    self.child.instance = self.instance.get(pk=item['id'])
                 validated = self.child.run_validation(item)
             except ValidationError as exc:
                 errors.append(exc.detail)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -46,6 +46,42 @@ class ShouldValidateModelSerializer(serializers.ModelSerializer):
         fields = ('renamed',)
 
 
+class UniqueTogetherModel(models.Model):
+    foo = models.IntegerField()
+    bar = models.IntegerField()
+
+    class Meta(object):
+        unique_together = ('foo', 'bar')
+
+
+class ExampleSerializer(serializers.ModelSerializer):
+    class Meta(object):
+        model = UniqueTogetherModel
+
+
+class TestUniqueTogether(TestCase):
+    def test_validation(self):
+        """
+        Ensure that validation works when model has unique together validation.
+        """
+        UniqueTogetherModel.objects.all().delete()
+        obj = UniqueTogetherModel.objects.create(foo=1, bar=2)
+
+        s = ExampleSerializer(
+            UniqueTogetherModel.objects.all(),
+            data=[
+                {
+                    'foo': 5,
+                    'id': obj.pk,
+                }
+            ],
+            partial=True,
+            many=True,
+        )
+
+        s.is_valid(raise_exception=True)
+
+
 class TestPreSaveValidationExclusionsSerializer(TestCase):
     def test_renamed_fields_are_model_validated(self):
         """


### PR DESCRIPTION
I came across this issue using drf-bulk to do a bulk update on a model with the unique_together validator on it. Looking into it further I came across the following issues that mirrored my problem: 

https://github.com/tomchristie/django-rest-framework/pull/2575
https://github.com/miki725/django-rest-framework-bulk/issues/30

This should allow validation to be run on each instance in the ListSerializer.