### PR TITLE
Document per-view versioning settings

### DIFF
--- a/docs/api-guide/versioning.md
+++ b/docs/api-guide/versioning.md
@@ -72,6 +72,19 @@ The following settings keys are also used to control versioning:
 * `ALLOWED_VERSIONS`. If set, this value will restrict the set of versions that may be returned by the versioning scheme, and will raise an error if the provided version if not in this set. Defaults to `None`.
 * `VERSION_PARAMETER`. The string that should used for any versioning parameters, such as in the media type or URL query parameters. Defaults to `'version'`.
 
+You can also set your versioning class plus those three values on a per-view or a per-viewset basis by defining your own versioning scheme and using the `default_version`, `allowed_versions` and `version_param` class variables. For example, if you want to use `URLPathVersioning`:
+
+    from rest_framework.versioning import URLPathVersioning
+    from rest_framework.views import APIView
+
+    class ExampleVersioning(URLPathVersioning):
+        default_version = ...
+        allowed_versions = ...
+        version_param = ...
+
+    class ExampleView(APIVIew):
+        versioning_class = ExampleVersioning
+
 ---
 
 # API Reference


### PR DESCRIPTION
Document the `default_version`, `allowed_version` and `version_param` class variables. This tripped me up in #2731, thank you @tomchristie! By the way, @tomchristie warned me about an issue with reverse. It works fine here, so I'm not sure what to say about this in the docs.

Anything I can improve to make my commit clearer?