### PR TITLE
Allow dynamic routes to set `serializer_class`

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -171,7 +171,7 @@ class SimpleRouter(BaseRouter):
                 method_kwargs = getattr(viewset, methodname).kwargs
                 initkwargs = route.initkwargs.copy()
                 initkwargs.update(method_kwargs)
-                url_path = initkwargs.pop("url_path", None) or methodname
+                url_path = initkwargs.pop('url_path', None) or methodname
                 ret.append(Route(
                     url=replace_methodname(route.url, url_path),
                     mapping=dict((httpmethod, methodname) for httpmethod in httpmethods),
@@ -254,6 +254,11 @@ class SimpleRouter(BaseRouter):
                     trailing_slash=self.trailing_slash
                 )
                 view = viewset.as_view(mapping, **route.initkwargs)
+
+                # Allow dynamic routes to set `serializer_class` kwarg
+                if isinstance(route, (DynamicDetailRoute, DynamicListRoute)):
+                    view.serializer_class = route.initkwargs.pop('serializer_class', None)
+
                 name = route.name.format(basename=basename)
                 ret.append(url(regex, view, name=name))
 


### PR DESCRIPTION
Interested if we can do something about #2062? To me it seemed as easy as adding 2 lines, but makes the browsable API so much more usable :)

P.S. I will of course make it a proper PR with tests and docs if needed.