### PR TITLE
AuthTokenSerializer - properly render password field

### DIFF
--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -6,7 +6,7 @@ from rest_framework import exceptions, serializers
 
 class AuthTokenSerializer(serializers.Serializer):
     username = serializers.CharField()
-    password = serializers.CharField()
+    password = serializers.CharField(style={'input_type': 'password'})
 
     def validate(self, attrs):
         username = attrs.get('username')


### PR DESCRIPTION
Tests are passing locally, but I cannot manually verify the correct behaviour in the browsable api because of https://github.com/tomchristie/django-rest-framework/pull/2424