### PR TITLE
Add pip caching to travis and tox configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,39 @@ language: python
 
 sudo: false
 
+cache:
+  directories:
+  - $HOME/.pip-cache
+
 env:
-    - TOX_ENV=py27-flake8
-    - TOX_ENV=py27-docs
-    - TOX_ENV=py34-django17
-    - TOX_ENV=py33-django17
-    - TOX_ENV=py32-django17
-    - TOX_ENV=py27-django17
-    - TOX_ENV=py34-django16
-    - TOX_ENV=py33-django16
-    - TOX_ENV=py32-django16
-    - TOX_ENV=py27-django16
-    - TOX_ENV=py26-django16
-    - TOX_ENV=py34-django15
-    - TOX_ENV=py33-django15
-    - TOX_ENV=py32-django15
-    - TOX_ENV=py27-django15
-    - TOX_ENV=py26-django15
-    - TOX_ENV=py27-django14
-    - TOX_ENV=py26-django14
-    - TOX_ENV=py34-django18beta
-    - TOX_ENV=py33-django18beta
-    - TOX_ENV=py32-django18beta
-    - TOX_ENV=py27-django18beta
+    global:
+        - PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+    matrix:
+        - TOX_ENV=py27-flake8
+        - TOX_ENV=py27-docs
+        - TOX_ENV=py34-django17
+        - TOX_ENV=py33-django17
+        - TOX_ENV=py32-django17
+        - TOX_ENV=py27-django17
+        - TOX_ENV=py34-django16
+        - TOX_ENV=py33-django16
+        - TOX_ENV=py32-django16
+        - TOX_ENV=py27-django16
+        - TOX_ENV=py26-django16
+        - TOX_ENV=py34-django15
+        - TOX_ENV=py33-django15
+        - TOX_ENV=py32-django15
+        - TOX_ENV=py27-django15
+        - TOX_ENV=py26-django15
+        - TOX_ENV=py27-django14
+        - TOX_ENV=py26-django14
+        - TOX_ENV=py34-django18beta
+        - TOX_ENV=py33-django18beta
+        - TOX_ENV=py32-django18beta
+        - TOX_ENV=py27-django18beta
 
 install:
-  - pip install tox
+  - pip install --download-cache $PIP_DOWNLOAD_CACHE tox
 
 script:
     - tox -e $TOX_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
        {py27,py32,py33,py34}-django{17,18beta}
 
 [testenv]
+downloadcache={env:PIP_DOWNLOAD_CACHE}
 commands = ./runtests.py --fast
 setenv =
        PYTHONDONTWRITEBYTECODE=1
@@ -19,12 +20,14 @@ deps =
        -rrequirements/requirements-optionals.txt
 
 [testenv:py27-flake8]
+downloadcache={env:PIP_DOWNLOAD_CACHE}
 deps =
        -rrequirements/requirements-testing.txt
        -rrequirements/requirements-codestyle.txt
 commands = ./runtests.py --lintonly
 
 [testenv:py27-docs]
+downloadcache={env:PIP_DOWNLOAD_CACHE}
 deps =
        -rrequirements/requirements-testing.txt
        -rrequirements/requirements-documentation.txt


### PR DESCRIPTION
https://github.com/tomchristie/django-rest-framework/issues/2677

Needs a comparison test run, as Travis caching is not always an obvious improvement, as it still has to download the cached dirs from S3. It can sometimes cause issues with Travis builds too, which need to be fixed by manually deleting the cache (happens rarely though).