### PR TITLE
Use `serializer_class` for browsable API display, even on plain APIView.

### DIFF
--- a/rest_framework/authtoken/views.py
+++ b/rest_framework/authtoken/views.py
@@ -11,9 +11,10 @@ class ObtainAuthToken(APIView):
     permission_classes = ()
     parser_classes = (parsers.FormParser, parsers.MultiPartParser, parsers.JSONParser,)
     renderer_classes = (renderers.JSONRenderer,)
+    serializer_class = AuthTokenSerializer
 
     def post(self, request):
-        serializer = AuthTokenSerializer(data=request.data)
+        serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data['user']
         token, created = Token.objects.get_or_create(user=user)


### PR DESCRIPTION
This complicates a little bit the logic in BrowsableAPIRenderer.get_rendered_html_form, but it allows to use view.serializer_class when get_serializer is not there.
I tested it locally and it seems to be working.