### PR TITLE
Add pip wheels cache for travis and tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,14 @@ language: python
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.wheelhouse
+
 env:
+  global:
+    - WHEEL_DIR=$HOME/.wheelhouse/
+  matrix:
     - TOX_ENV=py27-flake8
     - TOX_ENV=py27-docs
     - TOX_ENV=py34-django17
@@ -31,3 +38,4 @@ install:
 
 script:
     - tox -e $TOX_ENV
+    - rm -rf $WHEEL_DIR/djangorestframework*.whl

--- a/custom_pip_install.sh
+++ b/custom_pip_install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+pip install wheel==0.24.0
+pip wheel --wheel-dir=${WHEEL_DIR} --find-links=${WHEEL_DIR} "$@"
+pip install --no-index --find-links=${WHEEL_DIR} "$@"

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,9 @@ envlist =
        {py27,py32,py33,py34}-django{17,18beta}
 
 [testenv]
+install_command =
+       {toxinidir}/custom_pip_install.sh {opts} {packages}
+
 commands = ./runtests.py --fast
 setenv =
        PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
https://github.com/tomchristie/django-rest-framework/issues/2677

Following the approach from https://github.com/GoogleCloudPlatform/gcloud-python-wheels

@tomchristie 
This will require a rerun of the Travis build to test the difference in build time, as the first run will only create the cache.