### PR TITLE
Add pip caching to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 env:
     - TOX_ENV=py27-flake8
     - TOX_ENV=py27-docs


### PR DESCRIPTION
Simplest implementation of https://github.com/tomchristie/django-rest-framework/issues/2677, but it's likely that Travis cache will be invalidated every time, which will cause slower builds in the end.

Do not merge yet, needs comparison of Travis builds.