### PR TITLE
Enhancement dont require pk strictly related #2745

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -166,7 +166,6 @@ class HyperlinkedRelatedField(RelatedField):
         self.lookup_field = kwargs.pop('lookup_field', self.lookup_field)
         self.lookup_url_kwarg = kwargs.pop('lookup_url_kwarg', self.lookup_field)
         self.format = kwargs.pop('format', None)
-        self.id_field = kwargs.pop('id_field', 'pk')
 
         # We include this simply for dependency injection in tests.
         # We can't add it as a class attributes or it would expect an
@@ -197,7 +196,7 @@ class HyperlinkedRelatedField(RelatedField):
         attributes are not configured to correctly match the URL conf.
         """
         # Unsaved objects will not yet have a valid URL.
-        if getattr(obj, self.id_field) is None:
+        if hasattr(obj, 'pk') and obj.pk is None:
             return None
 
         lookup_value = getattr(obj, self.lookup_field)
@@ -341,7 +340,6 @@ class ManyRelatedField(Field):
         assert child_relation is not None, '`child_relation` is a required argument.'
         super(ManyRelatedField, self).__init__(*args, **kwargs)
         self.child_relation.bind(field_name='', parent=self)
-        self.id_field = kwargs.pop('id_field', 'pk')
 
     def get_value(self, dictionary):
         # We override the default field access in order to support
@@ -363,7 +361,7 @@ class ManyRelatedField(Field):
 
     def get_attribute(self, instance):
         # Can't have any relationships if not created
-        if getattr(instance, self.id_field) is None:
+        if hasattr(instance, 'pk') and instance.pk is None:
             return []
 
         relationship = get_attribute(instance, self.source_attrs)

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -341,6 +341,7 @@ class ManyRelatedField(Field):
         assert child_relation is not None, '`child_relation` is a required argument.'
         super(ManyRelatedField, self).__init__(*args, **kwargs)
         self.child_relation.bind(field_name='', parent=self)
+        self.id_field = kwargs.pop('id_field', 'pk')
 
     def get_value(self, dictionary):
         # We override the default field access in order to support
@@ -362,7 +363,7 @@ class ManyRelatedField(Field):
 
     def get_attribute(self, instance):
         # Can't have any relationships if not created
-        if not instance.pk:
+        if getattr(instance, self.id_field) is None:
             return []
 
         relationship = get_attribute(instance, self.source_attrs)

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -166,6 +166,7 @@ class HyperlinkedRelatedField(RelatedField):
         self.lookup_field = kwargs.pop('lookup_field', self.lookup_field)
         self.lookup_url_kwarg = kwargs.pop('lookup_url_kwarg', self.lookup_field)
         self.format = kwargs.pop('format', None)
+        self.id_field = kwargs.pop('id_field', 'pk')
 
         # We include this simply for dependency injection in tests.
         # We can't add it as a class attributes or it would expect an
@@ -196,7 +197,7 @@ class HyperlinkedRelatedField(RelatedField):
         attributes are not configured to correctly match the URL conf.
         """
         # Unsaved objects will not yet have a valid URL.
-        if obj.pk is None:
+        if getattr(obj, self.id_field) is None:
             return None
 
         lookup_value = getattr(obj, self.lookup_field)


### PR DESCRIPTION
## Rationale ##
I implemented the enhancement with the `id_field` to provide users using non-django ORM backends the ability to still utilize the check originally provided by `if obj.pk is None`, prior to providing a related reference. I believe this gives more flexibility but also potentially provides unnecessary functionality as alternative backends may not generate an identification value solely upon storage and could potentially have their identifier provided prior to save. If the backend does that this check would only serve to verify that the user properly assigned an identifier but would not provide the intended affect of verifying the object has been created. That being said, there is the potential for this to also be done with the django ORM as the following example illustrates:

```
from django.contrib.auth.models import User
from uuid import uuid1

new_uuid = str(uuid1())
my_user = User(pk=new_uuid, email="this@email.com", username="test_user")
print my_user.pk
query_user = User.objects.get(pk=new_uuid)
```
```
Out: '5412f4cc-d166-11e4-b274-080027a2dd8c'
Out: DoesNotExist: User matching query does not exist
```

This goes against using `User.objects.create(...)` but could be done. In either case providing the `id_field` gives the user the ability to choose, where `hasattr()` limits the check to only working when the `pk` attribute is present.

If this way of handling the enhancement is agreed upon I can add additional docs detailing the optional field and when to utilize it. Otherwise we can close out this PR and I can open one with my `hassattr()` modifications instead.


## Additional references ##
Per our discussion in #2745 I found a couple additional locations of `pk` attribute references. 

### PrimaryKeyRelatedField ###
There's a reference in the `to_representation` method but I opted not to change it as I believe the `SlugField` provides a way of achieving this functionality for a non-django ORM based backend.

### ManyRelatedField ###
There was a reference in the `get_attribute` method that I swapped out with `self.id_field` which also required the definition of `self.id_field` within it's own `__init__` method.

I chose to define it there rather than up in the `Field` class as the `ManyRelatedField` is "Automagically" created in the `RelatedField` and passed its `kwargs`. So instead of giving users the ability to set an `id_field` on every field, which would be unnecessary, this should reduce it to them only needing to set it on the `HyperlinkedRelatedField` and `HyperlinkedIdentityField` if they choose to, while still supporting `many=True`.