### PR TITLE
Backport 7872d0acbffeea5f4420aae5627f8767c6418ba3 to 2.4.x

### DIFF
--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -40,6 +40,12 @@ You can determine your currently installed version using `pip freeze`:
 
 ## 2.4.x series
 
+### 2.4.5
+
+**Date**: 24 March 2015
+
+* **Security fix**: Escape tab switching cookie name in browsable API. [Backported from 3.1.1](http://www.django-rest-framework.org/topics/release-notes/#311).
+
 ### 2.4.4
 
 **Date**: [3rd November 2014](https://github.com/tomchristie/django-rest-framework/issues?q=milestone%3A%222.4.4+Release%22+).

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,8 @@
 pytest-django==2.6
 pytest==2.5.2
 pytest-cov==1.6
-flake8==2.2.2
+pep8==1.5.7
+flake8==2.4.0
 
 # Optional packages
 markdown>=2.1.0

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -8,7 +8,7 @@ ______ _____ _____ _____    __
 """
 
 __title__ = 'Django REST framework'
-__version__ = '2.4.4'
+__version__ = '2.4.5'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 2-Clause'
 __copyright__ = 'Copyright 2011-2014 Tom Christie'

--- a/rest_framework/static/rest_framework/js/default.js
+++ b/rest_framework/static/rest_framework/js/default.js
@@ -44,6 +44,10 @@ var selectedTab = null;
 var selectedTabName = getCookie('tabstyle');
 
 if (selectedTabName) {
+    selectedTabName = selectedTabName.replace(/[^a-z-]/g, '');
+}
+
+if (selectedTabName) {
     selectedTab = $('.form-switcher a[name=' + selectedTabName + ']');
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,8 @@ setenv =
 [testenv:flake8]
 basepython = python2.7
 deps = pytest==2.5.2
-       flake8==2.2.2
+       pep8==1.5.7
+       flake8==2.4.0
 commands = ./runtests.py --lintonly
 
 [testenv:py3.4-django1.7]


### PR DESCRIPTION
Per @tomchristie's [comment](https://github.com/tomchristie/django-rest-framework/commit/7872d0acbffeea5f4420aae5627f8767c6418ba3#commitcomment-10348009) on 7872d0acbffeea5f4420aae5627f8767c6418ba3, I backported the 3.1.1 security fix to the 2.4 series and bumped the version.

I wasn't sure what to do about release notes. Should I add it to this branch? Or should that go in master so it's also on the main site?