### PR TITLE
Raise error when ModelSerializer used with abstract model

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -823,6 +823,10 @@ class ModelSerializer(Serializer):
                 serializer_class=self.__class__.__name__
             )
         )
+        if model_meta.is_abstract_model(self.Meta.model):
+            raise ValueError(
+                'Cannot use ModelSerializer with Abstract Models.'
+            )
 
         declared_fields = copy.deepcopy(self._declared_fields)
         model = getattr(self.Meta, 'model')

--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -167,3 +167,10 @@ def _merge_relationships(forward_relations, reverse_relations):
         list(forward_relations.items()) +
         list(reverse_relations.items())
     )
+
+
+def is_abstract_model(model):
+    """
+    Given a model class, returns a boolean True if it is abstract and False if it is not.
+    """
+    return hasattr(model, 'Meta') and hasattr(model._meta, 'abstract') and model._meta.abstract

--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -173,4 +173,4 @@ def is_abstract_model(model):
     """
     Given a model class, returns a boolean True if it is abstract and False if it is not.
     """
-    return hasattr(model, 'Meta') and hasattr(model._meta, 'abstract') and model._meta.abstract
+    return hasattr(model, '_meta') and hasattr(model._meta, 'abstract') and model._meta.abstract

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -94,6 +94,30 @@ class TestModelSerializer(TestCase):
         msginitial = 'Got a `TypeError` when calling `OneFieldModel.objects.create()`.'
         assert str(excinfo.exception).startswith(msginitial)
 
+    def test_abstract_model(self):
+        """
+        Test that trying to use ModelSerializer with Abstract Models
+        throws a ValueError exception.
+        """
+        class AbstractModel(models.Model):
+            afield = models.CharField(max_length=255)
+
+            class Meta:
+                abstract = True
+
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = AbstractModel
+                fields = ('afield',)
+
+        serializer = TestSerializer(data={
+            'afield': 'foo',
+        })
+        with self.assertRaises(ValueError) as excinfo:
+            serializer.is_valid()
+        msginitial = 'Cannot use ModelSerializer with Abstract Models.'
+        assert str(excinfo.exception).startswith(msginitial)
+
 
 class TestRegularFieldMappings(TestCase):
     def test_regular_fields(self):


### PR DESCRIPTION
Closes https://github.com/tomchristie/django-rest-framework/issues/2630

Raising an exception (ValueError) if an abstract model is used with a ModelSerializer. The check is happening in get_fields method of the ModelSerializer immediately after some other similar checks.

Do you think is better to make the checks earlier? Maybe in the constructor?