### PR TITLE
Unsaved File Objects may not have a `.url` attribute.

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1106,7 +1106,7 @@ class FileField(Field):
         return data
 
     def to_representation(self, value):
-        if self.use_url:
+        if self.use_url and hasattr(value, 'url'):
             if not value:
                 return None
             url = value.url


### PR DESCRIPTION
I'm unsure how this should behave.
basically accessing the `serializer.data` with a `FileField` value of `InMemoryUploadedFile`  raises `FileField 'InMemoryUploadedFile' object has no attribute 'url'`

This example does not provide any special use case, but I guess this should always provide the same behavior  no matter what the setting of ` 'UPLOADED_FILES_USE_URL': False|True`

```python
class FileSerializer(serializers.Serializer):
   file = serializers.FileField()

class MyView(views.APIView):
    def post(request, **kwargs):
        s = FileSerializer(data=request.data)
        if s.is_valid():
            return Response(data=serializer.data)
        return Response(data=serializer.errors)
 ```

AttributeError at /api/files
'InMemoryUploadedFile' object has no attribute 'url'
