### PR TITLE
Use default reason phrases from HTTP standard.

### DIFF
--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -5,7 +5,7 @@ it is initialized with unrendered data, instead of a pre-rendered string.
 The appropriate renderer is called during Django's template response rendering.
 """
 from __future__ import unicode_literals
-from django.core.handlers.wsgi import STATUS_CODE_TEXT
+from django.utils.six.moves.http_client import responses
 from django.template.response import SimpleTemplateResponse
 from django.utils import six
 
@@ -77,7 +77,7 @@ class Response(SimpleTemplateResponse):
         """
         # TODO: Deprecate and use a template tag instead
         # TODO: Status code text for RFC 6585 status codes
-        return STATUS_CODE_TEXT.get(self.status_code, '')
+        return responses.get(self.status_code, '')
 
     def __getstate__(self):
         """


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/24137
Pull Request: https://github.com/django/django/pull/3902

`django.core.handlers.wsgi.STATUS_CODE_TEXT` has been removed in favor of using Python's stdlib instead, `http.client.responses` for Python 3 and `httplib.responses` for Python 2.