### PR TITLE
Support for models with UUID primary keys

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -639,20 +639,37 @@ class URLField(CharField):
 
 
 class UUIDField(Field):
+    valid_formats = ('hex_verbose', 'hex', 'int', 'urn')
+
     default_error_messages = {
         'invalid': _('"{value}" is not a valid UUID.'),
     }
 
+    def __init__(self, **kwargs):
+        self.uuid_format = kwargs.pop('format', None) or 'hex_verbose'
+        if self.uuid_format not in self.valid_formats:
+            raise ValueError(
+                'Invalid format for uuid representation. '
+                'Must be one of "{0}"'.format('", "'.join(self.valid_formats))
+            )
+        super(UUIDField, self).__init__(**kwargs)
+
     def to_internal_value(self, data):
         if not isinstance(data, uuid.UUID):
             try:
-                return uuid.UUID(data)
+                if self.uuid_format == 'int':
+                    return uuid.UUID(int=data)
+                else:
+                    return uuid.UUID(hex=data)
             except (ValueError, TypeError):
                 self.fail('invalid', value=data)
         return data
 
     def to_representation(self, value):
-        return str(value)
+        if self.uuid_format == 'hex_verbose':
+            return str(value)
+        else:
+            return getattr(value, self.uuid_format)
 
 
 # Number types...

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -134,10 +134,16 @@ class PrimaryKeyRelatedField(RelatedField):
         'incorrect_type': _('Incorrect type. Expected pk value, received {data_type}.'),
     }
 
+    def __init__(self, **kwargs):
+        self.pk_field = kwargs.pop('pk_field', None)
+        super(PrimaryKeyRelatedField, self).__init__(**kwargs)
+
     def use_pk_only_optimization(self):
         return True
 
     def to_internal_value(self, data):
+        if self.pk_field is not None:
+            data = self.pk_field.to_internal_value(data)
         try:
             return self.get_queryset().get(pk=data)
         except ObjectDoesNotExist:
@@ -146,6 +152,8 @@ class PrimaryKeyRelatedField(RelatedField):
             self.fail('incorrect_type', data_type=type(data).__name__)
 
     def to_representation(self, value):
+        if self.pk_field is not None:
+            return self.pk_field.to_representation(value.pk)
         return value.pk
 
 

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -203,6 +203,13 @@ def get_relation_kwargs(field_name, relation_info):
         'view_name': get_detail_view_name(related_model)
     }
 
+    related_pk = related_model._meta.pk
+    if (not isinstance(related_pk, models.AutoField) and
+            not getattr(related_pk, 'is_relation', False)):
+        pk_field_class = type(related_pk)
+        pk_field_kwargs = get_field_kwargs('pk', related_pk)
+        kwargs['pk_field'] = (pk_field_class, pk_field_kwargs)
+
     if to_many:
         kwargs['many'] = True
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -526,7 +526,8 @@ class TestUUIDField(FieldValues):
     """
     valid_inputs = {
         '825d7aeb-05a9-45b5-a5b7-05df87923cda': uuid.UUID('825d7aeb-05a9-45b5-a5b7-05df87923cda'),
-        '825d7aeb05a945b5a5b705df87923cda': uuid.UUID('825d7aeb-05a9-45b5-a5b7-05df87923cda')
+        '825d7aeb05a945b5a5b705df87923cda': uuid.UUID('825d7aeb-05a9-45b5-a5b7-05df87923cda'),
+        'urn:uuid:213b7d9b-244f-410d-828c-dabce7a2615d': uuid.UUID('213b7d9b-244f-410d-828c-dabce7a2615d'),
     }
     invalid_inputs = {
         '825d7aeb-05a9-45b5-a5b7': ['"825d7aeb-05a9-45b5-a5b7" is not a valid UUID.']
@@ -535,6 +536,18 @@ class TestUUIDField(FieldValues):
         uuid.UUID('825d7aeb-05a9-45b5-a5b7-05df87923cda'): '825d7aeb-05a9-45b5-a5b7-05df87923cda'
     }
     field = serializers.UUIDField()
+
+    def _test_format(self, uuid_format, formatted_uuid_0):
+        field = serializers.UUIDField(format=uuid_format)
+        assert field.to_representation(uuid.UUID(int=0)) == formatted_uuid_0
+        assert field.to_internal_value(formatted_uuid_0) == uuid.UUID(int=0)
+
+    def test_formats(self):
+        self._test_format('int', 0)
+        self._test_format(None, '00000000-0000-0000-0000-000000000000')
+        self._test_format('hex_verbose', '00000000-0000-0000-0000-000000000000')
+        self._test_format('urn', 'urn:uuid:00000000-0000-0000-0000-000000000000')
+        self._test_format('hex', '0' * 32)
 
 
 # Number types...


### PR DESCRIPTION
Adds a `format` parameter to the UUIDField initializer, for choosing the representation format for UUIDs.

More importantly, adds a `pk_field` argument to `PrimaryKeyRelatedField`, which adds support for django models with UUID primary keys (and possibly models with other types of primary keys where sensible).