### PR TITLE
Modify subtle ChildSerializer(many=True, allow_null=True) behavior.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -50,7 +50,7 @@ from rest_framework.relations import *  # NOQA # isort:skip
 LIST_SERIALIZER_KWARGS = (
     'read_only', 'write_only', 'required', 'default', 'initial', 'source',
     'label', 'help_text', 'style', 'error_messages', 'allow_empty',
-    'instance', 'data', 'partial', 'context'
+    'instance', 'data', 'partial', 'context', 'allow_null'
 )
 
 

--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -121,7 +121,7 @@ class TestNestedSerializerWithMany:
         serializer = self.get_serializer(input_data)
 
         assert not serializer.is_valid()
-        assert set(serializer.errors) == {'nested'}
+        assert set(serializer.errors) == set(['nested'])
         assert serializer.errors['nested'][0] == serializer.error_messages['null']
 
     def test_run_the_field_validation_even_if_the_field_is_null(self):
@@ -132,7 +132,7 @@ class TestNestedSerializerWithMany:
         serializer = self.get_serializer(input_data, condition_to_allow_null=False)
 
         assert not serializer.is_valid()
-        assert set(serializer.errors) == {'payment_info'}
+        assert set(serializer.errors) == set(['payment_info'])
         assert serializer.errors['payment_info'][0] == serializer.ERROR_MESSAGE
 
     def test_expected_results_if_not_null(self):

--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -69,3 +69,88 @@ class TestNotRequiredNestedSerializer:
         input_data = QueryDict('nested[one]=1')
         serializer = self.Serializer(data=input_data)
         assert serializer.is_valid()
+
+
+class TestNestedSerializerWithMany:
+    def setup(self):
+        class PaymentInfoSerializer(serializers.Serializer):
+            url = serializers.URLField()
+            amount = serializers.DecimalField(max_digits=6, decimal_places=2)
+
+        class NestedSerializer(serializers.Serializer):
+            foo = serializers.CharField()
+
+        class AcceptRequestSerializer(serializers.Serializer):
+            ERROR_MESSAGE = '`payment_info` is required under this condition'
+
+            nested = NestedSerializer(many=True)
+            payment_info = PaymentInfoSerializer(many=True, allow_null=True)
+
+            def validate_payment_info(self, value):
+                if value is None and not self.context['condition_to_allow_null']:
+                    raise serializers.ValidationError(self.ERROR_MESSAGE)
+
+                return value
+
+        self.Serializer = AcceptRequestSerializer
+
+    def get_serializer(self, data, condition_to_allow_null=True):
+        return self.Serializer(
+            data=data,
+            context={'condition_to_allow_null': condition_to_allow_null})
+
+    def test_null_allowed_if_allow_null_is_set(self):
+        input_data = {
+            'nested': [{'foo': 'bar'}],
+            'payment_info': None
+        }
+        expected_data = {
+            'nested': [{'foo': 'bar'}],
+            'payment_info': None
+        }
+        serializer = self.get_serializer(input_data)
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data == expected_data
+
+    def test_null_is_not_allowed_if_allow_null_is_not_set(self):
+        input_data = {
+            'nested': None,
+            'payment_info': None
+        }
+        serializer = self.get_serializer(input_data)
+
+        assert not serializer.is_valid()
+        assert set(serializer.errors) == {'nested'}
+        assert serializer.errors['nested'][0] == serializer.error_messages['null']
+
+    def test_run_the_field_validation_even_if_the_field_is_null(self):
+        input_data = {
+            'nested': [{'foo': 'bar'}],
+            'payment_info': None,
+        }
+        serializer = self.get_serializer(input_data, condition_to_allow_null=False)
+
+        assert not serializer.is_valid()
+        assert set(serializer.errors) == {'payment_info'}
+        assert serializer.errors['payment_info'][0] == serializer.ERROR_MESSAGE
+
+    def test_expected_results_if_not_null(self):
+        input_data = {
+            'nested': [{'foo': 'bar'}],
+            'payment_info': [
+                {'url': 'https://domain.org/api/payment-method/1/', 'amount': '22'},
+                {'url': 'https://domain.org/api/payment-method/2/', 'amount': '33'},
+            ]
+        }
+        expected_data = {
+            'nested': [{'foo': 'bar'}],
+            'payment_info': [
+                {'url': 'https://domain.org/api/payment-method/1/', 'amount': 22},
+                {'url': 'https://domain.org/api/payment-method/2/', 'amount': 33},
+            ]
+        }
+        serializer = self.get_serializer(input_data)
+
+        assert serializer.is_valid()
+        assert serializer.validated_data == expected_data


### PR DESCRIPTION
**EDIT from @tomchristie**

Summary of this:

    children = ChildSerializer(many=True, allow_null=True)

Will allow `null` instead of a list, but not `null` items *in* the list.
If you want to treat null items in the list as valid, you'll need to instead do this:

    children = ListSerializer(child=ChildSerializer(allow_null=True))

---

This fixes #2673 

I tried to keep the test case minimal, but at the same to show a relevant use case. I agree that it might be done differently (suing a different API design), but that will work only for new projects. For existing projects that need to be migrated to DRF >= 3, it's a pain not to be able to just pass `allow_null=True` as it was done in DRF 2.x. The good part about this is that the fix is a single line of code changed.

