### PR TITLE
`query_params` in favor of `QUERY_PARAMS`

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -72,7 +72,7 @@ We can override `.get_queryset()` to deal with URLs such as `http://example.com/
             by filtering against a `username` query parameter in the URL.
             """
             queryset = Purchase.objects.all()
-            username = self.request.QUERY_PARAMS.get('username', None)
+            username = self.request.query_params.get('username', None)
             if username is not None:
                 queryset = queryset.filter(purchaser__username=username)
             return queryset

--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -133,9 +133,9 @@ May be overridden to provide more complex behavior with filters, such as using d
 For example:
 
     def get_filter_backends(self):
-        if "geo_route" in self.request.QUERY_PARAMS:
+        if "geo_route" in self.request.query_params:
             return (GeoRouteFilter, CategoryFilter)
-        elif "geo_point" in self.request.QUERY_PARAMS:
+        elif "geo_point" in self.request.query_params:
             return (GeoPointFilter, CategoryFilter)
 
         return (CategoryFilter,)


### PR DESCRIPTION
The usage of `request.QUERY_PARAMS` is now pending deprecation in favor of the lowercased `request.query_params`.