### PR TITLE
Require version param if ALLOWED_VERSIONS is set

### DIFF
--- a/rest_framework/versioning.py
+++ b/rest_framework/versioning.py
@@ -27,7 +27,7 @@ class BaseVersioning(object):
     def is_allowed_version(self, version):
         if not self.allowed_versions:
             return True
-        return (version == self.default_version) or (version in self.allowed_versions)
+        return version in self.allowed_versions
 
 
 class AcceptHeaderVersioning(BaseVersioning):


### PR DESCRIPTION
Documentation: "ALLOWED_VERSIONS. If set, this value will restrict the set of versions that may be returned by the versioning scheme, and will raise an error if the provided version if not in this set."

Previously allowed to omit the version parameter even if ALLOWED_VERSIONS was set.