### PR TITLE
Should use "ordering" in model Meta, not order_by in Serializer Relations example [documentation]

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -46,7 +46,7 @@ In order to explain the various types of relational fields, we'll use a couple o
 
         class Meta:
             unique_together = ('album', 'order')
-            order_by = 'order'
+            ordering = ['order']
 
         def __unicode__(self):
             return '%d: %s' % (self.order, self.title)


### PR DESCRIPTION
This is just a really minor documentation fix - in the example models for Serializer Relations, the Tracks model should be using `ordering`.   `order_by` is an invalid Meta attribute and will result in the following

`TypeError: 'class Meta' got invalid attribute(s): order_by`

This felt a bit silly to PR, but I did actually get briefly tripped up by it in an end of day moment... so yea ;)  
