### PR TITLE
Consistent handling of required=False nested serializers & objects for multipart requests

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1171,7 +1171,7 @@ class ListField(Field):
         # We override the default field access in order to support
         # lists in HTML forms.
         if html.is_html_input(dictionary):
-            return html.parse_html_list(dictionary, prefix=self.field_name)
+            return html.parse_html_list(dictionary, prefix=self.field_name) or empty
         return dictionary.get(self.field_name, empty)
 
     def to_internal_value(self, data):
@@ -1208,7 +1208,7 @@ class DictField(Field):
         # We override the default field access in order to support
         # dictionaries in HTML forms.
         if html.is_html_input(dictionary):
-            return html.parse_html_dict(dictionary, prefix=self.field_name)
+            return html.parse_html_dict(dictionary, prefix=self.field_name) or empty
         return dictionary.get(self.field_name, empty)
 
     def to_internal_value(self, data):

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -351,7 +351,7 @@ class Serializer(BaseSerializer):
         # We override the default field access in order to support
         # nested HTML forms.
         if html.is_html_input(dictionary):
-            return html.parse_html_dict(dictionary, prefix=self.field_name)
+            return html.parse_html_dict(dictionary, prefix=self.field_name) or empty
         return dictionary.get(self.field_name, empty)
 
     def run_validation(self, data=empty):
@@ -502,7 +502,7 @@ class ListSerializer(BaseSerializer):
         # We override the default field access in order to support
         # lists in HTML forms.
         if html.is_html_input(dictionary):
-            return html.parse_html_list(dictionary, prefix=self.field_name)
+            return html.parse_html_list(dictionary, prefix=self.field_name) or empty
         return dictionary.get(self.field_name, empty)
 
     def run_validation(self, data=empty):

--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -38,3 +38,70 @@ class TestNestedSerializer:
         }
         serializer = self.Serializer()
         assert serializer.data == expected_data
+
+
+class TestRequiredFalseNestedSerializer:
+    def setup(self):
+        class NestedSerializer(serializers.Serializer):
+            one = serializers.IntegerField(max_value=10)
+
+        class TestSerializer(serializers.Serializer):
+            nested = NestedSerializer(required=False)
+
+        self.Serializer = TestSerializer
+
+        class FakeMultiDict(dict):
+            """
+            Use this to fake a `format="multipart"` request, because
+            `utils.is_html_input()` returns `True` when the dict object has
+            an attribute of "getlist".
+            """
+            def getlist(self, value, default=None):
+                if value in self:
+                    return [self[value]]
+                else:
+                    return [] if default is None else default
+
+        self.FakeMultiDict = FakeMultiDict
+
+    def test_nested_json_validate(self):
+        input_data = {
+            'nested': {
+                'one': '1',
+            },
+        }
+        expected_data = {
+            'nested': {
+                'one': 1,
+            },
+        }
+        serializer = self.Serializer(data=input_data)
+        assert serializer.is_valid()
+        assert serializer.validated_data == expected_data
+
+    def test_missing_nested_json_validate(self):
+        input_data = {}
+        expected_data = {}
+        serializer = self.Serializer(data=input_data)
+        assert serializer.is_valid()
+        assert serializer.validated_data == expected_data
+
+    def test_nested_multipart_validate(self):
+        input_data = self.FakeMultiDict(**{
+            'nested.one': '1',
+        })
+        expected_data = {
+            'nested': {
+                'one': 1,
+            },
+        }
+        serializer = self.Serializer(data=input_data)
+        assert serializer.is_valid()
+        assert serializer.validated_data == expected_data
+
+    def test_missing_nested_multipart_validate(self):
+        input_data = self.FakeMultiDict()
+        expected_data = {}
+        serializer = self.Serializer(data=input_data)
+        assert serializer.is_valid()
+        assert serializer.validated_data == expected_data


### PR DESCRIPTION
Some serializer fields with `required=False` parse responses differently depending on whether the request format is “json” or “multipart”.

This list looks to be: Serializers, ListSerializers, DictFields, and ListFields (note: serializers can be fields too)

I have identified the discrepancy in the [.get_value(self, dictionary) methods](https://github.com/tomchristie/django-rest-framework/blob/86c5fa240131fe20121db707b0324a32967987ab/rest_framework/serializers.py#L350), which for `Serializer` looks like this:

```python
def get_value(self, dictionary):
    # We override the default field access in order to support
    # nested HTML forms.
    if html.is_html_input(dictionary):
        return html.parse_html_dict(dictionary, prefix=self.field_name)
    return dictionary.get(self.field_name, empty)
```

When the corresponding values aren’t present in the `dictionary` object the method returns a different value depending on the request format as such:

*   format="multipart" - returns an `OrderedDict({})` object
*   format="json" - returns a `rest_framework.fields.empty` object

This discrepancy bubbles back up into the validation and can lead to problems such as a Serializer field trying to validate on an empty dictionary (instead of skipping it entirely).

This pull request makes the “multipart” path of the `.get_value(…)` method for each of these fields return an `empty` instance instead of an empty dictionary or list, which is consistent with the existing functionality of the “json” paths. It also introduces a test that properly fails for a nested Serializer on the old code, but passes now with the changes.