### PR TITLE
Now it is possible to display viewset w/o paginator

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -611,7 +611,7 @@ class BrowsableAPIRenderer(BaseRenderer):
                 renderer_content_type += ' ;%s' % renderer.charset
         response_headers['Content-Type'] = renderer_content_type
 
-        if hasattr(view, 'paginator') and view.paginator.display_page_controls:
+        if getattr(view, 'paginator', None) and view.paginator.display_page_controls:
             paginator = view.paginator
         else:
             paginator = None


### PR DESCRIPTION
Since pagination is now included in every generic viewset, we should have ability to disable it and we have it: paginator=None or pagination_class=None. But this piece of code relies on existence of property instead of its value.