### PR TITLE
Move ul.breadcrumb margin to bootstrap-tweaks.css

### DIFF
--- a/rest_framework/static/rest_framework/css/bootstrap-tweaks.css
+++ b/rest_framework/static/rest_framework/css/bootstrap-tweaks.css
@@ -64,6 +64,10 @@ ul.breadcrumb {
   margin: 70px 0 0 0;
 }
 
+.breadcrumb li.active a {
+  color: #777;
+}
+
 .pagination>.disabled>a,
 .pagination>.disabled>a:hover,
 .pagination>.disabled>a:focus {

--- a/rest_framework/static/rest_framework/css/bootstrap-tweaks.css
+++ b/rest_framework/static/rest_framework/css/bootstrap-tweaks.css
@@ -60,6 +60,10 @@ a single block in the template.
   color: #C20000;
 }
 
+ul.breadcrumb {
+  margin: 70px 0 0 0;
+}
+
 .pagination>.disabled>a,
 .pagination>.disabled>a:hover,
 .pagination>.disabled>a:focus {

--- a/rest_framework/static/rest_framework/css/default.css
+++ b/rest_framework/static/rest_framework/css/default.css
@@ -32,10 +32,6 @@ h2, h3 {
   margin-right: 1em;
 }
 
-ul.breadcrumb {
-  margin: 70px 0 0 0;
-}
-
 .breadcrumb li.active a {
   color: #777;
 }

--- a/rest_framework/static/rest_framework/css/default.css
+++ b/rest_framework/static/rest_framework/css/default.css
@@ -13,6 +13,7 @@ h2, h3 {
 .resource-description, .response-info {
   margin-bottom: 2em;
 }
+
 .version:before {
   content: "v";
   opacity: 0.6;
@@ -30,10 +31,6 @@ h2, h3 {
 .button-form {
   float: right;
   margin-right: 1em;
-}
-
-.breadcrumb li.active a {
-  color: #777;
 }
 
 form select, form input, form textarea {


### PR DESCRIPTION
When importing other bootstrap themes from sites like bootswatch, the
margin in default.css persists and adds a 70px margin below the header.
This change will remove that margin when users choose to use a different
bootstrap theme.