### PR TITLE
Fix browsable API with SessionAuthentication PUT

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -393,6 +393,12 @@ class Request(object):
         ):
             self._method = self._data[self._METHOD_PARAM].upper()
 
+        # Inject the csrfmiddlewaretoken into request META if provided
+        csrf_header_name = getattr(settings, 'CSRF_HEADER_NAME', 'HTTP_X_CSRFTOKEN')
+        csrf_data = self._data.get('csrfmiddlewaretoken')
+        if csrf_data:
+            self.META[csrf_header_name] = csrf_data
+
         # Content overloading - modify the content type, and force re-parse.
         if (
             self._CONTENT_PARAM and


### PR DESCRIPTION
Fixes #2815

Would definitely like feedback on this approach. It's somewhat of a hack due to the Django CSRF internals not being very friendly to other HTTP verbs.

Another possible approach is to fix it in the `SessionAuthentication` backend, but it feels like this is a method overloading issue and as such should be handled here.