### PR TITLE
Added test for issue #2826

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -68,3 +68,9 @@ class NullableOneToOneSource(RESTFrameworkModel):
     name = models.CharField(max_length=100)
     target = models.OneToOneField(OneToOneTarget, null=True, blank=True,
                                   related_name='nullable_source')
+
+
+class NullableOneToOneSource2(RESTFrameworkModel):
+    name = models.CharField(max_length=100)
+    target = models.OneToOneField(NullableOneToOneSource, null=True, blank=True,
+                                  related_name='nullable_source2')


### PR DESCRIPTION
./runtests.py HyperlinkedNullableSecondDegreeOneToOneTests

In `test_relations_hyperlink.py:77-80` I have provided two different values for the source argument. Not sure which one is correct, but either will cause the test to fail.

cheers
Martin