### PR TITLE
docs/renderers: `StaticHTMLRenderer` instead of `TemplateHTMLRenderer`

### DIFF
--- a/docs/api-guide/renderers.md
+++ b/docs/api-guide/renderers.md
@@ -135,7 +135,7 @@ See also: `StaticHTMLRenderer`
 
 A simple renderer that simply returns pre-rendered HTML.  Unlike other renderers, the data passed to the response object should be a string representing the content to be returned.
 
-An example of a view that uses `TemplateHTMLRenderer`:
+An example of a view that uses `StaticHTMLRenderer`:
 
     @api_view(('GET',))
     @renderer_classes((StaticHTMLRenderer,))
@@ -143,7 +143,7 @@ An example of a view that uses `TemplateHTMLRenderer`:
         data = '<html><body><h1>Hello, world</h1></body></html>'
         return Response(data)
 
-You can use `TemplateHTMLRenderer` either to return regular HTML pages using REST framework, or to return both HTML and API responses from a single endpoint.
+You can use `StaticHTMLRenderer` either to return regular HTML pages using REST framework, or to return both HTML and API responses from a single endpoint.
 
 **.media_type**: `text/html`
 


### PR DESCRIPTION
The `StaticHTMLRenderer` section refers to `TemplateHTMLRenderer`
instead of `StaticHTMLRenderer`, which appears to be incorrect.