### PR TITLE
Update 5-relationships-and-hyperlinked-apis.md

### DIFF
--- a/docs/tutorial/5-relationships-and-hyperlinked-apis.md
+++ b/docs/tutorial/5-relationships-and-hyperlinked-apis.md
@@ -18,7 +18,7 @@ Right now we have endpoints for 'snippets' and 'users', but we don't have a sing
             'snippets': reverse('snippet-list', request=request, format=format)
         })
 
-Notice that we're using REST framework's `reverse` function in order to return fully-qualified URLs.
+Two things should be noticed here. First, we're using REST framework's `reverse` function in order to return fully-qualified URLs; second, URL patterns are identified by convenience names that we will declare later on in our `snippets/urls.py`. 
 
 ## Creating an endpoint for the highlighted snippets
 


### PR DESCRIPTION
Following  [@jpadilla](https://github.com/jpadilla)'s suggestion in issue [#2837](https://github.com/tomchristie/django-rest-framework/issues/2837), I am proposing a little addition in "Creating an endpoint for the root of our API" section in order to make it clear that the `user-list` and `snippet-list` names will be declared later in `snippets/urls.py`. Missing this clarification might lead a beginner (like me) to think that the names are somehow assigned by rest_framework under the hood and to try the code too early, getting stuck in the following errors.