### PR TITLE
incrase serializer compatibility to django 1.8

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -986,7 +986,11 @@ class ModelSerializer(Serializer):
                 m2m_data[field_name] = attrs.pop(field_name)
 
         # Forward m2m relations
-        for field in meta.many_to_many + meta.virtual_fields:
+        if issubclass(meta.many_to_many, tuple):
+            temp_m2m = list(meta.many_to_many)
+        else:
+            temp_m2m = meta.many_to_many
+        for field in temp_m2m + meta.virtual_fields:
             if isinstance(field, GenericForeignKey):
                 continue
             if field.name in attrs:


### PR DESCRIPTION
i ran into this issue when using v2.4 with django v1.8. (i didn't previously read it isn't supported)
It's not in the release notes but django.db.model.Options many_to_many() now returns an ImmutableList which is really just a tuple with a bunch of warnings and hooks on it.

if we don't make this typecast change we get the following error

    TypeError: can only concatenate tuple (not "list") to tuple

I'm not sure if this change is appropriate and not sure what, if any, additional tests to include with this .

I attempted to test this but must be doing something wrong. 
Every test fails when trying to use cursor. most of the errors I get are

     Failed: Database access not allowed, use the "django_db" mark to enable

i followed the instructions here.
https://github.com/tomchristie/django-rest-framework/blob/version-2.4.x/CONTRIBUTING.md