### PR TITLE
change SortedDict to OrderedDict + fix list and tuple concatination

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -284,3 +284,11 @@ if django.VERSION >= (1, 8):
     from django.contrib.contenttypes.fields import GenericForeignKey
 else:
     from django.contrib.contenttypes.generic import GenericForeignKey
+
+"""
+django.utils.importlib is deprecated since django 1.8
+"""
+try:
+    import importlib
+except ImportError:
+    from django.utils import importlib

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -266,11 +266,20 @@ except ImportError:
         klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
         return klass
 
+"""
+SortedDict deprecated since django 1.8. There is collections.OrderedDict
+which available since python 2.7 and python 3.1. There are no need of other
+checks because of django 1.7+ requires python 2.7+
+"""
 try:
-    from collections import OrderedDict
+    from collections import OrderedDict as SortedDict
 except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
+    from django.utils.datastructures import SortedDict
 
+"""
+GenericForeignKey moves from generic to fields in django 1.9 and in 1.8 shows
+deprecation warnings
+"""
 if django.VERSION >= (1, 8):
     from django.contrib.contenttypes.fields import GenericForeignKey
 else:

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -265,3 +265,13 @@ except ImportError:
         klass.__unicode__ = klass.__str__
         klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
         return klass
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict as OrderedDict
+
+if django.VERSION >= (1, 8):
+    from django.contrib.contenttypes.fields import GenericForeignKey
+else:
+    from django.contrib.contenttypes.generic import GenericForeignKey

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -30,6 +30,11 @@ from rest_framework.compat import (
 )
 from rest_framework.settings import api_settings
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict as OrderedDict
+
 
 def is_simple_callable(obj):
     """
@@ -224,7 +229,7 @@ class Field(object):
             return [self.to_native(item) for item in value]
         elif isinstance(value, dict):
             # Make sure we preserve field ordering, if it exists
-            ret = collections.OrderedDict()
+            ret = OrderedDict()
             for key, val in value.items():
                 ret[key] = self.to_native(val)
             return ret
@@ -239,7 +244,7 @@ class Field(object):
         return {}
 
     def metadata(self):
-        metadata = collections.OrderedDict()
+        metadata = OrderedDict()
         metadata['type'] = self.type_label
         metadata['required'] = getattr(self, 'required', False)
         optional_attrs = ['read_only', 'label', 'help_text',

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -25,15 +25,10 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
 from rest_framework import ISO_8601
 from rest_framework.compat import (
-    BytesIO, smart_text,
+    BytesIO, smart_text, OrderedDict,
     force_text, is_non_str_iterable
 )
 from rest_framework.settings import api_settings
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 
 
 def is_simple_callable(obj):

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -25,7 +25,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
 from rest_framework import ISO_8601
 from rest_framework.compat import (
-    BytesIO, smart_text, OrderedDict,
+    BytesIO, smart_text, SortedDict,
     force_text, is_non_str_iterable
 )
 from rest_framework.settings import api_settings
@@ -224,7 +224,7 @@ class Field(object):
             return [self.to_native(item) for item in value]
         elif isinstance(value, dict):
             # Make sure we preserve field ordering, if it exists
-            ret = OrderedDict()
+            ret = SortedDict()
             for key, val in value.items():
                 ret[key] = self.to_native(val)
             return ret
@@ -239,7 +239,7 @@ class Field(object):
         return {}
 
     def metadata(self):
-        metadata = OrderedDict()
+        metadata = SortedDict()
         metadata['type'] = self.type_label
         metadata['required'] = getattr(self, 'required', False)
         optional_attrs = ['read_only', 'label', 'help_text',

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -22,7 +22,6 @@ from django.forms import widgets
 from django.utils import six, timezone
 from django.utils.encoding import is_protected_type
 from django.utils.translation import ugettext_lazy as _
-from django.utils.datastructures import SortedDict
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
 from rest_framework import ISO_8601
 from rest_framework.compat import (
@@ -225,7 +224,7 @@ class Field(object):
             return [self.to_native(item) for item in value]
         elif isinstance(value, dict):
             # Make sure we preserve field ordering, if it exists
-            ret = SortedDict()
+            ret = collections.OrderedDict()
             for key, val in value.items():
                 ret[key] = self.to_native(val)
             return ret
@@ -240,7 +239,7 @@ class Field(object):
         return {}
 
     def metadata(self):
-        metadata = SortedDict()
+        metadata = collections.OrderedDict()
         metadata['type'] = self.type_label
         metadata['required'] = getattr(self, 'required', False)
         optional_attrs = ['read_only', 'label', 'help_text',

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -16,7 +16,7 @@ For example, you might have a `urls.py` that looks something like this:
 from __future__ import unicode_literals
 
 import itertools
-from collections import namedtuple, OrderedDict
+from collections import namedtuple
 from django.conf.urls import patterns, url
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
@@ -24,6 +24,11 @@ from rest_framework import views
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.urlpatterns import format_suffix_patterns
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict as OrderedDict
 
 
 Route = namedtuple('Route', ['url', 'mapping', 'name', 'initkwargs'])

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -21,7 +21,7 @@ from django.conf.urls import patterns, url
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
 from rest_framework import views
-from rest_framework.compat import OrderedDict
+from rest_framework.compat import SortedDict
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.urlpatterns import format_suffix_patterns
@@ -278,7 +278,7 @@ class DefaultRouter(SimpleRouter):
         """
         Return a view to use as the API root.
         """
-        api_root_dict = OrderedDict()
+        api_root_dict = SortedDict()
         list_name = self.routes[0].name
         for prefix, viewset, basename in self.registry:
             api_root_dict[prefix] = list_name.format(basename=basename)
@@ -287,7 +287,7 @@ class DefaultRouter(SimpleRouter):
             _ignore_model_permissions = True
 
             def get(self, request, *args, **kwargs):
-                ret = OrderedDict()
+                ret = SortedDict()
                 for key, url_name in api_root_dict.items():
                     try:
                         ret[key] = reverse(

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -16,11 +16,10 @@ For example, you might have a `urls.py` that looks something like this:
 from __future__ import unicode_literals
 
 import itertools
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 from django.conf.urls import patterns, url
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
-from django.utils.datastructures import SortedDict
 from rest_framework import views
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
@@ -278,7 +277,7 @@ class DefaultRouter(SimpleRouter):
         """
         Return a view to use as the API root.
         """
-        api_root_dict = SortedDict()
+        api_root_dict = OrderedDict()
         list_name = self.routes[0].name
         for prefix, viewset, basename in self.registry:
             api_root_dict[prefix] = list_name.format(basename=basename)
@@ -287,7 +286,7 @@ class DefaultRouter(SimpleRouter):
             _ignore_model_permissions = True
 
             def get(self, request, *args, **kwargs):
-                ret = SortedDict()
+                ret = OrderedDict()
                 for key, url_name in api_root_dict.items():
                     try:
                         ret[key] = reverse(

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -21,14 +21,10 @@ from django.conf.urls import patterns, url
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
 from rest_framework import views
+from rest_framework.compat import OrderedDict
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.urlpatterns import format_suffix_patterns
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 
 
 Route = namedtuple('Route', ['url', 'mapping', 'name', 'initkwargs'])

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -23,6 +23,7 @@ from django.forms import widgets
 from django.utils import six
 from django.utils.functional import cached_property
 from django.core.exceptions import ObjectDoesNotExist
+from rest_framework.compat import OrderedDict, GenericForeignKey
 from rest_framework.settings import api_settings
 
 
@@ -35,16 +36,6 @@ from rest_framework.settings import api_settings
 
 from rest_framework.relations import *  # NOQA
 from rest_framework.fields import *  # NOQA
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
-
-if django.VERSION >= (1, 8):
-    from django.contrib.contenttypes.fields import GenericForeignKey
-else:
-    from django.contrib.contenttypes.generic import GenericForeignKey
 
 
 def _resolve_model(obj):

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -997,7 +997,7 @@ class ModelSerializer(Serializer):
             if isinstance(field, GenericForeignKey):
                 continue
             if field.name in attrs:
-                 m2m_data[field.name] = attrs.pop(field.name)
+                m2m_data[field.name] = attrs.pop(field.name)
 
         # Nested forward relations - These need to be marked so we can save
         # them before saving the parent model instance.

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -16,7 +16,7 @@ import datetime
 import inspect
 import types
 from decimal import Decimal
-from django.contrib.contenttypes.fields import GenericForeignKey
+import django
 from django.core.paginator import Page
 from django.db import models
 from django.forms import widgets
@@ -40,6 +40,11 @@ try:
     from collections import OrderedDict
 except ImportError:
     from django.utils.datastructures import SortedDict as OrderedDict
+
+if django.VERSION >= (1, 8):
+    from django.contrib.contenttypes.fields import GenericForeignKey
+else:
+    from django.contrib.contenttypes.generic import GenericForeignKey
 
 
 def _resolve_model(obj):

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -16,7 +16,6 @@ import datetime
 import inspect
 import types
 from decimal import Decimal
-import django
 from django.core.paginator import Page
 from django.db import models
 from django.forms import widgets

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -11,7 +11,6 @@ python primitives.
 response content is handled by parsers and renderers.
 """
 from __future__ import unicode_literals
-from collections import OrderedDict
 import copy
 import datetime
 import inspect
@@ -36,6 +35,11 @@ from rest_framework.settings import api_settings
 
 from rest_framework.relations import *  # NOQA
 from rest_framework.fields import *  # NOQA
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict as OrderedDict
 
 
 def _resolve_model(obj):

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -992,15 +992,12 @@ class ModelSerializer(Serializer):
             if field_name in attrs:
                 m2m_data[field_name] = attrs.pop(field_name)
 
-        def _inner_loop_code(field):
-            if isinstance(field, GenericForeignKey):
-                return
-            if field.name in attrs:
-                m2m_data[field.name] = attrs.pop(field.name)
-
         # Forward m2m relations
-        [_inner_loop_code(field) for field in meta.many_to_many]
-        [_inner_loop_code(field) for field in meta.virtual_fields]
+        for field in meta.many_to_many + meta.virtual_fields:
+            if isinstance(field, GenericForeignKey):
+                continue
+            if field.name in attrs:
+                 m2m_data[field.name] = attrs.pop(field.name)
 
         # Nested forward relations - These need to be marked so we can save
         # them before saving the parent model instance.

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -992,8 +992,8 @@ class ModelSerializer(Serializer):
                 m2m_data[field.name] = attrs.pop(field.name)
 
         # Forward m2m relations
-        _ = [_inner_loop_code(field) for field in meta.many_to_many]
-        _ = [_inner_loop_code(field) for field in meta.virtual_fields]
+        [_inner_loop_code(field) for field in meta.many_to_many]
+        [_inner_loop_code(field) for field in meta.virtual_fields]
 
         # Nested forward relations - These need to be marked so we can save
         # them before saving the parent model instance.

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -16,7 +16,7 @@ import datetime
 import inspect
 import types
 from decimal import Decimal
-from django.contrib.contenttypes.generic import GenericForeignKey
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.core.paginator import Page
 from django.db import models
 from django.forms import widgets
@@ -114,6 +114,9 @@ class OrderedDictWithMetadata(OrderedDict):
     """
     A sorted dict-like object, that can have additional properties attached.
     """
+    def __reduce__(self):
+        return self.__class__, (OrderedDict(self), )
+
     def __getstate__(self):
         """
         Used by pickle (e.g., caching).

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -19,8 +19,13 @@ back to the defaults.
 """
 from __future__ import unicode_literals
 from django.conf import settings
-from django.utils import importlib, six
+from django.utils import six
 from rest_framework import ISO_8601
+
+try:
+    import importlib
+except ImportError:
+    from django.utils import importlib
 
 
 USER_SETTINGS = getattr(settings, 'REST_FRAMEWORK', None)

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -21,11 +21,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.utils import six
 from rest_framework import ISO_8601
-
-try:
-    import importlib
-except ImportError:
-    from django.utils import importlib
+from rest_framework.compat import importlib
 
 
 USER_SETTINGS = getattr(settings, 'REST_FRAMEWORK', None)

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -5,17 +5,12 @@ from __future__ import unicode_literals
 from django.utils import timezone
 from django.db.models.query import QuerySet
 from django.utils.functional import Promise
-from rest_framework.compat import force_text
+from rest_framework.compat import force_text, OrderedDict
 from rest_framework.serializers import DictWithMetadata, OrderedDictWithMetadata
 import datetime
 import decimal
 import types
 import json
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 
 
 class JSONEncoder(json.JSONEncoder):

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -5,8 +5,8 @@ from __future__ import unicode_literals
 from django.utils import timezone
 from django.db.models.query import QuerySet
 from django.utils.functional import Promise
-from rest_framework.compat import force_text, OrderedDict
-from rest_framework.serializers import DictWithMetadata, OrderedDictWithMetadata
+from rest_framework.compat import force_text, SortedDict
+from rest_framework.serializers import DictWithMetadata, SortedDictWithMetadata
 import datetime
 import decimal
 import types
@@ -66,7 +66,7 @@ else:
     class SafeDumper(yaml.SafeDumper):
         """
         Handles decimals as strings.
-        Handles OrderedDicts as usual dicts, but preserves field order, rather
+        Handles SortedDicts as usual dicts, but preserves field order, rather
         than the usual behaviour of sorting the keys.
         """
         def represent_decimal(self, data):
@@ -80,7 +80,7 @@ else:
             best_style = True
             if hasattr(mapping, 'items'):
                 mapping = list(mapping.items())
-                if not isinstance(mapping, OrderedDict):
+                if not isinstance(mapping, SortedDict):
                     mapping.sort()
             for item_key, item_value in mapping:
                 node_key = self.represent_data(item_key)
@@ -102,7 +102,7 @@ else:
         SafeDumper.represent_decimal
     )
     SafeDumper.add_representer(
-        OrderedDict,
+        SortedDict,
         yaml.representer.SafeRepresenter.represent_dict
     )
     SafeDumper.add_representer(
@@ -110,7 +110,7 @@ else:
         yaml.representer.SafeRepresenter.represent_dict
     )
     SafeDumper.add_representer(
-        OrderedDictWithMetadata,
+        SortedDictWithMetadata,
         yaml.representer.SafeRepresenter.represent_dict
     )
     SafeDumper.add_representer(

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -2,7 +2,6 @@
 Helper classes for parsers.
 """
 from __future__ import unicode_literals
-from collections import OrderedDict
 from django.utils import timezone
 from django.db.models.query import QuerySet
 from django.utils.functional import Promise
@@ -12,6 +11,11 @@ import datetime
 import decimal
 import types
 import json
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict as OrderedDict
 
 
 class JSONEncoder(json.JSONEncoder):

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -2,12 +2,12 @@
 Helper classes for parsers.
 """
 from __future__ import unicode_literals
+from collections import OrderedDict
 from django.utils import timezone
 from django.db.models.query import QuerySet
-from django.utils.datastructures import SortedDict
 from django.utils.functional import Promise
 from rest_framework.compat import force_text
-from rest_framework.serializers import DictWithMetadata, SortedDictWithMetadata
+from rest_framework.serializers import DictWithMetadata, OrderedDictWithMetadata
 import datetime
 import decimal
 import types
@@ -67,7 +67,7 @@ else:
     class SafeDumper(yaml.SafeDumper):
         """
         Handles decimals as strings.
-        Handles SortedDicts as usual dicts, but preserves field order, rather
+        Handles OrderedDicts as usual dicts, but preserves field order, rather
         than the usual behaviour of sorting the keys.
         """
         def represent_decimal(self, data):
@@ -81,7 +81,7 @@ else:
             best_style = True
             if hasattr(mapping, 'items'):
                 mapping = list(mapping.items())
-                if not isinstance(mapping, SortedDict):
+                if not isinstance(mapping, OrderedDict):
                     mapping.sort()
             for item_key, item_value in mapping:
                 node_key = self.represent_data(item_key)
@@ -103,7 +103,7 @@ else:
         SafeDumper.represent_decimal
     )
     SafeDumper.add_representer(
-        SortedDict,
+        OrderedDict,
         yaml.representer.SafeRepresenter.represent_dict
     )
     SafeDumper.add_representer(
@@ -111,7 +111,7 @@ else:
         yaml.representer.SafeRepresenter.represent_dict
     )
     SafeDumper.add_representer(
-        SortedDictWithMetadata,
+        OrderedDictWithMetadata,
         yaml.representer.SafeRepresenter.represent_dict
     )
     SafeDumper.add_representer(

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -7,7 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import status, exceptions
-from rest_framework.compat import smart_text, HttpResponseBase, OrderedDict, View
+from rest_framework.compat import smart_text, HttpResponseBase, SortedDict, View
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
@@ -420,7 +420,7 @@ class APIView(View):
         # By default we can't provide any form-like information, however the
         # generic views override this implementation and add additional
         # information for POST and PUT methods, based on the serializer.
-        ret = OrderedDict()
+        ret = SortedDict()
         ret['name'] = self.get_view_name()
         ret['description'] = self.get_view_description()
         ret['renders'] = [renderer.media_type for renderer in self.renderer_classes]

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -3,9 +3,9 @@ Provides an APIView class that is the base of all views in REST framework.
 """
 from __future__ import unicode_literals
 
+from collections import OrderedDict
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
-from django.utils.datastructures import SortedDict
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import status, exceptions
 from rest_framework.compat import smart_text, HttpResponseBase, View
@@ -421,7 +421,7 @@ class APIView(View):
         # By default we can't provide any form-like information, however the
         # generic views override this implementation and add additional
         # information for POST and PUT methods, based on the serializer.
-        ret = SortedDict()
+        ret = OrderedDict()
         ret['name'] = self.get_view_name()
         ret['description'] = self.get_view_description()
         ret['renders'] = [renderer.media_type for renderer in self.renderer_classes]

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -3,7 +3,6 @@ Provides an APIView class that is the base of all views in REST framework.
 """
 from __future__ import unicode_literals
 
-from collections import OrderedDict
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.views.decorators.csrf import csrf_exempt
@@ -13,6 +12,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.utils import formatting
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict as OrderedDict
 
 
 def get_view_name(view_cls, suffix=None):

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -7,16 +7,11 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import status, exceptions
-from rest_framework.compat import smart_text, HttpResponseBase, View
+from rest_framework.compat import smart_text, HttpResponseBase, OrderedDict, View
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.utils import formatting
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 
 
 def get_view_name(view_cls, suffix=None):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,7 +3,6 @@ General serializer field tests.
 """
 from __future__ import unicode_literals
 
-from collections import OrderedDict
 import datetime
 import re
 from decimal import Decimal
@@ -13,6 +12,11 @@ from django.db import models
 from django.test import TestCase
 from rest_framework import serializers
 from tests.models import RESTFrameworkModel
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict as OrderedDict
 
 
 class TimestampedModel(models.Model):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,6 +3,7 @@ General serializer field tests.
 """
 from __future__ import unicode_literals
 
+from collections import OrderedDict
 import datetime
 import re
 from decimal import Decimal
@@ -10,7 +11,6 @@ from uuid import uuid4
 from django.core import validators
 from django.db import models
 from django.test import TestCase
-from django.utils.datastructures import SortedDict
 from rest_framework import serializers
 from tests.models import RESTFrameworkModel
 
@@ -95,7 +95,7 @@ class BasicFieldTests(TestCase):
         Field should preserve dictionary ordering, if it exists.
         See: https://github.com/tomchristie/django-rest-framework/issues/832
         """
-        ret = SortedDict()
+        ret = OrderedDict()
         ret['c'] = 1
         ret['b'] = 1
         ret['a'] = 1

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -11,12 +11,8 @@ from django.core import validators
 from django.db import models
 from django.test import TestCase
 from rest_framework import serializers
+from rest_framework.compat import SortedDict
 from tests.models import RESTFrameworkModel
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 
 
 class TimestampedModel(models.Model):
@@ -99,7 +95,7 @@ class BasicFieldTests(TestCase):
         Field should preserve dictionary ordering, if it exists.
         See: https://github.com/tomchristie/django-rest-framework/issues/832
         """
-        ret = OrderedDict()
+        ret = SortedDict()
         ret['c'] = 1
         ret['b'] = 1
         ret['a'] = 1

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1297,7 +1297,7 @@ class SerializerPickleTests(TestCase):
 
     def test_pickle_inner_serializer(self):
         """
-        Test pickling a serializer whose resulting .data (a OrderedDictWithMetadata) will
+        Test pickling a serializer whose resulting .data (a SortedDictWithMetadata) will
         have unpickleable meta data--in order to make sure metadata doesn't get pulled into the pickle.
         See DictWithMetadata.__getstate__
         """
@@ -1318,7 +1318,7 @@ class SerializerPickleTests(TestCase):
         """
         Another regression test for #645.
         """
-        data = serializers.OrderedDictWithMetadata({1: 1})
+        data = serializers.SortedDictWithMetadata({1: 1})
         repr(pickle.loads(pickle.dumps(data, 0)))
 
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1297,7 +1297,7 @@ class SerializerPickleTests(TestCase):
 
     def test_pickle_inner_serializer(self):
         """
-        Test pickling a serializer whose resulting .data (a SortedDictWithMetadata) will
+        Test pickling a serializer whose resulting .data (a OrderedDictWithMetadata) will
         have unpickleable meta data--in order to make sure metadata doesn't get pulled into the pickle.
         See DictWithMetadata.__getstate__
         """
@@ -1312,13 +1312,13 @@ class SerializerPickleTests(TestCase):
         Regression test for #645.
         """
         data = serializers.DictWithMetadata({1: 1})
-        self.assertEqual(data.__getstate__(), serializers.SortedDict({1: 1}))
+        self.assertEqual(data.__getstate__(), serializers.OrderedDict({1: 1}))
 
     def test_serializer_data_is_pickleable(self):
         """
         Another regression test for #645.
         """
-        data = serializers.SortedDictWithMetadata({1: 1})
+        data = serializers.OrderedDictWithMetadata({1: 1})
         repr(pickle.loads(pickle.dumps(data, 0)))
 
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1312,7 +1312,7 @@ class SerializerPickleTests(TestCase):
         Regression test for #645.
         """
         data = serializers.DictWithMetadata({1: 1})
-        self.assertEqual(data.__getstate__(), serializers.OrderedDict({1: 1}))
+        self.assertEqual(data.__getstate__(), serializers.SortedDict({1: 1}))
 
     def test_serializer_data_is_pickleable(self):
         """


### PR DESCRIPTION
I need to support django-rest-framework on django 1.8 a little bit more, but there are some errors and irritating warnings. This PR fixes error and changes deprecated SortedDict to OrderedDict (as I seen you are not using something special from SortedDict which not compatible with OrderedDict)