### PR TITLE
Check AcceptHeaderVersioning with content negotiation in place

### DIFF
--- a/rest_framework/negotiation.py
+++ b/rest_framework/negotiation.py
@@ -4,7 +4,7 @@ incoming request.  Typically this will be based on the request's Accept header.
 """
 from __future__ import unicode_literals
 from django.http import Http404
-from rest_framework import exceptions
+from rest_framework import HTTP_HEADER_ENCODING, exceptions
 from rest_framework.settings import api_settings
 from rest_framework.utils.mediatypes import order_by_precedence, media_type_matches
 from rest_framework.utils.mediatypes import _MediaType
@@ -54,13 +54,19 @@ class DefaultContentNegotiation(BaseContentNegotiation):
                 for media_type in media_type_set:
                     if media_type_matches(renderer.media_type, media_type):
                         # Return the most specific media type as accepted.
+                        media_type_wrapper = _MediaType(media_type)
                         if (
                             _MediaType(renderer.media_type).precedence >
-                            _MediaType(media_type).precedence
+                            media_type_wrapper.precedence
                         ):
                             # Eg client requests '*/*'
                             # Accepted media type is 'application/json'
-                            return renderer, renderer.media_type
+                            full_media_type = ';'.join(
+                                (renderer.media_type,) +
+                                tuple('{0}={1}'.format(
+                                    key, value.decode(HTTP_HEADER_ENCODING))
+                                    for key, value in media_type_wrapper.params.items()))
+                            return renderer, full_media_type
                         else:
                             # Eg client requests 'application/json; indent=8'
                             # Accepted media type is 'application/json; indent=8'

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -82,6 +82,10 @@ class TestRequestVersion:
         response = view(request)
         assert response.data == {'version': '1.2.3'}
 
+        request = factory.get('/endpoint/', HTTP_ACCEPT='*/*; version=1.2.3')
+        response = view(request)
+        assert response.data == {'version': '1.2.3'}
+
         request = factory.get('/endpoint/', HTTP_ACCEPT='application/json')
         response = view(request)
         assert response.data == {'version': None}


### PR DESCRIPTION
When request contains `Accept` header with value `*/*; version=1` then the `request.accepted_media_type` attribute looses additional parameters send to `Accept` header.
Thus defeating versioning support.
