### PR TITLE
Document correct method usage for get_paginated_response

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -193,7 +193,7 @@ You won't typically need to override the following methods, although you might n
 
 * `get_serializer_context(self)` - Returns a dictionary containing any extra context that should be supplied to the serializer.  Defaults to including `'request'`, `'view'` and `'format'` keys.
 * `get_serializer(self, instance=None, data=None, files=None, many=False, partial=False, allow_add_remove=False)` - Returns a serializer instance.
-* `get_paginated_response(self, page)` - Returns a serializer instance to use with paginated data.
+* `get_paginated_response(self, data)` - Returns a paginated style `Response` object.
 * `paginate_queryset(self, queryset)` - Paginate a queryset if required, either returning a page object, or `None` if pagination is not configured for this view.
 * `filter_queryset(self, queryset)` - Given a queryset, filter it with whichever filter backends are in use, returning a new queryset.
 

--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -193,7 +193,7 @@ You won't typically need to override the following methods, although you might n
 
 * `get_serializer_context(self)` - Returns a dictionary containing any extra context that should be supplied to the serializer.  Defaults to including `'request'`, `'view'` and `'format'` keys.
 * `get_serializer(self, instance=None, data=None, files=None, many=False, partial=False, allow_add_remove=False)` - Returns a serializer instance.
-* `get_pagination_serializer(self, page)` - Returns a serializer instance to use with paginated data.
+* `get_paginated_response(self, page)` - Returns a serializer instance to use with paginated data.
 * `paginate_queryset(self, queryset)` - Paginate a queryset if required, either returning a page object, or `None` if pagination is not configured for this view.
 * `filter_queryset(self, queryset)` - Given a queryset, filter it with whichever filter backends are in use, returning a new queryset.
 

--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -137,7 +137,7 @@ For example:
         def recent_users(self, request):
             recent_users = User.objects.all().order('-last_login')
             page = self.paginate_queryset(recent_users)
-            serializer = self.get_pagination_serializer(page)
+            serializer = self.get_paginated_response(page)
             return Response(serializer.data)
 
 The decorators can additionally take extra arguments that will be set for the routed view only.  For example...

--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -136,8 +136,13 @@ For example:
         @list_route()
         def recent_users(self, request):
             recent_users = User.objects.all().order('-last_login')
+
             page = self.paginate_queryset(recent_users)
-            serializer = self.get_paginated_response(page)
+            if page is not None:
+                serializer = self.get_serializer(page, many=True)
+                return self.get_paginated_response(serializer.data)
+
+            serializer = self.get_serializer(recent_users, many=True)
             return Response(serializer.data)
 
 The decorators can additionally take extra arguments that will be set for the routed view only.  For example...


### PR DESCRIPTION
This fixes the reference to get_paginated_response for 3.x docs

From issue #2797