### PR TITLE
Delete imported but not used method

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -168,7 +168,6 @@ The `curl` command line tool may be useful for testing token authenticated APIs.
 If you want every user to have an automatically generated Token, you can simply catch the User's `post_save` signal.
 
     from django.conf import settings
-    from django.contrib.auth import get_user_model
     from django.db.models.signals import post_save
     from django.dispatch import receiver
     from rest_framework.authtoken.models import Token


### PR DESCRIPTION
 In 'Generating Tokens' section, the example code imported get_user_model but not used.