### PR TITLE
Fix for iterating over NoneType in ManyRelatedField's choices()

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -375,7 +375,7 @@ class ManyRelatedField(Field):
 
     @property
     def choices(self):
-        queryset = self.child_relation.queryset
+        queryset = self.child_relation.queryset or []
         iterable = queryset.all() if (hasattr(queryset, 'all')) else queryset
         items_and_representations = [
             (item, self.child_relation.to_representation(item))


### PR DESCRIPTION
If queryset is not set in the child relation of a ManyRelatedField, choices() will fail trying to iterate over NoneType. This commit fixes this.