### PR TITLE
Support nested serializers in SimpleMetadata's representation of metadata

### DIFF
--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -34,7 +34,7 @@ class SimpleMetadata(BaseMetadata):
     for us to base this on.
     """
     label_lookup = ClassLookupDict({
-        serializers.Serializer: 'serializer',
+        serializers.BaseSerializer: 'serializer',
         serializers.Field: 'field',
         serializers.BooleanField: 'boolean',
         serializers.NullBooleanField: 'boolean',
@@ -137,7 +137,7 @@ class SimpleMetadata(BaseMetadata):
                 for choice_value, choice_name in field.choices.items()
             ]
 
-        if isinstance(field, serializers.Serializer):
+        if isinstance(field, serializers.BaseSerializer):
             field_info['fields'] = self.get_serializer_info(field)
 
         return field_info

--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -34,6 +34,7 @@ class SimpleMetadata(BaseMetadata):
     for us to base this on.
     """
     label_lookup = ClassLookupDict({
+        serializers.Serializer: 'serializer',
         serializers.Field: 'field',
         serializers.BooleanField: 'boolean',
         serializers.NullBooleanField: 'boolean',
@@ -135,5 +136,8 @@ class SimpleMetadata(BaseMetadata):
                 }
                 for choice_value, choice_name in field.choices.items()
             ]
+
+        if isinstance(field, serializers.Serializer):
+            field_info['fields'] = self.get_serializer_info(field)
 
         return field_info


### PR DESCRIPTION
With this commit, nested serializer fields in the representation done by SimpleMetadata class are getting a type of 'serializer' and a 'fields' attribute containing metadata for their inner fields.