### PR TITLE
MultiPart encoding from test client should error on nested data.

### DIFF
--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -1,3 +1,4 @@
+from django.http import QueryDict
 from rest_framework import serializers
 
 
@@ -26,6 +27,26 @@ class TestNestedSerializer:
             }
         }
         serializer = self.Serializer(data=input_data)
+        assert serializer.is_valid()
+        assert serializer.validated_data == expected_data
+
+    def test_nested_query_dict_validate(self):
+        input_data = {
+            'nested': {
+                'one': '1',
+                'two': '2',
+            }
+        }
+        input_data_q_dict = QueryDict('', mutable=True)
+        input_data_q_dict.update(input_data)
+
+        expected_data = {
+            'nested': {
+                'one': 1,
+                'two': 2,
+            }
+        }
+        serializer = self.Serializer(data=input_data_q_dict)
         assert serializer.is_valid()
         assert serializer.validated_data == expected_data
 


### PR DESCRIPTION
When I run the tests the failure complains about unbalanced braces, however here's a demonstration of the problem (using 3.1.1 from pypi)

    In [18]: class NestedSerializer(serializers.Serializer):
       ....:     one = serializers.IntegerField(max_value=10)
       ....:     two = serializers.IntegerField(max_value=10)
       ....:     

    In [19]: class TestSerializer(serializers.Serializer):
       ....:     nested = NestedSerializer()
       ....:     

    In [20]: input_data = {'nested': {'one': 1, 'two': 2}}

    In [21]: input_data_q_dict = QueryDict('', mutable=True)

    In [22]: input_data_q_dict.update(input_data)

    In [23]: s = TestSerializer(data=input_data_q_dict)

    In [24]: s.is_valid()
    Out[24]: False

    In [25]: s.errors
    Out[25]: {'nested': {'two': [u'This field is required.'], 'one': [u'This field is required.']}}

The same test with a normal dict passes.

I'm pretty sure this is a stripped back demonstration of the problem discussed in #1936. As suggested by @jamescooke in (https://github.com/tomchristie/django-rest-framework/issues/1936#issuecomment-63177765), it seems like the `QueryDict` should be handled here https://github.com/tomchristie/django-rest-framework/blob/35efbe41abcff15ea2f60096aaa95bd41f2532a3/rest_framework/serializers.py#L350-356
