### PR TITLE
set user's backend when use TokenAuthentication

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -175,6 +175,8 @@ class TokenAuthentication(BaseAuthentication):
         if not token.user.is_active:
             raise exceptions.AuthenticationFailed(_('User inactive or deleted.'))
 
+        token.user.backend = "{0}.{1}".format(self.__class__.__module__, self.__class__.__name__)
+
         return (token.user, token)
 
     def authenticate_header(self, request):


### PR DESCRIPTION
This feature is used to improve call "django.contrib.auth.login".

"django.contrib.auth.login" depends user's backend.

```
request.session[BACKEND_SESSION_KEY] = user.backend
```

if user don't set `TokenAuthentication`  in `settings.AUTHENTICATION_BACKENDS`,this will cause an error. and it's not necessary to add it in settings.



