### PR TITLE
Added ability to use the Jinja2 template engine and to use multiple namespaces to versions

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -200,6 +200,42 @@ class TemplateHTMLRenderer(BaseRenderer):
                                        response.status_text.title()))
 
 
+class JinjaTemplateRenderer(TemplateHTMLRenderer):
+    """
+    Renders data to HTML for use with the Jinja2 template engine.
+
+    The template name is determined by (in order of preference):
+
+    1. An explicit .template_name set on the response.
+    2. An explicit .template_name set on this class.
+    3. The return result of calling view.get_template_names().
+    """
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+
+        renderer_context = renderer_context or {}
+        view = renderer_context['view']
+        request = renderer_context['request']
+        response = renderer_context['response']
+
+        # add the current user to the context
+        # otherwise it won't be available in templates
+        renderer_context['user'] = request.user
+
+        # get template (jinja2)
+        if response.exception:
+            template = self.get_exception_template(response)
+        else:
+            template_names = self.get_template_names(response, view)
+            template = self.resolve_template(template_names)
+
+        # return the dict containing the context
+        # for jinja2 to process.
+        # Would throw a value error if a
+        # RequestContext was returned
+        return template.render(renderer_context)
+
+
 # Note, subclass TemplateHTMLRenderer simply for the exception behavior
 class StaticHTMLRenderer(TemplateHTMLRenderer):
     """

--- a/rest_framework/versioning.py
+++ b/rest_framework/versioning.py
@@ -131,7 +131,7 @@ class NamespaceVersioning(BaseVersioning):
         return request.version + ':' + viewname
 
 
-class MultipleNamespaceVersioning(versioning.NamespaceVersioning):
+class MultipleNamespaceVersioning(NamespaceVersioning):
 
     """
     This is the same as NamespaceVersioning, the difference is that

--- a/rest_framework/versioning.py
+++ b/rest_framework/versioning.py
@@ -184,8 +184,10 @@ class MultipleNamespaceVersioning(NamespaceVersioning):
         for namespace in resolver_match.namespaces:
             if namespace in self.allowed_versions:
                 version = namespace
+
         if version is None:
             version = self.default_version
+            
         return version
 
     def reverse(self, viewname, args=None, kwargs=None, request=None, format=None, **extra):
@@ -200,7 +202,6 @@ class MultipleNamespaceVersioning(NamespaceVersioning):
             return ':'.join(request.resolver_match.namespaces)
 
         return request.version + ':' + viewname
-
 
 
 class HostNameVersioning(BaseVersioning):

--- a/rest_framework/versioning.py
+++ b/rest_framework/versioning.py
@@ -187,7 +187,7 @@ class MultipleNamespaceVersioning(NamespaceVersioning):
 
         if version is None:
             version = self.default_version
-            
+
         return version
 
     def reverse(self, viewname, args=None, kwargs=None, request=None, format=None, **extra):

--- a/rest_framework/versioning.py
+++ b/rest_framework/versioning.py
@@ -132,7 +132,6 @@ class NamespaceVersioning(BaseVersioning):
 
 
 class MultipleNamespaceVersioning(NamespaceVersioning):
-
     """
     This is the same as NamespaceVersioning, the difference is that
     multiple namespaces can be used for bigger projects.
@@ -168,13 +167,11 @@ class MultipleNamespaceVersioning(NamespaceVersioning):
     {% url 'json:items:detail' pk=2 }
     --> /json/items/2/
 
-
     allowed versions must be set as it will be used to compare its
     contents with the given namespaces of the url
     """
 
     def determine_version(self, request, *args, **kwargs):
-
         resolver_match = getattr(request, 'resolver_match', None)
         version = None
 
@@ -187,10 +184,8 @@ class MultipleNamespaceVersioning(NamespaceVersioning):
         for namespace in resolver_match.namespaces:
             if namespace in self.allowed_versions:
                 version = namespace
-
         if version is None:
             version = self.default_version
-
         return version
 
     def reverse(self, viewname, args=None, kwargs=None, request=None, format=None, **extra):


### PR DESCRIPTION
Fixed the ValueError that would be thrown when using the [Jinja2 template engine](http://stackoverflow.com/questions/30200022/django-rest-jinja2-valueerror-dictionary-update-sequence-element-0-has-leng).

Added the ability to use more than one namespace when using versions