### PR TITLE
provide get_success_headers on UpdateModelMixin

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -76,7 +76,7 @@ class UpdateModelMixin(object):
     def partial_update(self, request, *args, **kwargs):
         kwargs['partial'] = True
         return self.update(request, *args, **kwargs)
-        
+
     def get_success_headers(self, data):
         try:
             return {'Content-Location': data[api_settings.URL_FIELD_NAME]}

--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -67,7 +67,8 @@ class UpdateModelMixin(object):
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
-        return Response(serializer.data)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, headers=headers)
 
     def perform_update(self, serializer):
         serializer.save()
@@ -75,6 +76,12 @@ class UpdateModelMixin(object):
     def partial_update(self, request, *args, **kwargs):
         kwargs['partial'] = True
         return self.update(request, *args, **kwargs)
+        
+    def get_success_headers(self, data):
+        try:
+            return {'Content-Location': data[api_settings.URL_FIELD_NAME]}
+        except (TypeError, KeyError):
+            return {}
 
 
 class DestroyModelMixin(object):


### PR DESCRIPTION
This change provides a `get_success_headers` method on the UpdateModelMixin which can be used like the corresponding method on the CreateModelMixin. I thought this might be usefull because I was trying to add a header based on the result of the update operation, and this seems like a valid way. The only default I could think of is `Content-Location` which according to RFC 5789 is a valid and useful piece of information for the PATCH response.