### PR TITLE
Support basic authentication with custom user models that change username field

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -4,12 +4,11 @@ Provides various authentication policies.
 from __future__ import unicode_literals
 import base64
 from django.contrib.auth import authenticate
-from django.contrib.auth import get_user_model
 from django.middleware.csrf import CsrfViewMiddleware
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import exceptions, HTTP_HEADER_ENCODING
 from rest_framework.authtoken.models import Token
-
+from rest_framework.compat import get_user_model
 
 def get_authorization_header(request):
     """

--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -85,8 +85,13 @@ class BasicAuthentication(BaseAuthentication):
         """
         Authenticate the userid and password against username and password.
         """
+        user_model = get_user_model()
+        if hasattr(user_model, 'USERNAME_FIELD'):
+            username_field = user_model.USERNAME_FIELD
+        else:
+            username_field = 'username'
         credentials = {
-            get_user_model().USERNAME_FIELD: userid,
+            username_field: userid,
             'password': password
         }
         user = authenticate(**credentials)

--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -86,11 +86,7 @@ class BasicAuthentication(BaseAuthentication):
         """
         Authenticate the userid and password against username and password.
         """
-        user_model = get_user_model()
-        if hasattr(user_model, 'USERNAME_FIELD'):
-            username_field = user_model.USERNAME_FIELD
-        else:
-            username_field = 'username'
+        username_field = getattr(get_user_model(), 'USERNAME_FIELD', 'username')
         credentials = {
             username_field: userid,
             'password': password

--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -4,6 +4,7 @@ Provides various authentication policies.
 from __future__ import unicode_literals
 import base64
 from django.contrib.auth import authenticate
+from django.contrib.auth import get_user_model
 from django.middleware.csrf import CsrfViewMiddleware
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import exceptions, HTTP_HEADER_ENCODING
@@ -85,7 +86,11 @@ class BasicAuthentication(BaseAuthentication):
         """
         Authenticate the userid and password against username and password.
         """
-        user = authenticate(username=userid, password=password)
+        credentials = {
+            get_user_model().USERNAME_FIELD: userid,
+            'password': password
+        }
+        user = authenticate(**credentials)
 
         if user is None:
             raise exceptions.AuthenticationFailed(_('Invalid username/password.'))

--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -10,6 +10,7 @@ from rest_framework import exceptions, HTTP_HEADER_ENCODING
 from rest_framework.authtoken.models import Token
 from rest_framework.compat import get_user_model
 
+
 def get_authorization_header(request):
     """
     Return request's 'Authorization:' header, as a bytestring.

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -119,6 +119,14 @@ def get_model_name(model_cls):
         return model_cls._meta.module_name
 
 
+# Support custom user models in Django 1.5+
+try:
+    from django.contrib.auth import get_user_model
+except ImportError:
+    from django.contrib.auth.models import User
+    get_user_model = lambda: User
+
+
 # View._allowed_methods only present from 1.5 onwards
 if django.VERSION >= (1, 5):
     from django.views.generic import View


### PR DESCRIPTION
Support basic authentication with custom user models with a username field that is not named 'username'.