### PR TITLE
Update mkdocs version to 0.12.2

### DIFF
--- a/requirements/requirements-documentation.txt
+++ b/requirements/requirements-documentation.txt
@@ -1,2 +1,2 @@
 # MkDocs to build our documentation.
-mkdocs==0.11.1
+mkdocs==0.12.2


### PR DESCRIPTION
The old version of mkdocs required 'Markdown>=2.3.1,<2.5' and
requirements-optionals.txt lists markdown==2.5.2 causing mkdocs
to fail.