### PR TITLE
Fixed ModelClass.object.create - Comes with error 'model has no attribute objects'

### DIFF
--- a/requirements/requirements-packaging.txt
+++ b/requirements/requirements-packaging.txt
@@ -5,4 +5,4 @@ wheel==0.24.0
 twine==1.4.0
 
 # Transifex client for managing translation resources.
-transifex-client==0.10
+transifex-client==0.11b3

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -772,7 +772,7 @@ class ModelSerializer(Serializer):
                 many_to_many[field_name] = validated_data.pop(field_name)
 
         try:
-            instance = ModelClass.objects.create(**validated_data)
+            instance = ModelClass.object.create(**validated_data)
         except TypeError as exc:
             msg = (
                 'Got a `TypeError` when calling `%s.objects.create()`. '


### PR DESCRIPTION
Hi Tom, 

I found a bug into the serializer class in line 775. I got the error "model has no attribute 'objects'". So I aren't able to create new models. With ModelClass.object.create() it works with Django 1.8.1.

Furthermore I set the newer version of trasifex-client into the requierments, because the old version were not downloadable.

Kind regards,
Djordje Ilic