### PR TITLE
can't create nested serializers for unique_together relations

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1088,6 +1088,9 @@ class ModelSerializer(Serializer):
         if extra_kwargs.get('default') and kwargs.get('required') is False:
             kwargs.pop('required')
 
+        if kwargs.get('read_only', False):
+            extra_kwargs.pop('required', None)
+
         kwargs.update(extra_kwargs)
 
         return kwargs

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -316,6 +316,13 @@ class RelationalModel(models.Model):
     through = models.ManyToManyField(ThroughTargetModel, through=Supplementary, related_name='reverse_through')
 
 
+class UniqueTogetherModel(models.Model):
+    foreign_key = models.ForeignKey(ForeignKeyTargetModel, related_name='unique_foreign_key')
+    one_to_one = models.OneToOneField(OneToOneTargetModel, related_name='unique_one_to_one')
+    class Meta:
+        unique_together = ("foreign_key", "one_to_one")
+
+
 class TestRelationalFieldMappings(TestCase):
     def test_pk_relations(self):
         class TestSerializer(serializers.ModelSerializer):
@@ -392,6 +399,25 @@ class TestRelationalFieldMappings(TestCase):
                 through = NestedSerializer(many=True, read_only=True):
                     url = HyperlinkedIdentityField(view_name='throughtargetmodel-detail')
                     name = CharField(max_length=100)
+        """)
+        self.assertEqual(unicode_repr(TestSerializer()), expected)
+
+    def test_nested_unique_together_relations(self):
+        class TestSerializer(serializers.HyperlinkedModelSerializer):
+            class Meta:
+                model = UniqueTogetherModel
+                depth = 1
+        expected = dedent("""
+            TestSerializer():
+                url = HyperlinkedIdentityField(view_name='uniquetogethermodel-detail')
+                foreign_key = NestedSerializer(read_only=True):
+                    url = HyperlinkedIdentityField(view_name='foreignkeytargetmodel-detail')
+                    name = CharField(max_length=100)
+                one_to_one = NestedSerializer(read_only=True):
+                    url = HyperlinkedIdentityField(view_name='onetoonetargetmodel-detail')
+                    name = CharField(max_length=100)
+                class Meta:
+                    validators = [<UniqueTogetherValidator(queryset=UniqueTogetherModel.objects.all(), fields=('foreign_key', 'one_to_one'))>]
         """)
         self.assertEqual(unicode_repr(TestSerializer()), expected)
 

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -419,6 +419,13 @@ class TestRelationalFieldMappings(TestCase):
                 class Meta:
                     validators = [<UniqueTogetherValidator(queryset=UniqueTogetherModel.objects.all(), fields=('foreign_key', 'one_to_one'))>]
         """)
+        if six.PY2:
+            # This case is also too awkward to resolve fully across both py2
+            # and py3.  (See above)
+            expected = expected.replace(
+                "('foreign_key', 'one_to_one')",
+                "(u'foreign_key', u'one_to_one')"
+            )
         self.assertEqual(unicode_repr(TestSerializer()), expected)
 
     def test_pk_reverse_foreign_key(self):

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -319,6 +319,7 @@ class RelationalModel(models.Model):
 class UniqueTogetherModel(models.Model):
     foreign_key = models.ForeignKey(ForeignKeyTargetModel, related_name='unique_foreign_key')
     one_to_one = models.OneToOneField(OneToOneTargetModel, related_name='unique_one_to_one')
+
     class Meta:
         unique_together = ("foreign_key", "one_to_one")
 


### PR DESCRIPTION
I came across an unexpected issue when trying to create a read-only nested serializer for a related field that's part of a `unique_together` constraint (in [vera](https://github.com/wq/vera)).  An `extra_kwargs` entry of `required=True` is set for the constraint, but that conflicts with `read_only=True` set as the nested field's `kwargs`.