### PR TITLE
Form overloading reparsing redux

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -381,8 +381,7 @@ class Request(object):
             return
 
         # At this point we're committed to parsing the request as form data.
-        self._data = self._request.POST
-        self._files = self._request.FILES
+        self._data, self._files = self._parse()
         self._full_data = self._data.copy()
         self._full_data.update(self._files)
 

--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -385,6 +385,10 @@ class Request(object):
         self._full_data = self._data.copy()
         self._full_data.update(self._files)
 
+        # Point the underlying request data to our parsed data for backwards compatibility.
+        self._request._post = self._data
+        self._request._files = self._files
+
         # Method overloading - change the method and remove the param from the content.
         if (
             self._METHOD_PARAM and

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -58,6 +58,7 @@ class TestMethodOverloading(TestCase):
         reserved form field
         """
         request = Request(factory.post('/', {api_settings.FORM_METHOD_OVERRIDE: 'DELETE'}))
+        request.parsers = (MultiPartParser(), )
         self.assertEqual(request.method, 'DELETE')
 
     def test_x_http_method_override_header(self):
@@ -66,6 +67,7 @@ class TestMethodOverloading(TestCase):
         the X-HTTP-Method-Override header.
         """
         request = Request(factory.post('/', {'foo': 'bar'}, HTTP_X_HTTP_METHOD_OVERRIDE='DELETE'))
+        request.parsers = (MultiPartParser(), )
         self.assertEqual(request.method, 'DELETE')
 
         request = Request(factory.get('/', {'foo': 'bar'}, HTTP_X_HTTP_METHOD_OVERRIDE='DELETE'))
@@ -148,7 +150,7 @@ class TestContentParsing(TestCase):
             api_settings.FORM_CONTENTTYPE_OVERRIDE: content_type
         }
         request = Request(factory.post('/', form_data))
-        request.parsers = (JSONParser(), )
+        request.parsers = (JSONParser(), MultiPartParser(), )
         self.assertEqual(request.DATA, json_data)
 
     def test_form_POST_unicode(self):


### PR DESCRIPTION
I think this works as an alternative to #2972. 
A few notes:
- The data from the stream should only be stored once, since the request stream is only read by the parser. This gets around the issue from my other PR, where request data also had to be stored in the request `body`.
- There shouldn't be any additional parsing overhead since parsing is now performed by the DRF parser instead of the django request `_load_post_and_files`. Reparsing on overload operates the same as before.