### PR TITLE
MultipleChoiceField empties incorrectly on a partial update using multipart/form-data (#2894)

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1060,7 +1060,11 @@ class MultipleChoiceField(ChoiceField):
         # We override the default field access in order to support
         # lists in HTML forms.
         if html.is_html_input(dictionary):
-            return dictionary.getlist(self.field_name)
+            ret = dictionary.getlist(self.field_name)
+            if getattr(self.root, 'partial', False) and not ret:
+                ret = empty
+            return ret
+
         return dictionary.get(self.field_name, empty)
 
     def to_internal_value(self, data):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1018,10 +1018,13 @@ class TestMultipleChoiceField(FieldValues):
         ]
     )
 
-    def test_against_partial_updates(self):
+    def test_against_partial_and_full_updates(self):
         # serializer = self.Serializer(data=MockHTMLDict())
         from django.http import QueryDict
         field = serializers.MultipleChoiceField(choices=(('a', 'a'), ('b', 'b')))
+        field.partial = False
+        assert field.get_value(QueryDict({})) == []
+        field.partial = True
         assert field.get_value(QueryDict({})) == rest_framework.fields.empty
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from django.utils import timezone
 from rest_framework import serializers
+import rest_framework
 import datetime
 import django
 import pytest
@@ -1016,6 +1017,12 @@ class TestMultipleChoiceField(FieldValues):
             ('diesel', 'Diesel'),
         ]
     )
+
+    def test_against_partial_updates(self):
+        # serializer = self.Serializer(data=MockHTMLDict())
+        from django.http import QueryDict
+        field = serializers.MultipleChoiceField(choices=(('a', 'a'), ('b', 'b')))
+        assert field.get_value(QueryDict({})) == rest_framework.fields.empty
 
 
 # File serializers...


### PR DESCRIPTION
This is the first part to get #2894 fixed.