### PR TITLE
Let py.test use the short traceback format.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
+[pytest]
+addopts=--tb=short
+
 [tox]
 envlist =
        py27-{flake8,docs},


### PR DESCRIPTION
Once discussed never done.
This will allow short traceback format to help with readability.
See https://pytest.org/latest/usage.html#modifying-python-traceback-printing for documentation.
Basically it's a one line per level stack display.