### PR TITLE
Handle invalid characters in "Authorization: token ..." headers

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -170,7 +170,13 @@ class TokenAuthentication(BaseAuthentication):
             msg = _('Invalid token header. Token string should not contain spaces.')
             raise exceptions.AuthenticationFailed(msg)
 
-        return self.authenticate_credentials(auth[1])
+        try:
+            token = auth[1].decode()
+        except UnicodeError:
+            msg = _('Invalid token header. Token string should not contain invalid characters.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        return self.authenticate_credentials(token)
 
     def authenticate_credentials(self, key):
         try:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 from __future__ import unicode_literals
 from django.conf.urls import patterns, url, include
 from django.contrib.auth.models import User
@@ -161,6 +163,12 @@ class TokenAuthTests(TestCase):
         auth = 'Token ' + self.key
         response = self.csrf_client.post('/token/', {'example': 'example'}, HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_fail_post_form_passing_invalid_token_auth(self):
+        # add an 'invalid' unicode character
+        auth = 'Token ' + self.key + "¸"
+        response = self.csrf_client.post('/token/', {'example': 'example'}, HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_post_json_passing_token_auth(self):
         """Ensure POSTing form over token auth with correct credentials passes and does not require CSRF"""


### PR DESCRIPTION
Resolve #2928.

Request headers are passed as `bytes()` on Py3 (or `str()` on Py2), so, we try to decode it before calling `self.authenticate_credentials()`.

If we got an error decoding token we raise an AuthenticationFailed() exception.