### PR TITLE
Include correct limits in LimitOffsetPagination link urls

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -431,6 +431,8 @@ class LimitOffsetPagination(BasePagination):
             return None
 
         url = self.request.build_absolute_uri()
+        url = replace_query_param(url, self.limit_query_param, self.limit)
+
         offset = self.offset + self.limit
         return replace_query_param(url, self.offset_query_param, offset)
 
@@ -439,6 +441,7 @@ class LimitOffsetPagination(BasePagination):
             return None
 
         url = self.request.build_absolute_uri()
+        url = replace_query_param(url, self.limit_query_param, self.limit)
 
         if self.offset - self.limit <= 0:
             return remove_query_param(url, self.offset_query_param)


### PR DESCRIPTION
For `LimitOffsetPagination`, if the limit from the query param is invalid or greater than the `max_limit`, then the previous and next links should contain the actual limit being used instead of the originally requested limit. 

Examples:
- with a `default_limit` set, a request to `http://testserver/?limit=hello`
```python
# instead of keeping the invalid limit in the url
url = 'http://testserver/?limit=hello&offset{0}'.format(default_limit)
# should provide a next link with the default_limit in the url
url = 'http://testserver/?limit={0}&offset={1}'.format(default_limit, default_limit)
```

- similarly, with a `max_limit` set to 10, a request to `http://testserver/?limit=100` should provide a next link with url `http://testserver/?limit=10&offset=10` instead of `http://testserver/?limit=100&offset=10`