### PR TITLE
Fix set_rollback on @transaction.non_atomic_requests.

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -274,7 +274,8 @@ def set_rollback():
         if connection.settings_dict.get('ATOMIC_REQUESTS', False):
             # If running in >=1.6 then mark a rollback as required,
             # and allow it to be handled by Django.
-            transaction.set_rollback(True)
+            if connection.in_atomic_block:
+                transaction.set_rollback(True)
     elif transaction.is_managed():
         # Otherwise handle it explicitly if in managed mode.
         if transaction.is_dirty():

--- a/tests/test_atomic_requests.py
+++ b/tests/test_atomic_requests.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals
 
+from django.conf.urls import patterns, url
 from django.db import connection, connections, transaction
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
+from django.http import Http404
 from django.utils.decorators import method_decorator
 from django.utils.unittest import skipUnless
 from rest_framework import status
-from rest_framework.exceptions import APIException, PermissionDenied
+from rest_framework.exceptions import APIException
 from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory
 from rest_framework.views import APIView
@@ -113,30 +115,33 @@ class DBTransactionAPIExceptionTests(TestCase):
 
 @skipUnless(connection.features.uses_savepoints,
             "'atomic' requires transactions and savepoints.")
-class NonAtomicDBTransactionAPIExceptionTests(TestCase):
-    def setUp(self):
-        # only Django >= 1.6 provides @transaction.non_atomic_requests
+class NonAtomicDBTransactionAPIExceptionTests(TransactionTestCase):
+    @property
+    def urls(self):
         class NonAtomicAPIExceptionView(APIView):
             @method_decorator(transaction.non_atomic_requests)
             def dispatch(self, *args, **kwargs):
                 return super(NonAtomicAPIExceptionView, self).dispatch(*args, **kwargs)
 
-            def post(self, request, *args, **kwargs):
-                BasicModel.objects.create()
-                raise PermissionDenied
+            def get(self, request, *args, **kwargs):
+                BasicModel.objects.all()
+                raise Http404
 
-        self.view = NonAtomicAPIExceptionView.as_view()
+        return patterns(
+            '',
+            url(r'^$', NonAtomicAPIExceptionView.as_view())
+        )
+
+    def setUp(self):
         connections.databases['default']['ATOMIC_REQUESTS'] = True
 
     def tearDown(self):
         connections.databases['default']['ATOMIC_REQUESTS'] = False
 
     def test_api_exception_rollback_transaction_non_atomic_view(self):
-        request = factory.post('/')
-
-        response = self.view(request)
+        response = self.client.get('/')
 
         # without checking connection.in_atomic_block view raises 500
         # due attempt to rollback without transaction
         self.assertEqual(response.status_code,
-                         status.HTTP_403_FORBIDDEN)
+                         status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
```python
set_rollback()
``` 
checks only `ATOMIC_REQUEST` value, but it can be turned off per view by 

```python 
@transaction.non_atomic_requests
```

Attempt to rollback without atomic block raises

```python
raise TransactionManagementError("The rollback flag doesn't work outside of an 'atomic' block.")
```

https://github.com/django/django/blob/06dc6759d85c6c24b599de07cea47387d3dc2cf9/django/db/backends/base/base.py#L361

Really critical, due `http404` for every `@transaction.non_atomic_requests`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tomchristie/django-rest-framework/3016)
<!-- Reviewable:end -->
