### PR TITLE
Set the filter_backends class variable in the DjangoFilterBackend docs

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -149,6 +149,7 @@ If all you need is simple equality-based filtering, you can set a `filter_fields
     class ProductList(generics.ListAPIView):
         queryset = Product.objects.all()
         serializer_class = ProductSerializer
+        filter_backends = (filters.DjangoFilterBackend,)
         filter_fields = ('category', 'in_stock')
 
 This will automatically create a `FilterSet` class for the given fields, and will allow you to make requests such as:
@@ -174,6 +175,7 @@ For more advanced filtering requirements you can specify a `FilterSet` class tha
     class ProductList(generics.ListAPIView):
         queryset = Product.objects.all()
         serializer_class = ProductSerializer
+        filter_backends = (filters.DjangoFilterBackend,)
         filter_class = ProductFilter
 
 


### PR DESCRIPTION
The examples in the DjangoFilterBackend documentation omit the setting of the filter_backends class variable. The examples seem to assume that the configuration setting DEFAULT_FILTER_BACKENDS is set to default to DjangoFilterBackend.

This is not immediately clear to new users and may lead to confusion. This pull request simply adds the filter_backends setting to the examples to make these more easy to reproduce.