### PR TITLE
Fixed error serializer source attribute

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -808,7 +808,16 @@ class ModelSerializer(Serializer):
         raise_errors_on_nested_writes('update', self, validated_data)
 
         for attr, value in validated_data.items():
-            setattr(instance, attr, value)
+            if isinstance(value, dict):
+                instance_attr = getattr(instance, attr)
+                for _attr, _value in value.items():
+                    setattr(instance_attr, _attr, _value)
+
+                instance_attr.save()
+                setattr(instance, attr, instance_attr)
+            else:
+                setattr(instance, attr, value)
+
         instance.save()
 
         return instance


### PR DESCRIPTION
Let me try explain my error:
I have related (One-To-One) models:
```
class User(models.Model):
    email = models.EmailField(...)

class UserProfile(models.Model):
    user = models.OneToOneField(User, related_name='profile')
    age = models.IntegerField(...)
```

and I wanted to create serializer for user. That serializer have `User` model fields and `UserProfile` model's fields too. (I want flat data: `{'email': 'my@email.com', 'age': 10}` not `{'user': {'email': 'my@email.com'}, 'age': 10}`)
 Here is my serializer:
```
class UserSerializer(serializers.ModelSerializer):
    age = serializers.IntegerField(source='profile.age')  # Here I'm using source attribute

    class Meta:
        model = User
        fields = 'age', ...
```
I've used this serializer in viewset which support `PATCH` method.

When I try to update the `age` of the user it's throws the error: `Cannot assign "{'age': 1}": "User.profile" must be a "UserProfile" instance.`

Hope you understand my error. Sorry for bad english :)