### PR TITLE
Remove `django.conf.urls.pattern`

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -17,7 +17,7 @@ from __future__ import unicode_literals
 
 import itertools
 from collections import namedtuple
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
 from rest_framework import views
@@ -76,7 +76,7 @@ class BaseRouter(object):
     @property
     def urls(self):
         if not hasattr(self, '_urls'):
-            self._urls = patterns('', *self.get_urls())
+            self._urls = self.get_urls()
         return self._urls
 
 

--- a/rest_framework/urls.py
+++ b/rest_framework/urls.py
@@ -4,23 +4,22 @@ Login and logout views for the browsable API.
 Add these to your root URLconf if you're using the browsable API and
 your API requires authentication:
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         ...
         url(r'^auth/', include('rest_framework.urls', namespace='rest_framework'))
-    )
+    ]
 
 The urls must be namespaced as 'rest_framework', and you should make sure
 your authentication settings include `SessionAuthentication`.
 """
 from __future__ import unicode_literals
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth import views
 
 
 template_name = {'template_name': 'rest_framework/login.html'}
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^login/$', views.login, template_name, name='login'),
-    url(r'^logout/$', views.logout, template_name, name='logout')
-)
+    url(r'^logout/$', views.logout, template_name, name='logout'),
+]

--- a/tests/browsable_api/auth_urls.py
+++ b/tests/browsable_api/auth_urls.py
@@ -1,11 +1,10 @@
 from __future__ import unicode_literals
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 
 from .views import MockView
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     (r'^$', MockView.as_view()),
     url(r'^auth/', include('rest_framework.urls', namespace='rest_framework')),
-)
+]

--- a/tests/browsable_api/auth_urls.py
+++ b/tests/browsable_api/auth_urls.py
@@ -5,6 +5,6 @@ from .views import MockView
 
 
 urlpatterns = [
-    (r'^$', MockView.as_view()),
+    url(r'^$', MockView.as_view()),
     url(r'^auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]

--- a/tests/browsable_api/no_auth_urls.py
+++ b/tests/browsable_api/no_auth_urls.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 
+from django.conf.urls import url
 from .views import MockView
 
 urlpatterns = [
-    (r'^$', MockView.as_view()),
+    url(r'^$', MockView.as_view()),
 ]

--- a/tests/browsable_api/no_auth_urls.py
+++ b/tests/browsable_api/no_auth_urls.py
@@ -1,9 +1,7 @@
 from __future__ import unicode_literals
-from django.conf.urls import patterns
 
 from .views import MockView
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     (r'^$', MockView.as_view()),
-)
+]

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.test import TestCase
@@ -37,14 +37,13 @@ class MockView(APIView):
         return HttpResponse({'a': 1, 'b': 2, 'c': 3})
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     (r'^session/$', MockView.as_view(authentication_classes=[SessionAuthentication])),
     (r'^basic/$', MockView.as_view(authentication_classes=[BasicAuthentication])),
     (r'^token/$', MockView.as_view(authentication_classes=[TokenAuthentication])),
     (r'^auth-token/$', 'rest_framework.authtoken.views.obtain_auth_token'),
     url(r'^auth/', include('rest_framework.urls', namespace='rest_framework'))
-)
+]
 
 
 class BasicAuthTests(TestCase):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -38,11 +38,11 @@ class MockView(APIView):
 
 
 urlpatterns = [
-    (r'^session/$', MockView.as_view(authentication_classes=[SessionAuthentication])),
-    (r'^basic/$', MockView.as_view(authentication_classes=[BasicAuthentication])),
-    (r'^token/$', MockView.as_view(authentication_classes=[TokenAuthentication])),
-    (r'^auth-token/$', 'rest_framework.authtoken.views.obtain_auth_token'),
-    url(r'^auth/', include('rest_framework.urls', namespace='rest_framework'))
+    url(r'^session/$', MockView.as_view(authentication_classes=[SessionAuthentication])),
+    url(r'^basic/$', MockView.as_view(authentication_classes=[BasicAuthentication])),
+    url(r'^token/$', MockView.as_view(authentication_classes=[TokenAuthentication])),
+    url(r'^auth-token/$', 'rest_framework.authtoken.views.obtain_auth_token'),
+    url(r'^auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import datetime
 from decimal import Decimal
 from django.db import models
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -94,13 +94,12 @@ if django_filters:
         def get_queryset(self):
             return FilterableItem.objects.all()
 
-    urlpatterns = patterns(
-        '',
+    urlpatterns = [
         url(r'^(?P<pk>\d+)/$', FilterClassDetailView.as_view(), name='detail-view'),
         url(r'^$', FilterClassRootView.as_view(), name='root-view'),
         url(r'^get-queryset/$', GetQuerysetView.as_view(),
             name='get-queryset-view'),
-    )
+    ]
 
 
 class CommonFilteringTestCase(TestCase):

--- a/tests/test_htmlrenderer.py
+++ b/tests/test_htmlrenderer.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from django.core.exceptions import PermissionDenied
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.http import Http404
 from django.test import TestCase
 from django.template import TemplateDoesNotExist, Template
@@ -34,12 +34,11 @@ def not_found(request):
     raise Http404()
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', example),
     url(r'^permission_denied$', permission_denied),
     url(r'^not_found$', not_found),
-)
+]
 
 
 class TemplateHTMLRendererTests(TestCase):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,5 +1,5 @@
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.models import User
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.authtoken.models import Token
@@ -7,10 +7,9 @@ from rest_framework.test import APITestCase
 from rest_framework.views import APIView
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', APIView.as_view(authentication_classes=(TokenAuthentication,))),
-)
+]
 
 
 class MyMiddleware(object):

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -103,8 +103,7 @@ class HTMLView1(APIView):
     def get(self, request, **kwargs):
         return Response('text')
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^.*\.(?P<format>.+)$', MockView.as_view(renderer_classes=[RendererA, RendererB])),
     url(r'^$', MockView.as_view(renderer_classes=[RendererA, RendererB])),
     url(r'^cache$', MockGETView.as_view()),
@@ -113,7 +112,7 @@ urlpatterns = patterns(
     url(r'^html1$', HTMLView1.as_view()),
     url(r'^empty$', EmptyGETView.as_view()),
     url(r'^api', include('rest_framework.urls', namespace='rest_framework'))
-)
+]
 
 
 class POSTDeniedPermission(permissions.BasePermission):

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.core.cache import cache
 from django.db import models
 from django.test import TestCase

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -2,6 +2,7 @@
 Tests for content parsing, and form-overloaded content parsing.
 """
 from __future__ import unicode_literals
+from django.conf.urls import url
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -189,7 +190,7 @@ class MockView(APIView):
         return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 urlpatterns = [
-    (r'^$', MockView.as_view()),
+    url(r'^$', MockView.as_view()),
 ]
 
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -2,7 +2,6 @@
 Tests for content parsing, and form-overloaded content parsing.
 """
 from __future__ import unicode_literals
-from django.conf.urls import patterns
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -189,10 +188,9 @@ class MockView(APIView):
 
         return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     (r'^$', MockView.as_view()),
-)
+]
 
 
 class TestContentParsingWithAuthentication(TestCase):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.test import TestCase
 from django.utils import six
 from tests.models import BasicModel
@@ -113,8 +113,7 @@ new_model_viewset_router = routers.DefaultRouter()
 new_model_viewset_router.register(r'', HTMLNewModelViewSet)
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^setbyview$', MockViewSettingContentType.as_view(renderer_classes=[RendererA, RendererB, RendererC])),
     url(r'^.*\.(?P<format>.+)$', MockView.as_view(renderer_classes=[RendererA, RendererB, RendererC])),
     url(r'^$', MockView.as_view(renderer_classes=[RendererA, RendererB, RendererC])),
@@ -123,7 +122,7 @@ urlpatterns = patterns(
     url(r'^html_new_model$', HTMLNewModelView.as_view()),
     url(r'^html_new_model_viewset', include(new_model_viewset_router.urls)),
     url(r'^restframework', include('rest_framework.urls', namespace='rest_framework'))
-)
+]
 
 
 # TODO: Clean tests bellow - remove duplicates with above, better unit testing, ...

--- a/tests/test_reverse.py
+++ b/tests/test_reverse.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.urlresolvers import NoReverseMatch
 from django.test import TestCase
 from rest_framework.reverse import reverse
@@ -11,10 +11,9 @@ factory = APIRequestFactory()
 def null_view(request):
     pass
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^view$', null_view, name='view'),
-)
+]
 
 
 class MockVersioningScheme(object):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 from __future__ import unicode_literals
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.models import User
 from django.shortcuts import redirect
 from django.test import TestCase

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -32,12 +32,11 @@ def redirect_view(request):
     return redirect('/view/')
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^view/$', view),
     url(r'^session-view/$', session_view),
     url(r'^redirect-view/$', redirect_view),
-)
+]
 
 
 class TestAPITestClient(TestCase):

--- a/tests/test_urlpatterns.py
+++ b/tests/test_urlpatterns.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from collections import namedtuple
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.core import urlresolvers
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
@@ -36,10 +36,9 @@ class FormatSuffixTests(TestCase):
             self.assertEqual(callback_kwargs, test_path.kwargs)
 
     def test_format_suffix(self):
-        urlpatterns = patterns(
-            '',
+        urlpatterns = [
             url(r'^test$', dummy_view),
-        )
+        ]
         test_paths = [
             URLTestPath('/test', (), {}),
             URLTestPath('/test.api', (), {'format': 'api'}),
@@ -48,10 +47,9 @@ class FormatSuffixTests(TestCase):
         self._resolve_urlpatterns(urlpatterns, test_paths)
 
     def test_default_args(self):
-        urlpatterns = patterns(
-            '',
+        urlpatterns = [
             url(r'^test$', dummy_view, {'foo': 'bar'}),
-        )
+        ]
         test_paths = [
             URLTestPath('/test', (), {'foo': 'bar', }),
             URLTestPath('/test.api', (), {'foo': 'bar', 'format': 'api'}),
@@ -60,14 +58,12 @@ class FormatSuffixTests(TestCase):
         self._resolve_urlpatterns(urlpatterns, test_paths)
 
     def test_included_urls(self):
-        nested_patterns = patterns(
-            '',
+        nested_patterns = [
             url(r'^path$', dummy_view)
-        )
-        urlpatterns = patterns(
-            '',
+        ]
+        urlpatterns = [
             url(r'^test/', include(nested_patterns), {'foo': 'bar'}),
-        )
+        ]
         test_paths = [
             URLTestPath('/test/path', (), {'foo': 'bar', }),
             URLTestPath('/test/path.api', (), {'foo': 'bar', 'format': 'api'}),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from django.core.exceptions import ImproperlyConfigured
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.test import TestCase
 from django.utils import six
 from rest_framework.utils.model_meta import _resolve_model

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,14 +31,13 @@ class NestedResourceInstance(APIView):
     pass
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', Root.as_view()),
     url(r'^resource/$', ResourceRoot.as_view()),
     url(r'^resource/(?P<key>[0-9]+)$', ResourceInstance.as_view()),
     url(r'^resource/(?P<key>[0-9]+)/$', NestedResourceRoot.as_view()),
     url(r'^resource/(?P<key>[0-9]+)/(?P<other>[A-Za-z]+)$', NestedResourceInstance.as_view()),
-)
+]
 
 
 class BreadcrumbTests(TestCase):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,4 @@
 """
 Blank URLConf just to keep the test suite happy
 """
-from django.conf.urls import patterns
-
-urlpatterns = patterns('')
+urlpatterns = []


### PR DESCRIPTION
Since they already have been removed from the doc and will be removed in Django 2.0