### PR TITLE
Use get_queryset() for RelatedField choices property

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -109,7 +109,7 @@ class RelatedField(Field):
                 six.text_type(self.to_representation(item)),
                 six.text_type(item)
             )
-            for item in self.queryset.all()
+            for item in self.get_queryset()
         ])
 
 


### PR DESCRIPTION
When overriding the get_queryset() method the property that outputs the choices sometimes uses a different queryset due to hardcoded .all()