### PR TITLE
allow user to pass additional fields to constructor

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -17,12 +17,12 @@ class CreateModelMixin(object):
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        self.perform_create(serializer)
+        self.perform_create(serializer, **(kwargs.get('extra_fields', {})))
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
-    def perform_create(self, serializer):
-        serializer.save()
+    def perform_create(self, serializer, **kwargs):
+        serializer.save(**kwargs)
 
     def get_success_headers(self, data):
         try:


### PR DESCRIPTION
When a consumer creates an object, sometimes additional fields need to be passed to the model beyond what is collected in the form. Adding support for 'extra_fields' in kwargs allows the consumer to submit these fields. Examples would include the request.user object.