### PR TITLE
Document setting URL_FORMAT_OVERRIDE to None

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -273,6 +273,8 @@ Default: `'accept'`
 
 The name of a URL parameter that may be used to override the default `Accept` header based content negotiation.
 
+If the value of this setting is `None` then URL format overloading will be disabled.
+
 Default: `'format'`
 
 ---

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -72,20 +72,24 @@
         {% if 'GET' in allowed_methods %}
           <form id="get-form" class="pull-right">
             <fieldset>
-              <div class="btn-group format-selection">
-                <a class="btn btn-primary js-tooltip" href='{{ request.get_full_path }}' rel="nofollow" title="Make a GET request on the {{ name }} resource">GET</a>
+              {% if api_settings.URL_FORMAT_OVERRIDE %}
+                <div class="btn-group format-selection">
+                  <a class="btn btn-primary js-tooltip" href="{{ request.get_full_path }}" rel="nofollow" title="Make a GET request on the {{ name }} resource">GET</a>
 
-                <button class="btn btn-primary dropdown-toggle js-tooltip" data-toggle="dropdown" title="Specify a format for the GET request">
-                  <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu">
-                  {% for format in available_formats %}
-                    <li>
-                      <a class="js-tooltip format-option" href='{% add_query_param request api_settings.URL_FORMAT_OVERRIDE format %}' rel="nofollow" title="Make a GET request on the {{ name }} resource with the format set to `{{ format }}`">{{ format }}</a>
-                    </li>
-                  {% endfor %}
-                </ul>
-              </div>
+                  <button class="btn btn-primary dropdown-toggle js-tooltip" data-toggle="dropdown" title="Specify a format for the GET request">
+                    <span class="caret"></span>
+                  </button>
+                  <ul class="dropdown-menu">
+                    {% for format in available_formats %}
+                      <li>
+                        <a class="js-tooltip format-option" href="{% add_query_param request api_settings.URL_FORMAT_OVERRIDE format %}" rel="nofollow" title="Make a GET request on the {{ name }} resource with the format set to `{{ format }}`">{{ format }}</a>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              {% else %}
+                <a class="btn btn-primary js-tooltip" href="{{ request.get_full_path }}" rel="nofollow" title="Make a GET request on the {{ name }} resource">GET</a>
+              {% endif %}
             </fieldset>
           </form>
         {% endif %}


### PR DESCRIPTION
This also hides the format dropdown from the Browsable API if `URL_FORMAT_OVERRIDE` is disabled.