### PR TITLE
Made exception message more verbose

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -417,10 +417,11 @@ class Field(object):
         Transform the *outgoing* native value into primitive data.
         """
         raise NotImplementedError(
-            '{cls}.to_representation() must be implemented.\n'
+            '{cls}.to_representation() must be implemented for field {field_name}.\n'
             'If you are upgrading from REST framework version 2 '
             'you might want `ReadOnlyField`.'.format(
-                cls=self.__class__.__name__
+                cls=self.__class__.__name__,
+                field_name=self.field_name,
             )
         )
 


### PR DESCRIPTION
This exception helps you to upgrade from 2 -> 3 and since a lot of fields may be in 2 using serializers.Field as parent class, this message should contain at least name of upgraded field to help user to grep and fix the codebase faster.