### PR TITLE
Unsaved file objects may not have an associated URL.

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1198,8 +1198,12 @@ class FileField(Field):
         return data
 
     def to_representation(self, value):
+        if not value:
+            return None
+
         if self.use_url:
-            if not value:
+            if not getattr(value, 'url', None):
+                # If the file has not been saved it may not have a URL.
                 return None
             url = value.url
             request = self.context.get('request', None)


### PR DESCRIPTION
If a file object is unsaved it may not have an associated URL.
If we're using `FileField(use_url=True)` in that case then return `None` for the field representation.

Superseeds #2759.