### PR TITLE
Fix ManyRelatedField.choices

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -388,16 +388,4 @@ class ManyRelatedField(Field):
 
     @property
     def choices(self):
-        queryset = self.child_relation.queryset
-        iterable = queryset.all() if (hasattr(queryset, 'all')) else queryset
-        items_and_representations = [
-            (item, self.child_relation.to_representation(item))
-            for item in iterable
-        ]
-        return OrderedDict([
-            (
-                six.text_type(item_representation),
-                six.text_type(item) + ' - ' + six.text_type(item_representation)
-            )
-            for item, item_representation in items_and_representations
-        ])
+        return self.child_relation.choices


### PR DESCRIPTION
Child relation is already responsible for generating choices for that kind of field. When we can select more than one element this does not change possible choices.

We can just simply use what `self.child_relation.choices` will generate.
