### PR TITLE
Handle AttributeError as well (when the imported module exists but the specified function/class does not).

### DIFF
--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -171,7 +171,7 @@ def import_from_string(val, setting_name):
         module_path, class_name = '.'.join(parts[:-1]), parts[-1]
         module = importlib.import_module(module_path)
         return getattr(module, class_name)
-    except ImportError as e:
+    except (ImportError, AttributeError) as e:
         msg = "Could not import '%s' for API setting '%s'. %s: %s." % (val, setting_name, e.__class__.__name__, e)
         raise ImportError(msg)
 


### PR DESCRIPTION
This is a minor fix to show the meaningful ImportError (referencing the setting name and the value) when the specified module does exist but the function or class does not. (Which raises an AttributeError instead of an ImportError, and which the original code allowed to propagate.)