### PR TITLE
Ability to customize DateTimeField with a custom datetime_parser

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -888,11 +888,13 @@ class DateTimeField(Field):
     format = api_settings.DATETIME_FORMAT
     input_formats = api_settings.DATETIME_INPUT_FORMATS
     default_timezone = timezone.get_default_timezone() if settings.USE_TZ else None
+    datetime_parser = datetime.datetime.strptime
 
-    def __init__(self, format=empty, input_formats=None, default_timezone=None, *args, **kwargs):
+    def __init__(self, format=empty, datetime_parser=None, input_formats=None, default_timezone=None, *args, **kwargs):
         self.format = format if format is not empty else self.format
         self.input_formats = input_formats if input_formats is not None else self.input_formats
         self.default_timezone = default_timezone if default_timezone is not None else self.default_timezone
+        self.datetime_parser = datetime_parser if datetime_parser is not None else self.datetime_parser
         super(DateTimeField, self).__init__(*args, **kwargs)
 
     def enforce_timezone(self, value):
@@ -924,7 +926,7 @@ class DateTimeField(Field):
                         return self.enforce_timezone(parsed)
             else:
                 try:
-                    parsed = datetime.datetime.strptime(value, format)
+                    parsed = self.datetime_parser(value, format)
                 except (ValueError, TypeError):
                     pass
                 else:


### PR DESCRIPTION
This could be applied to DateField and TimeField, but I thought I'd propose the general idea with this.

DateTimeField is very nicely put together, but datetime.datetime.strptime is extraordinarily limited and in several ways doesn't even work as documented.  This change would allow the user to substitute a different datetime parser in so long as it took the same value, format pair as an argument. While it might require a small wrapper function to handle exceptions, the Arrow module's parser should work as a drop-in replacement (albeit with a different format syntax).

This could be problematic with regards to the to_representation implementation, as there should probably also be a way to customize output formatting.

I can flesh this out a bit more if it seems like something worth pursuing.