### PR TITLE
Update `get_serializer` signature (fix #2893)

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -195,7 +195,7 @@ These override points are also particularly useful for adding behavior that occu
 You won't typically need to override the following methods, although you might need to call into them if you're writing custom views using `GenericAPIView`.
 
 * `get_serializer_context(self)` - Returns a dictionary containing any extra context that should be supplied to the serializer.  Defaults to including `'request'`, `'view'` and `'format'` keys.
-* `get_serializer(self, instance=None, data=None, files=None, many=False, partial=False, allow_add_remove=False)` - Returns a serializer instance.
+* `get_serializer(self, instance=None, data=None, many=False, partial=False)` - Returns a serializer instance.
 * `get_paginated_response(self, data)` - Returns a paginated style `Response` object.
 * `paginate_queryset(self, queryset)` - Paginate a queryset if required, either returning a page object, or `None` if pagination is not configured for this view.
 * `filter_queryset(self, queryset)` - Given a queryset, filter it with whichever filter backends are in use, returning a new queryset.


### PR DESCRIPTION
- remove the `files` and `allow_add_remove` arguments that were part of the 2.x API.