### PR TITLE
Update extra_kwargs on model serializer for required and read_only

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1105,8 +1105,8 @@ class ModelSerializer(Serializer):
         if extra_kwargs.get('default') and kwargs.get('required') is False:
             kwargs.pop('required')
 
-        if kwargs.get('read_only', False):
-            extra_kwargs.pop('required', None)
+        if extra_kwargs.get('read_only', kwargs.get('read_only', False)):
+            extra_kwargs.pop('required', None)  # Read only fields should always omit the 'required' argument.
 
         kwargs.update(extra_kwargs)
 

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -235,6 +235,23 @@ class TestRegularFieldMappings(TestCase):
         """)
         self.assertEqual(repr(TestSerializer()), expected)
 
+    def test_extra_field_kwargs_required(self):
+        """
+        Ensure `extra_kwargs` are passed to generated fields.
+        """
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = RegularFieldsModel
+                fields = ('auto_field', 'char_field')
+                extra_kwargs = {'auto_field': {'required': False, 'read_only': False}}
+
+        expected = dedent("""
+            TestSerializer():
+                auto_field = IntegerField(read_only=False, required=False)
+                char_field = CharField(max_length=100)
+        """)
+        self.assertEqual(repr(TestSerializer()), expected)
+
     def test_invalid_field(self):
         """
         Field names that do not map to a model field or relationship should


### PR DESCRIPTION
Ensures that `read_only` is pulled from `extra_kwargs` and `required` is set appropriately.
Closes #3091.