### PR TITLE
Remove unused import from docs example

### DIFF
--- a/docs/tutorial/2-requests-and-responses.md
+++ b/docs/tutorial/2-requests-and-responses.md
@@ -108,7 +108,7 @@ and
 
 Now update the `urls.py` file slightly, to append a set of `format_suffix_patterns` in addition to the existing URLs.
 
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
     from rest_framework.urlpatterns import format_suffix_patterns
     from snippets import views
 


### PR DESCRIPTION
Was confused by patterns which seems to be deprecated in [django 1.8](https://docs.djangoproject.com/en/1.8/ref/urls/#django.conf.urls.patterns).