### PR TITLE
Adding recursion on child of List Field

### DIFF
--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -131,6 +131,9 @@ class SimpleMetadata(BaseMetadata):
             if value is not None and value != '':
                 field_info[attr] = force_text(value, strings_only=True)
 
+        if getattr(field, 'child', None):
+            field_info['child'] = self.get_field_info(field.child)
+
         if not field_info.get('read_only') and hasattr(field, 'choices'):
             field_info['choices'] = [
                 {

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -67,6 +67,11 @@ class TestMetadata:
             char_field = serializers.CharField(
                 required=False, min_length=3, max_length=40
             )
+            list_field = serializers.ListField(
+                child=serializers.ListField(
+                    child=serializers.IntegerField()
+                )
+            )
 
         class ExampleView(views.APIView):
             """Example view."""
@@ -119,6 +124,22 @@ class TestMetadata:
                         'label': 'Char field',
                         'min_length': 3,
                         'max_length': 40
+                    },
+                    'list_field': {
+                        'type': 'list',
+                        'required': True,
+                        'read_only': False,
+                        'label': 'List field',
+                        'child': {
+                            'type': 'list',
+                            'required': True,
+                            'read_only': False,
+                            'child': {
+                                'type': 'integer',
+                                'required': True,
+                                'read_only': False
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This pull request add recursively the metadata of the child in a list field.

For a serializer like this : 
```python
class PowerSerializer(serializers.Serializer):
    groups = serializers.ListField(child=serializers.IntegerField(), default=[], required=False)
```

You will have this metadata:
```json
"actions": {
    "POST": {
      "groups": {
        "type": "list",
        "required": false,
        "read_only": false,
        "label": "Groups",
        "child": {
          "type": "integer",
          "required": true,
          "read_only": false
        }
      }
    }
  }
```
I included the test directly in a existing test. Don't know if it was necessary to create a new one.
In the test provided, I use the recursion to be sure it works correctly.