### PR TITLE
Fix nested serializer required=False multipart data validation bug

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -367,7 +367,7 @@ class Serializer(BaseSerializer):
         # We override the default field access in order to support
         # nested HTML forms.
         if html.is_html_input(dictionary):
-            return html.parse_html_dict(dictionary, prefix=self.field_name)
+            return html.parse_html_dict(dictionary, prefix=self.field_name) or empty
         return dictionary.get(self.field_name, empty)
 
     def run_validation(self, data=empty):

--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -62,7 +62,7 @@ class TestNotRequiredNestedSerializer:
         assert serializer.is_valid()
 
     def test_multipart_validate(self):
-        input_data = QueryDict()
+        input_data = QueryDict('')
         serializer = self.Serializer(data=input_data)
         assert serializer.is_valid()
 

--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -1,3 +1,5 @@
+from django.http import QueryDict
+
 from rest_framework import serializers
 
 
@@ -50,20 +52,6 @@ class TestNotRequiredNestedSerializer:
 
         self.Serializer = TestSerializer
 
-        class FakeMultiDict(dict):
-            """
-            Use this to fake a `format="multipart"` request, because
-            `utils.is_html_input()` returns `True` when the dict object has
-            an attribute of "getlist".
-            """
-            def getlist(self, value, default=None):
-                if value in self:
-                    return [self[value]]
-                else:
-                    return [] if default is None else default
-
-        self.FakeMultiDict = FakeMultiDict
-
     def test_json_validate(self):
         input_data = {}
         serializer = self.Serializer(data=input_data)
@@ -74,10 +62,10 @@ class TestNotRequiredNestedSerializer:
         assert serializer.is_valid()
 
     def test_multipart_validate(self):
-        input_data = self.FakeMultiDict()
+        input_data = QueryDict()
         serializer = self.Serializer(data=input_data)
         assert serializer.is_valid()
 
-        input_data = self.FakeMultiDict(**{'nested.one': '1'})
+        input_data = QueryDict('nested[one]=1')
         serializer = self.Serializer(data=input_data)
         assert serializer.is_valid()

--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -38,3 +38,46 @@ class TestNestedSerializer:
         }
         serializer = self.Serializer()
         assert serializer.data == expected_data
+
+
+class TestNotRequiredNestedSerializer:
+    def setup(self):
+        class NestedSerializer(serializers.Serializer):
+            one = serializers.IntegerField(max_value=10)
+
+        class TestSerializer(serializers.Serializer):
+            nested = NestedSerializer(required=False)
+
+        self.Serializer = TestSerializer
+
+        class FakeMultiDict(dict):
+            """
+            Use this to fake a `format="multipart"` request, because
+            `utils.is_html_input()` returns `True` when the dict object has
+            an attribute of "getlist".
+            """
+            def getlist(self, value, default=None):
+                if value in self:
+                    return [self[value]]
+                else:
+                    return [] if default is None else default
+
+        self.FakeMultiDict = FakeMultiDict
+
+    def test_json_validate(self):
+        input_data = {}
+        serializer = self.Serializer(data=input_data)
+        assert serializer.is_valid()
+
+        input_data = {'nested': {'one': '1'}}
+        serializer = self.Serializer(data=input_data)
+        assert serializer.is_valid()
+
+    def test_multipart_validate(self):
+        input_data = self.FakeMultiDict()
+        serializer = self.Serializer(data=input_data)
+        assert serializer.is_valid()
+
+        input_data = self.FakeMultiDict(**{'nested.one': '1'})
+        serializer = self.Serializer(data=input_data)
+        assert serializer.is_valid()


### PR DESCRIPTION
After reviewing  https://github.com/tomchristie/django-rest-framework/pull/2796, https://github.com/tomchristie/django-rest-framework/issues/2719, and https://github.com/tomchristie/django-rest-framework/pull/2919, I thought it might not hurt to propose a fix for the simpler use case where mulitpart data for nested serializers with required=False fails validation when the field is not present.

I agree that great care is needed regarding the design decisions still needed on how the data in a serializer's "validated_data" property should be constructed (and that it should be consistent and predictable), but the fact still remains that currently, you cannot use a View with a serializer that defines a nested serializer with required=False.

I'm hoping this fix can make it into the core, so the format/structure/construction of a serializer's "validated_data" properly can be handled as separate issue.