### PR TITLE
Poor's man fix for non-descriptive error message

### DIFF
--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -43,6 +43,9 @@ class Response(SimpleTemplateResponse):
         media_type = getattr(self, 'accepted_media_type', None)
         context = getattr(self, 'renderer_context', None)
 
+        if isinstance(self.data, dict) and self.data.get('error', False):
+            raise self.data['content']
+
         assert renderer, ".accepted_renderer not set on Response"
         assert media_type, ".accepted_media_type not set on Response"
         assert context, ".renderer_context not set on Response"


### PR DESCRIPTION
This is a simple attempt to at least show the right message when rendering an error message.

Probably lots can be done to improve this approach, but now it saves me from errors that does not mean anything.