### PR TITLE
When making datetimes aware, use the active timezone if it exists. Fixes #2850.

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -13,7 +13,6 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import RegexValidator, ip_address_validators
 from django.forms import ImageField as DjangoImageField
-from django.forms.utils import from_current_timezone
 from django.utils import six, timezone
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
 from django.utils.encoding import is_protected_type, smart_text
@@ -29,6 +28,12 @@ from rest_framework.compat import (
 from rest_framework.exceptions import ValidationError
 from rest_framework.settings import api_settings
 from rest_framework.utils import html, humanize_datetime, representation
+
+# django.form.util was renamed in 1.7
+try:
+    from django.forms.utils import from_current_timezone
+except ImportError:
+    from django.forms.util import from_current_timezone
 
 
 class empty:

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -941,6 +941,11 @@ class DateTimeField(Field):
         self.fail('invalid', format=humanized_format)
 
     def to_representation(self, value):
+        if timezone.is_aware(value):
+            # convert the datetime to the timezone the user is expecting
+            tz = getattr(timezone._active, "value", self.default_timezone)
+            value = timezone.localtime(value, tz)
+
         if self.format is None:
             return value
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -29,12 +29,6 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.settings import api_settings
 from rest_framework.utils import html, humanize_datetime, representation
 
-# django.form.util was renamed in 1.7
-try:
-    from django.forms.utils import from_current_timezone
-except ImportError:
-    from django.forms.util import from_current_timezone
-
 
 class empty:
     """
@@ -909,10 +903,10 @@ class DateTimeField(Field):
         When `self.default_timezone` is not `None`, always return aware datetimes.
         """
         if (self.default_timezone is not None) and not timezone.is_aware(value):
-            # If a timezone is active, we want to use it, but if not we want to use the timezone
+            # If a timezone is active we want to use it, but if not we want to use the timezone
             # specified for this field over the system's default timezone.
             if hasattr(timezone._active, 'value'):
-                return from_current_timezone(value)
+                return timezone.make_aware(value, timezone._active.value)
             else:
                 return timezone.make_aware(value, self.default_timezone)
         elif (self.default_timezone is None) and timezone.is_aware(value):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -868,7 +868,7 @@ class TestAwareDateTimeField:
 
     @override_settings(USE_TZ=True)
     def test_with_timezone_active(self):
-        naive_now = timezone.make_naive(timezone.now())
+        naive_now = timezone.make_naive(timezone.now(), timezone.UTC())
         timezone.activate(FakeTimezone())
         field = serializers.DateTimeField(default_timezone=timezone.UTC())
         aware_now = field.enforce_timezone(naive_now)
@@ -877,7 +877,7 @@ class TestAwareDateTimeField:
 
     @override_settings(USE_TZ=True)
     def test_without_timezone_active(self):
-        naive_now = timezone.make_naive(timezone.now())
+        naive_now = timezone.make_naive(timezone.now(), timezone.UTC())
         field = serializers.DateTimeField(default_timezone=timezone.UTC())
         aware_now = field.enforce_timezone(naive_now)
         assert aware_now.tzname() == 'UTC'

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 import django
 import pytest
+from django.test.utils import override_settings
 from django.utils import timezone
 
 import rest_framework
@@ -846,6 +847,40 @@ class TestNoOutputFormatDateField(FieldValues):
         datetime.date(2001, 1, 1): datetime.date(2001, 1, 1)
     }
     field = serializers.DateField(format=None)
+
+
+class FakeTimezone(datetime.tzinfo):
+
+    def __repr__(self):
+        return "<FakeTimezone>"
+
+    def utcoffset(self, dt):
+        return datetime.timedelta(1)
+
+    def tzname(self, dt):
+        return "FakeTimezone"
+
+    def dst(self, dt):
+        return datetime.timedelta(1)
+
+
+class TestAwareDateTimeField:
+
+    @override_settings(USE_TZ=True)
+    def test_with_timezone_active(self):
+        naive_now = timezone.make_naive(timezone.now())
+        timezone.activate(FakeTimezone())
+        field = serializers.DateTimeField(default_timezone=timezone.UTC())
+        aware_now = field.enforce_timezone(naive_now)
+        assert aware_now.tzname() == 'FakeTimezone'
+        timezone.deactivate()
+
+    @override_settings(USE_TZ=True)
+    def test_without_timezone_active(self):
+        naive_now = timezone.make_naive(timezone.now())
+        field = serializers.DateTimeField(default_timezone=timezone.UTC())
+        aware_now = field.enforce_timezone(naive_now)
+        assert aware_now.tzname() == 'UTC'
 
 
 class TestDateTimeField(FieldValues):


### PR DESCRIPTION
Enables DateTimeFields to use the active timezone when interpreting naive DateTimes, as identified in #2850.  If no timezone is active the behavior is unchanged.

I don't like looking at timezone._active, but I don't see another way to check if a timezone is active.