### PR TITLE
Allow passing models.Manager to RelatedField.queryset

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.core.urlresolvers import (
     NoReverseMatch, Resolver404, get_script_prefix, resolve
 )
+from django.db import models
 from django.db.models.query import QuerySet
 from django.utils import six
 from django.utils.encoding import smart_text
@@ -87,7 +88,7 @@ class RelatedField(Field):
 
     def get_queryset(self):
         queryset = self.queryset
-        if isinstance(queryset, QuerySet):
+        if isinstance(queryset, (QuerySet, models.Manager)):
             # Ensure queryset is re-evaluated whenever used.
             queryset = queryset.all()
         return queryset


### PR DESCRIPTION
This will allow django rest framework to work even when `models.Manager` is passed instead of `QuerySet`.

Actually this is kind of workorund to problem that I cant see from where it comes. It raises an error that Manager is not iterable. For some reason model's manager is passed instead of queryset when DRF create fields automatically for my M2MField.

I've solved the problem by checking if queryset is a manager and also execute the `all()` method.

If you think that this is not a good solution I will try to see why manager is passed instead of queryset for the field.