### PR TITLE
Ignore many=True serializer on POST during html form rendering

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -448,6 +448,8 @@ class BrowsableAPIRenderer(BaseRenderer):
                 instance = None
         else:
             instance = None
+            if method == 'POST':
+                serializer = None
 
         # If this is valid serializer data, and the form is for the same
         # HTTP method as was used in the request then use the existing


### PR DESCRIPTION
I've been fighting issue #2918 all afternoon. After finding the (closed!) issue, I started poking at the rest framework code for a simple work-around.

I don't know if this is correct, though it does get me past my problems. This makes get_rendered_html_form ignore the serializer on hand for POST if many=True, and rediscovers what the serializer should be.

Existing tests still pass. Comments welcome.