### PR TITLE
Custom offset cutoff

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -540,7 +540,7 @@ class CursorPagination(BasePagination):
         if not self.has_next:
             return None
 
-        if self.cursor and self.cursor.reverse and self.cursor.offset != 0:
+        if self.cursor and self.cursor.reverse and self.cursor.offset != 0 and self.page:
             # If we're reversing direction and we have an offset cursor
             # then we cannot use the first position we find as a marker.
             compare = self._get_position_from_instance(self.page[-1], self.ordering)
@@ -588,7 +588,7 @@ class CursorPagination(BasePagination):
         if not self.has_previous:
             return None
 
-        if self.cursor and not self.cursor.reverse and self.cursor.offset != 0:
+        if self.cursor and not self.cursor.reverse and self.cursor.offset != 0 and self.page:
             # If we're reversing direction and we have an offset cursor
             # then we cannot use the first position we find as a marker.
             compare = self._get_position_from_instance(self.page[0], self.ordering)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -6,7 +6,7 @@ import pytest
 from rest_framework import (
     exceptions, filters, generics, pagination, serializers, status
 )
-from rest_framework.pagination import PAGE_BREAK, PageLink
+from rest_framework.pagination import PAGE_BREAK, PageLink, Cursor
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
@@ -647,6 +647,16 @@ class TestCursorPagination:
         assert next == [1, 2, 3, 4, 4]
 
         assert isinstance(self.pagination.to_html(), type(''))
+
+    def test_offset_cutoff(self):
+        (previous, current, next, previous_url, next_url) = self.get_pages('/')
+
+        next_url = self.pagination.encode_cursor(Cursor(1050, False, None))
+        (previous, current, next, previous_url, next_url) = self.get_pages(next_url)
+
+        assert previous == [7, 7, 7, 8, 9]
+        assert current == []
+        assert next is None
 
 
 def test_get_displayed_page_numbers():


### PR DESCRIPTION
This allows custom `offset_cutoff` for different sorting.

For example in our project we have large files list with sorting by upload date (with microseconds) and files size. Upload date almost impossible can be the same. So cutoff of 10 is quite enough. On other hand, file size can have very large number of items with duplicated values. And I'd like to set cutoff to 5000, for example.

This also fixes case when offset is set to higher value than number of items is queryset and DRF tries to access page's items when page is empty.