### PR TITLE
Add `get_page_size` hook to `CursorPagination`

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -454,14 +454,6 @@ class CursorPagination(BasePagination):
     # Defaults to `None`, meaning pagination is disabled.
     page_size = api_settings.PAGE_SIZE
 
-    # Client can control the page size using this query parameter.
-    # Default is 'None'. Set to eg 'page_size' to enable usage.
-    page_size_query_param = None
-
-    # Set to an integer to limit the maximum page size the client may request.
-    # Only relevant if 'page_size_query_param' has also been set.
-    max_page_size = None
-
     invalid_cursor_message = _('Invalid cursor')
     ordering = '-created'
     template = 'rest_framework/pagination/previous_and_next.html'
@@ -544,16 +536,6 @@ class CursorPagination(BasePagination):
         return self.page
 
     def get_page_size(self, request):
-        if self.page_size_query_param:
-            try:
-                return _positive_int(
-                    request.query_params[self.page_size_query_param],
-                    strict=True,
-                    cutoff=self.max_page_size
-                )
-            except (KeyError, ValueError):
-                pass
-
         return self.page_size
 
     def get_next_link(self):

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -455,8 +455,8 @@ class CursorPagination(BasePagination):
     template = 'rest_framework/pagination/previous_and_next.html'
 
     def paginate_queryset(self, queryset, request, view=None):
-        self.page_size = self.get_page_size(request)
-        if not self.page_size:
+        page_size = self.get_page_size(request)
+        if not page_size:
             return None
 
         self.base_url = request.build_absolute_uri()
@@ -491,8 +491,8 @@ class CursorPagination(BasePagination):
         # If we have an offset cursor then offset the entire page by that amount.
         # We also always fetch an extra item in order to determine if there is a
         # page following on from this one.
-        results = list(queryset[offset:offset + self.page_size + 1])
-        self.page = list(results[:self.page_size])
+        results = list(queryset[offset:offset + page_size + 1])
+        self.page = list(results[:page_size])
 
         # Determine the position of the final item following the page.
         if len(results) > len(self.page):

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -449,11 +449,7 @@ class CursorPagination(BasePagination):
     http://cramer.io/2011/03/08/building-cursors-for-the-disqus-api/
     """
     cursor_query_param = 'cursor'
-
-    # The default page size.
-    # Defaults to `None`, meaning pagination is disabled.
     page_size = api_settings.PAGE_SIZE
-
     invalid_cursor_message = _('Invalid cursor')
     ordering = '-created'
     template = 'rest_framework/pagination/previous_and_next.html'

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -513,8 +513,6 @@ class TestCursorPagination:
 
         class ExamplePagination(pagination.CursorPagination):
             page_size = 5
-            page_size_query_param = 'page_size'
-            max_page_size = 20
             ordering = 'created'
 
         self.pagination = ExamplePagination()
@@ -649,24 +647,6 @@ class TestCursorPagination:
         assert next == [1, 2, 3, 4, 4]
 
         assert isinstance(self.pagination.to_html(), type(''))
-
-    def test_page_size(self):
-        (previous, current, next, previous_url, next_url) = \
-            self.get_pages('/?page_size=10')
-
-        assert previous is None
-        assert current == [1, 1, 1, 1, 1, 1, 2, 3, 4, 4]
-        assert next == [4, 4, 5, 6, 7, 7, 7, 7, 7, 7]
-        assert 'page_size=10' in next_url
-
-        (previous, current, next, previous_url, next_url) = \
-            self.get_pages(next_url.replace('page_size=10', 'page_size=4'))
-
-        assert previous == [2, 3, 4, 4]
-        assert current == [4, 4, 5, 6]
-        assert next == [7, 7, 7, 7]
-        assert 'page_size=4' in previous_url
-        assert 'page_size=4' in next_url
 
 
 def test_get_displayed_page_numbers():


### PR DESCRIPTION
Allows developers to easily customize support for `page_size` parameters or any other page size behaviors.

The default behavior is left intentionally simple, on the basis that cursor paginations should *tend* to present their query parameters as opaque cursors, and should *tend* to have page sizes determined server side, rather than client side.