### PR TITLE
add default handling of Django ValidationError exceptions

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import inspect
 import warnings
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.utils import six
@@ -90,6 +91,12 @@ def exception_handler(exc, context):
 
         set_rollback()
         return Response(data, status=status.HTTP_403_FORBIDDEN)
+    elif isinstance(exc, DjangoValidationError):
+        msg = _('Validation error.')
+        data = {'detail': exc.messages}
+
+        set_rollback()
+        return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
     # Note: Unhandled exceptions will raise a 500 error.
     return None


### PR DESCRIPTION
As discussed in ticket #3148, this pull request adds handling of Django ValidationError exceptions to the default exception_handler defined in views.py as well as some new unit tests to test it out. While this is useful for rest views that do not map directly to models, it might be tricky to explain since this is not the normal use case for DRF API views. Accordingly I have not attempted to update the doc yet.