### PR TITLE
Add support for QueryDict data in serializers.ListField

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -13,6 +13,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import RegexValidator, ip_address_validators
 from django.forms import ImageField as DjangoImageField
+from django.http.request import QueryDict
 from django.utils import six, timezone
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
 from django.utils.encoding import is_protected_type, smart_text
@@ -1273,6 +1274,8 @@ class ListField(Field):
     def get_value(self, dictionary):
         # We override the default field access in order to support
         # lists in HTML forms.
+        if dictionary.__class__ == QueryDict:
+            return dictionary.getlist(self.field_name, empty)
         if html.is_html_input(dictionary):
             return html.parse_html_list(dictionary, prefix=self.field_name)
         return dictionary.get(self.field_name, empty)


### PR DESCRIPTION
Failing case:

When user uploads multiple images (for example, &lt;input type="file" name="image_files" multiple=""&gt;) and I try to serialize it with:
- image_files = serializers.ListField(child=serializers.FileField(write_only=True))

Serializer fails to evaluate "list of files".

Problem:
https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/fields.py#L1273
```
    # Suppose dictionary.__class__ == QueryDict
    def get_value(self, dictionary):
        # dictionary has attribute 'getlist', so is_html_input returns True
        if html.is_html_input(dictionary):
            # but try to parse it as MultiDict
            return html.parse_html_list(dictionary, prefix=self.field_name)
        return dictionary.get(self.field_name, empty)
```
ListField class doesn't handle QueryDict-typed data properly.

Solution:

I haven't looked up for all codes related to this issue, so my PR is just a naive hotfix. I think there should be more consistent method to handle both QueryDict & MultiDict data types.