### PR TITLE
Removed import of unused django.forms.widgets

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -89,7 +89,6 @@ We'll also need to create an initial migration for our snippet model, and sync t
 
 The first thing we need to get started on our Web API is to provide a way of serializing and deserializing the snippet instances into representations such as `json`.  We can do this by declaring serializers that work very similar to Django's forms.  Create a file in the `snippets` directory named `serializers.py` and add the following.
 
-    from django.forms import widgets
     from rest_framework import serializers
     from snippets.models import Snippet, LANGUAGE_CHOICES, STYLE_CHOICES
 


### PR DESCRIPTION
That import is not used. Widgets are just used in the description text but not in the code.