### PR TITLE
Set a default max_limit based on api_settings

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -341,7 +341,7 @@ class LimitOffsetPagination(BasePagination):
     default_limit = api_settings.PAGE_SIZE
     limit_query_param = 'limit'
     offset_query_param = 'offset'
-    max_limit = None
+    max_limit = api_settings.MAX_PAGINATE_BY
     template = 'rest_framework/pagination/numbers.html'
 
     def paginate_queryset(self, queryset, request, view=None):


### PR DESCRIPTION
With a default of `None`, this can allow for some scary requests, even when `MAX_PAGINATE_BY` is set.  If we set `max_limit` to the global default, the behaviour is more predictable.