### PR TITLE
Put `allow_null` in field metadata

### DIFF
--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -123,7 +123,8 @@ class SimpleMetadata(BaseMetadata):
         attrs = [
             'read_only', 'label', 'help_text',
             'min_length', 'max_length',
-            'min_value', 'max_value'
+            'min_value', 'max_value',
+            'allow_null',
         ]
 
         for attr in attrs:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -106,6 +106,7 @@ class TestMetadata:
                         'type': 'choice',
                         'required': True,
                         'read_only': False,
+                        'allow_null': False,
                         'label': 'Choice field',
                         'choices': [
                             {'display_name': 'red', 'value': 'red'},
@@ -117,6 +118,7 @@ class TestMetadata:
                         'type': 'integer',
                         'required': True,
                         'read_only': False,
+                        'allow_null': False,
                         'label': 'Integer field',
                         'min_value': 1,
                         'max_value': 1000,
@@ -126,6 +128,7 @@ class TestMetadata:
                         'type': 'string',
                         'required': False,
                         'read_only': False,
+                        'allow_null': False,
                         'label': 'Char field',
                         'min_length': 3,
                         'max_length': 40
@@ -134,15 +137,18 @@ class TestMetadata:
                         'type': 'list',
                         'required': True,
                         'read_only': False,
+                        'allow_null': False,
                         'label': 'List field',
                         'child': {
                             'type': 'list',
                             'required': True,
                             'read_only': False,
+                            'allow_null': False,
                             'child': {
                                 'type': 'integer',
                                 'required': True,
-                                'read_only': False
+                                'read_only': False,
+                                'allow_null': False,
                             }
                         }
                     },
@@ -150,18 +156,21 @@ class TestMetadata:
                         'type': 'nested object',
                         'required': True,
                         'read_only': False,
+                        'allow_null': False,
                         'label': 'Nested field',
                         'children': {
                             'a': {
                                 'type': 'integer',
                                 'required': True,
                                 'read_only': False,
+                                'allow_null': False,
                                 'label': 'A'
                             },
                             'b': {
                                 'type': 'integer',
                                 'required': True,
                                 'read_only': False,
+                                'allow_null': False,
                                 'label': 'B'
                             }
                         }
@@ -316,18 +325,21 @@ class TestModelSerializerMetadata(TestCase):
                         'type': 'integer',
                         'required': False,
                         'read_only': True,
+                        'allow_null': False,
                         'label': 'ID'
                     },
                     'children': {
                         'type': 'field',
                         'required': False,
                         'read_only': True,
+                        'allow_null': False,
                         'label': 'Children'
                     },
                     'integer_field': {
                         'type': 'integer',
                         'required': True,
                         'read_only': False,
+                        'allow_null': False,
                         'label': 'Integer field',
                         'min_value': 1,
                         'max_value': 1000
@@ -336,6 +348,7 @@ class TestModelSerializerMetadata(TestCase):
                         'type': 'string',
                         'required': False,
                         'read_only': False,
+                        'allow_null': True,
                         'label': 'Name',
                         'max_length': 100
                     }


### PR DESCRIPTION
Make it possible to see if `allow_null` is `True` for given field when make OPTIONS call.

This is useful when from the frond end I need to decide if I need to send `null` or empty string for particular field.