### PR TITLE
Errors in browsable API on error.

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext
 
 from rest_framework import status
+from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
 
 
 def _force_text_recursive(data):
@@ -22,14 +23,20 @@ def _force_text_recursive(data):
     lazy translation strings into plain text.
     """
     if isinstance(data, list):
-        return [
+        ret = [
             _force_text_recursive(item) for item in data
         ]
+        if isinstance(data, ReturnList):
+            return ReturnList(ret, serializer=data.serializer)
+        return data
     elif isinstance(data, dict):
-        return dict([
+        ret = dict([
             (key, _force_text_recursive(value))
             for key, value in data.items()
         ])
+        if isinstance(data, ReturnDict):
+            return ReturnDict(ret, serializer=data.serializer)
+        return data
     return force_text(data)
 
 

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -204,7 +204,7 @@ class BaseSerializer(Field):
                 self._errors = {}
 
         if self._errors and raise_exception:
-            raise ValidationError(self._errors)
+            raise ValidationError(self.errors)
 
         return not bool(self._errors)
 

--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -72,7 +72,7 @@ class BoundField(object):
         ))
 
     def as_form_field(self):
-        value = force_text(self.value)
+        value = '' if self.value is None else force_text(self.value)
         return self.__class__(self._field, value, self.errors, self._prefix)
 
 
@@ -100,7 +100,7 @@ class NestedBoundField(BoundField):
             if isinstance(value, (list, dict)):
                 values[key] = value
             else:
-                values[key] = force_text(value)
+                values[key] = '' if value is None else force_text(value)
         return self.__class__(self._field, values, self.errors, self._prefix)
 
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -153,7 +153,7 @@ class TestRootView(TestCase):
         request = factory.post('/', data, HTTP_ACCEPT='text/html')
         response = self.view(request).render()
         expected_error = '<span class="help-block">Ensure this field has no more than 100 characters.</span>'
-        self.assertIn(expected_error, response.rendered_content)
+        self.assertIn(expected_error, response.rendered_content.decode('utf-8'))
 
 
 EXPECTED_QUERIES_FOR_PUT = 3 if django.VERSION < (1, 6) else 2
@@ -300,7 +300,7 @@ class TestInstanceView(TestCase):
         request = factory.put('/', data, HTTP_ACCEPT='text/html')
         response = self.view(request, pk=1).render()
         expected_error = '<span class="help-block">Ensure this field has no more than 100 characters.</span>'
-        self.assertIn(expected_error, response.rendered_content)
+        self.assertIn(expected_error, response.rendered_content.decode('utf-8'))
 
 
 class TestFKInstanceView(TestCase):

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -145,6 +145,16 @@ class TestRootView(TestCase):
         created = self.objects.get(id=4)
         self.assertEqual(created.text, 'foobar')
 
+    def test_post_error_root_view(self):
+        """
+        POST requests to ListCreateAPIView in HTML should include a form error.
+        """
+        data = {'text': 'foobar' * 100}
+        request = factory.post('/', data, HTTP_ACCEPT='text/html')
+        response = self.view(request).render()
+        expected_error = '<span class="help-block">Ensure this field has no more than 100 characters.</span>'
+        self.assertIn(expected_error, response.rendered_content)
+
 
 EXPECTED_QUERIES_FOR_PUT = 3 if django.VERSION < (1, 6) else 2
 
@@ -281,6 +291,16 @@ class TestInstanceView(TestCase):
             response = self.view(request, pk=999).render()
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertFalse(self.objects.filter(id=999).exists())
+
+    def test_put_error_instance_view(self):
+        """
+        Incorrect PUT requests in HTML should include a form error.
+        """
+        data = {'text': 'foobar' * 100}
+        request = factory.put('/', data, HTTP_ACCEPT='text/html')
+        response = self.view(request, pk=1).render()
+        expected_error = '<span class="help-block">Ensure this field has no more than 100 characters.</span>'
+        self.assertIn(expected_error, response.rendered_content)
 
 
 class TestFKInstanceView(TestCase):


### PR DESCRIPTION
Closes #3024.
Refs #2926.

Example:

![image](https://cloud.githubusercontent.com/assets/647359/8851578/41f3849a-3148-11e5-8b6e-901ea835dac6.png)
