### PR TITLE
Guard against erroneous direct .queryset evaluation in CBVs.

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -119,7 +119,7 @@ class APIView(View):
         This allows us to discover information about the view when we do URL
         reverse lookups.  Used for breadcrumb generation.
         """
-        if isinstance(getattr(cls, 'queryset', None), models.QuerySet):
+        if isinstance(getattr(cls, 'queryset', None), models.query.QuerySet):
             def force_evaluation():
                 raise AssertionError(
                     'Do not evaluate the `.queryset` attribute directly, '

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -126,8 +126,8 @@ class APIView(View):
                     'as the result will be cached and reused between requests. '
                     'Use `.all()` or call `.get_queryset()` instead.'
                 )
-
             cls.queryset._fetch_all = force_evaluation
+            cls.queryset._result_iter = force_evaluation  # Django <= 1.5
 
         view = super(APIView, cls).as_view(**initkwargs)
         view.cls = cls


### PR DESCRIPTION
For further consideration...

Evaluating the results for `.queryset` on a CBV is an error as it'll be cached and returned between requests. We could explicitly guard against this.