### PR TITLE
Correct API ROOT to enable parametered urls

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -291,6 +291,7 @@ class DefaultRouter(SimpleRouter):
                     try:
                         ret[key] = reverse(
                             url_name,
+                            kwargs=kwargs,
                             request=request,
                             format=kwargs.get('format', None)
                         )

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -291,6 +291,7 @@ class DefaultRouter(SimpleRouter):
                     try:
                         ret[key] = reverse(
                             url_name,
+                            args=args,
                             kwargs=kwargs,
                             request=request,
                             format=kwargs.get('format', None)


### PR DESCRIPTION
Hi all,

This small modification is needed to be able to completely build parametered urls in the API Root.