### PR TITLE
Fix weird search behavior

### DIFF
--- a/docs_theme/base.html
+++ b/docs_theme/base.html
@@ -69,7 +69,7 @@
           </div>
 
           <div class="modal-body">
-            <form role="form">
+            <form role="form" autocomplete="off">
               <div class="form-group">
                 <input type="text" name="q" class="form-control" placeholder="Search..." id="mkdocs-search-query">
               </div>

--- a/docs_theme/js/theme.js
+++ b/docs_theme/js/theme.js
@@ -1,35 +1,35 @@
-function getSearchTerm()
-{
-    var sPageURL = window.location.search.substring(1);
-    var sURLVariables = sPageURL.split('&');
-    for (var i = 0; i < sURLVariables.length; i++)
-    {
-        var sParameterName = sURLVariables[i].split('=');
-        if (sParameterName[0] == 'q')
-        {
-            return sParameterName[1];
-        }
+var getSearchTerm = function() {
+  var sPageURL = window.location.search.substring(1);
+  var sURLVariables = sPageURL.split('&');
+  for (var i = 0; i < sURLVariables.length; i++) {
+    var sParameterName = sURLVariables[i].split('=');
+    if (sParameterName[0] === 'q') {
+      return sParameterName[1];
     }
-}
+  }
+};
+
+var initilizeSearch = function() {
+  require.config({ baseUrl: '/mkdocs/js' });
+  require(['search']);
+};
 
 $(function() {
+  var searchTerm = getSearchTerm(),
+    $searchModal = $('#mkdocs_search_modal'),
+    $searchQuery = $searchModal.find('#mkdocs-search-query'),
+    $searchResults = $searchModal.find('#mkdocs-search-results');
 
-    var initialise_search = function(){
-        require.config({"baseUrl":"/mkdocs/js"});
-        require(["search",]);
-    }
+  $('pre code').parent().addClass('prettyprint well');
 
-    var search_term = getSearchTerm();
-    if(search_term){
-        $('#mkdocs_search_modal').modal();
-    }
+  if (searchTerm) {
+    $searchQuery.val(searchTerm);
+    $searchResults.text('Searching...');
+    $searchModal.modal();
+  }
 
-    $('pre code').parent().addClass('prettyprint well');
-
-    $(document).on("submit", "#mkdocs_search_modal form", function (e) {
-        $("#mkdocs-search-results").html("Searching...");
-        initialise_search();
-        return false;
-    });
-
+  $searchModal.on('shown', function() {
+    $searchQuery.focus();
+    initilizeSearch();
+  });
 });


### PR DESCRIPTION
Steps:

1. Click on search button at the top
2. Type search term
3. Hit return. "Searching..." text shows. No results show.
4. Hit return again. Results show up.

Problem seemed to be with how we were deferring requiring mkdocs search index after hitting return. I changed it to initialize after the modal's shown event has triggered.

![untitled](https://cloud.githubusercontent.com/assets/83319/8973957/c589eeca-3639-11e5-98b8-03a9d80d7004.gif)
