### PR TITLE
Add package reference to docs: DRY Rest Permissions

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -251,6 +251,10 @@ The [Composed Permissions][composed-permissions] package provides a simple way t
 
 The [REST Condition][rest-condition] package is another extension for building complex permissions in a simple and convenient way.  The extension allows you to combine permissions with logical operators.
 
+## DRY Rest Permissions
+
+The [DRY Rest Permissions][dry-rest-permissions] package provides the ability to define different permissions for individual default and custom actions. This package is made for apps with permissions that are derived from relationships defined in the app's data model. It also supports permission checks being returned to a client app through the API's serializer. Additionally it supports adding permissions to the default and custom list actions to restrict the data they retrive per user.
+
 [cite]: https://developer.apple.com/library/mac/#documentation/security/Conceptual/AuthenticationAndAuthorizationGuide/Authorization/Authorization.html
 [authentication]: authentication.md
 [throttling]: throttling.md
@@ -264,3 +268,4 @@ The [REST Condition][rest-condition] package is another extension for building c
 [drf-any-permissions]: https://github.com/kevin-brown/drf-any-permissions
 [composed-permissions]: https://github.com/niwibe/djangorestframework-composed-permissions
 [rest-condition]: https://github.com/caxap/rest_condition
+[dry-rest-permissions]: https://github.com/Helioscene/dry-rest-permissions

--- a/docs/topics/third-party-resources.md
+++ b/docs/topics/third-party-resources.md
@@ -195,6 +195,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 * [drf-any-permissions][drf-any-permissions] - Provides alternative permission handling.
 * [djangorestframework-composed-permissions][djangorestframework-composed-permissions] - Provides a simple way to define complex permissions.
 * [rest_condition][rest-condition] - Another extension for building complex permissions in a simple and convenient way.
+* [dry-rest-permissions][dry-rest-permissions] - Provides a simple way to define permissions for individual api actions.
 
 ### Serializers
 
@@ -341,3 +342,4 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [cdrf.co]:http://www.cdrf.co
 [drf-tracking]: https://github.com/aschn/drf-tracking
 [django-rest-framework-braces]: https://github.com/dealertrack/django-rest-framework-braces
+[dry-rest-permissions]: https://github.com/Helioscene/dry-rest-permissions


### PR DESCRIPTION
This pull request is to add our new package, DRY Rest Permissions, to the drf documentation.
https://github.com/Helioscene/dry-rest-permissions

This is a package that allows developers to define permissions for individual api actions and also return permission check results to a client app through a serializer.