### PR TITLE
Fix custom HyperlinkedRelatedField example

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -498,10 +498,10 @@ For example, if all your object URLs used both a account and a slug in the the U
             kwargs = {'account': obj.account, 'slug': obj.slug}
             return reverse(view_name, kwargs=kwargs, request=request, format=format)
 
-        def get_object(self, queryset, view_name, view_args, view_kwargs):
+        def get_object(self, view_name, view_args, view_kwargs):
             account = view_kwargs['account']
             slug = view_kwargs['slug']
-            return queryset.get(account=account, slug=slug)
+            return self.get_queryset().get(account=account, slug=slug)
 
 ---
 


### PR DESCRIPTION
Fix `get_object` method signature to match [`HyperlinkedRelatedField.get_object`](https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/relations.py#L227-L236).