### PR TITLE
Report test coverage via Codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-branch = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,7 @@ install:
 
 script:
     - tox -e $TOX_ENV
+
+after_success:
+    - pip install codecov
+    - codecov

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # [Django REST framework][docs]
 
 [![build-status-image]][travis]
+[![coverage-status-image]][codecov]
 [![pypi-version]][pypi]
 
 **Awesome web-browsable Web APIs.**
@@ -159,6 +160,8 @@ Send a description of the issue via email to [rest-framework-security@googlegrou
 
 [build-status-image]: https://secure.travis-ci.org/tomchristie/django-rest-framework.svg?branch=master
 [travis]: http://travis-ci.org/tomchristie/django-rest-framework?branch=master
+[coverage-status-image]: http://codecov.io/github/tomchristie/django-rest-framework/coverage.svg?branch=master
+[codecov]: http://codecov.io/github/tomchristie/django-rest-framework?branch=master
 [pypi-version]: https://img.shields.io/pypi/v/djangorestframework.svg
 [pypi]: https://pypi.python.org/pypi/djangorestframework
 [twitter]: https://twitter.com/_tomchristie

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
        {py27,py32,py33,py34}-django{17,18,master}
 
 [testenv]
-commands = ./runtests.py --fast {posargs}
+commands = ./runtests.py --fast {posargs} --coverage
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =


### PR DESCRIPTION
**Full disclosure**: I work for Codecov

Changes:
- Measure code coverage in tox
- Report code coverage to [Codecov][]
- When using coverage.py, always measure branch coverage

Coveralls support was discussed in #3107 (which was closed until #2936 was resolved).

Here are a few reasons you might prefer Codecov over Coveralls:

- The reports are easier to navigate (Codecov uses a tree view by default, like GitHub)
- Codecov has a browser plugin for viewing coverage overlaid on GitHub
- Codecov supports branch coverage (this is the sole reason I switched my projects to Codecov initially)

[Here's an example Codecov report for django-rest-framework][example]

If enabling coverage in all tox environments is undesirable, we could probably enable it conditionally based on an environment variable or command-line switch.

[codecov]: https://codecov.io/
[example]: https://codecov.io/github/treyhunner/django-rest-framework?branch=add-codecov