### PR TITLE
Fixed #3235 - ListField now returns the QueryDict value even if it's a list of only one item.

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1384,7 +1384,7 @@ class ListField(Field):
         # lists in HTML forms.
         if html.is_html_input(dictionary):
             val = dictionary.getlist(self.field_name, [])
-            if len(val) > 1:
+            if len(val) > 0:
                 # Support QueryDict lists in HTML input.
                 return val
             return html.parse_html_list(dictionary, prefix=self.field_name)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -317,6 +317,14 @@ class TestHTMLInput:
         assert serializer.is_valid()
         assert serializer.validated_data == {'scores': [1, 3]}
 
+    def test_querydict_list_input_only_one_input(self):
+        class TestSerializer(serializers.Serializer):
+            scores = serializers.ListField(child=serializers.IntegerField())
+
+        serializer = TestSerializer(data=QueryDict('scores=1&'))
+        assert serializer.is_valid()
+        assert serializer.validated_data == {'scores': [1]}
+
 
 class TestCreateOnlyDefault:
     def setup(self):


### PR DESCRIPTION
Closes: #3235

- 08d60f5 provides the failing test.
- 0078f66 implements the fix which lets the tests pass.

Tested against CPython 2.7 via `./runtests.py`