### PR TITLE
Fix comment around importing exception best practices

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -59,11 +59,11 @@ class APIException(Exception):
 
 
 # The recommended style for using `ValidationError` is to keep it namespaced
-# under `serializers`, in order to minimize potential confusion with Django's
+# under `exceptions`, in order to minimize potential confusion with Django's
 # built in `ValidationError`. For example:
 #
-# from rest_framework import serializers
-# raise serializers.ValidationError('Value was invalid')
+# from rest_framework import exceptions
+# raise exceptions.ValidationError('Value was invalid')
 
 class ValidationError(APIException):
     status_code = status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
The code in the comment suggests importing `serializers` to use `ValidationError` which does not work. Changed to `exceptions`.

Cheers!