### PR TITLE
Duplicated IPAddressField validation errors

### DIFF
--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -344,6 +344,22 @@ class TestDurationFieldMapping(TestCase):
         self.assertEqual(unicode_repr(TestSerializer()), expected)
 
 
+class TestGenericIPAddressFieldValidation(TestCase):
+    def test_ip_address_validation(self):
+        class IPAddressFieldModel(models.Model):
+            address = models.GenericIPAddressField()
+
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = IPAddressFieldModel
+
+        s = TestSerializer(data={'address': 'not an ip address'})
+        self.assertFalse(s.is_valid())
+        self.assertEquals(1, len(s.errors['address']),
+                          'Unexpected number of validation errors: '
+                          '{0}'.format(s.errors))
+
+
 # Tests for relational field mappings.
 # ------------------------------------
 


### PR DESCRIPTION
Using the ModelSerializer with a model containing a GenericIPAddressField
produces duplicated validation error messages.