### PR TITLE
Add a method to return the string value used in `choices` of a `RelatedField`

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -537,6 +537,14 @@ If you explicitly specify a relational field pointing to a
 ``ManyToManyField`` with a through model, be sure to set ``read_only``
 to ``True``.
 
+## The `display_value` method
+
+The `__str__` (`__unicode__` on Python 2) method of the model will be called to generate string representations of the objects used to populate the `choices` property. To provide customized representations, override `display_value` of a `RelatedField` subclass. This method will receive a model object, and should return a string suitable for representing it. For example:
+
+    class TrackPrimaryKeyRelatedField(serializers.PrimaryKeyRelatedField):
+        def display_value(self, instance):
+            return 'Track: %s' % (instance.title)
+
 ---
 
 # Third Party Packages

--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -539,7 +539,7 @@ to ``True``.
 
 ## The `display_value` method
 
-The `__str__` (`__unicode__` on Python 2) method of the model will be called to generate string representations of the objects used to populate the `choices` property. To provide customized representations, override `display_value` of a `RelatedField` subclass. This method will receive a model object, and should return a string suitable for representing it. For example:
+The `__str__` (`__unicode__` on Python 2) method of the model will be called to generate string representations of the objects used to populate the `choices` property. These choices are used to populate select HTML inputs in the browsable API. To provide customized representations for such inputs, override `display_value` of a `RelatedField` subclass. This method will receive a model object, and should return a string suitable for representing it. For example:
 
     class TrackPrimaryKeyRelatedField(serializers.PrimaryKeyRelatedField):
         def display_value(self, instance):

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -148,7 +148,7 @@ class RelatedField(Field):
         return OrderedDict([
             (
                 six.text_type(self.to_representation(item)),
-                six.text_type(self.display_value(item))
+                self.display_value(item)
             )
             for item in queryset
         ])

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -148,7 +148,7 @@ class RelatedField(Field):
         return OrderedDict([
             (
                 six.text_type(self.to_representation(item)),
-                six.text_type(item)
+                six.text_type(self.display_value(item))
             )
             for item in queryset
         ])
@@ -159,6 +159,9 @@ class RelatedField(Field):
 
     def iter_options(self):
         return iter_options(self.grouped_choices)
+
+    def display_value(self, instance):
+        return six.text_type(instance)
 
 
 class StringRelatedField(RelatedField):


### PR DESCRIPTION
Issue #3254 