### PR TITLE
Allow format suffixes after trailing slash

### DIFF
--- a/rest_framework/urlpatterns.py
+++ b/rest_framework/urlpatterns.py
@@ -23,7 +23,10 @@ def apply_suffix_patterns(urlpatterns, suffix_pattern, suffix_required):
 
         else:
             # Regular URL pattern
-            regex = urlpattern.regex.pattern.rstrip('$').rstrip('/') + suffix_pattern
+            regex = urlpattern.regex.pattern.rstrip('$')
+            if regex[-1:] == '/':
+                regex += '?'
+            regex += suffix_pattern
             view = urlpattern._callback or urlpattern._callback_str
             kwargs = urlpattern.default_args
             name = urlpattern.name

--- a/tests/test_urlpatterns.py
+++ b/tests/test_urlpatterns.py
@@ -47,7 +47,7 @@ class FormatSuffixTests(TestCase):
 
         test_paths = [
             (URLTestPath('/test.api', (), {'format': 'api'}), True),
-            (URLTestPath('/test/.api', (), {'format': 'api'}), False),
+            (URLTestPath('/test/.api', (), {'format': 'api'}), True),
             (URLTestPath('/test.api/', (), {'format': 'api'}), True),
         ]
 


### PR DESCRIPTION
This commit https://github.com/tomchristie/django-rest-framework/commit/e7e5946c2ec65fd9e50053ed427cc7b938917785 removed the ability to use format suffixes after trailing slashes like:
http://example.com/api/items/4/.json

This conflicts with the tutorial at:
http://www.django-rest-framework.org/tutorial/2-requests-and-responses/#adding-optional-format-suffixes-to-our-urls.

This pull request adds back in the ability to use format suffixes after slashes but I couldn't find references to why the original removal was made so maybe the tutorial should be updated instead.