### PR TITLE
Introduced immutable serializers for performance sensetive APIs

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -278,6 +278,7 @@ class Field(object):
         self.help_text = help_text
         self.style = {} if style is None else style
         self.allow_null = allow_null
+        self.is_bound = False
 
         if self.default_empty_html is not empty:
             if default is not empty:
@@ -302,6 +303,9 @@ class Field(object):
         Initializes the field name and parent for the field instance.
         Called when a field is added to the parent serializer instance.
         """
+
+        if self.is_bound:
+            return
 
         # In order to enforce a consistent style, we error if a redundant
         # 'source' argument has been used. For example:
@@ -330,6 +334,8 @@ class Field(object):
             self.source_attrs = []
         else:
             self.source_attrs = self.source.split('.')
+
+        self.is_bound = True
 
     # .validators is a lazily loaded property, that gets its default
     # value from `get_validators`.

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -792,7 +792,7 @@ class ModelSerializer(Serializer):
     # views, to correctly handle the 'Location' response header for
     # "HTTP 201 Created" responses.
     url_field_name = api_settings.URL_FIELD_NAME
-    
+
     @cached_property
     def _depth(self):
         return getattr(self.Meta, 'depth', 0)
@@ -898,7 +898,7 @@ class ModelSerializer(Serializer):
 
     def _get_serializer_fields_from_declared_fields(self, declared_fields, depth):
         model = getattr(self.Meta, 'model')
-        
+
         # Retrieve metadata about fields & relationships on the model class.
         info = model_meta.get_field_info(model)
         field_names = self.get_field_names(declared_fields, info)


### PR DESCRIPTION
The immutable serializers do not copy the fields each time they are instantiated and they don't not bind the field every time.
This reduces the serialization overhead a lot.
This PR does not include tests or documentation yet and is created for discussion.