### PR TITLE
Declare the default validators as an empty tuple for faster copying

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -247,7 +247,7 @@ class Field(object):
         'required': _('This field is required.'),
         'null': _('This field may not be null.')
     }
-    default_validators = []
+    default_validators = ()
     default_empty_html = empty
     initial = None
 


### PR DESCRIPTION
Copying a tuple is way faster than copying a list since tuples are immutable.

Microbenchmark:
```
In [25]: %timeit ()[:]
10000000 loops, best of 3: 29.9 ns per loop

In [26]: %timeit [][:]
10000000 loops, best of 3: 47.9 ns per loop

In [27]: %timeit (1,2,3,4,5,6,7)[:]
The slowest run took 63.88 times longer than the fastest. This could mean that an intermediate result is being cached 
10000000 loops, best of 3: 29.9 ns per loop

In [28]: %timeit [1,2,3,4,5,6,7][:]
The slowest run took 24.33 times longer than the fastest. This could mean that an intermediate result is being cached 
1000000 loops, best of 3: 167 ns per loop

In [29]: %timeit (1,2,3,4,5,6,7,'gfd')[:]
10000000 loops, best of 3: 29.7 ns per loop

In [30]: %timeit [1,2,3,4,5,6,7,'gfd'][:]
The slowest run took 21.99 times longer than the fastest. This could mean that an intermediate result is being cached 
1000000 loops, best of 3: 173 ns per loop
```