### PR TITLE
Cached the field's root and context property

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -17,6 +17,7 @@ from django.forms import ImageField as DjangoImageField
 from django.utils import six, timezone
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
 from django.utils.encoding import is_protected_type, smart_text
+from django.utils.functional import cached_property
 from django.utils.ipv6 import clean_ipv6_address
 from django.utils.translation import ugettext_lazy as _
 
@@ -522,7 +523,7 @@ class Field(object):
         message_string = msg.format(**kwargs)
         raise ValidationError(message_string)
 
-    @property
+    @cached_property
     def root(self):
         """
         Returns the top-level serializer for this field.
@@ -532,7 +533,7 @@ class Field(object):
             root = root.parent
         return root
 
-    @property
+    @cached_property
     def context(self):
         """
         Returns the context as passed to the root serializer on initialization.


### PR DESCRIPTION
There's no need to recalculate them every time they are accessed.