### PR TITLE
Added explicit id field in multi update example

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -747,6 +747,8 @@ To support multiple updates you'll need to do so explicitly. When writing your m
 * How should insertions be handled? Are they invalid, or do they create new objects?
 * How should removals be handled? Do they imply object deletion, or removing a relationship? Should they be silently ignored, or are they invalid?
 * How should ordering be handled? Does changing the position of two items imply any state change or is it ignored?
+ 
+You will need to add an explicit `id` field to the instance serializer. The default implicitly-generated `id` field is marked as `read_only`. This causes it to be removed on updates. Once you declare it explicitly, it will be available in the list serializer's `update` method.
 
 Here's an example of how you might choose to implement multiple updates:
 
@@ -774,10 +776,7 @@ Here's an example of how you might choose to implement multiple updates:
 
     class BookSerializer(serializers.Serializer):
         ...
-        id = serializers.IntegerField(
-            read_only=False,
-            required=False
-        )
+        id = serializers.IntegerField(required=False)
     
         class Meta:
             list_serializer_class = BookListSerializer

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -774,6 +774,11 @@ Here's an example of how you might choose to implement multiple updates:
 
     class BookSerializer(serializers.Serializer):
         ...
+        id = serializers.IntegerField(
+            read_only=False,
+            required=False
+        )
+    
         class Meta:
             list_serializer_class = BookListSerializer
 


### PR DESCRIPTION
If the id field is implicitly created, it is created as `read_only=True`. This causes the data validation step to remove the id values in the validated data.