### PR TITLE
Add import to example for filtering

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -163,6 +163,7 @@ For more advanced filtering requirements you can specify a `FilterSet` class tha
     import django_filters
     from myapp.models import Product
     from myapp.serializers import ProductSerializer
+    from rest_framework import filters
     from rest_framework import generics
 
     class ProductFilter(django_filters.FilterSet):


### PR DESCRIPTION
`from rest_framework import filters` was missing from one of the examples