### PR TITLE
Raise error when `source=` use on a child.

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1381,7 +1381,13 @@ class ListField(Field):
     def __init__(self, *args, **kwargs):
         self.child = kwargs.pop('child', copy.deepcopy(self.child))
         self.allow_empty = kwargs.pop('allow_empty', True)
+
         assert not inspect.isclass(self.child), '`child` has not been instantiated.'
+        assert self.child.source is None, (
+            "The `source` argument is not meaningful when applied to a `child=` field. "
+            "Remove `source=` from the field declaration."
+        )
+
         super(ListField, self).__init__(*args, **kwargs)
         self.child.bind(field_name='', parent=self)
 
@@ -1424,7 +1430,13 @@ class DictField(Field):
 
     def __init__(self, *args, **kwargs):
         self.child = kwargs.pop('child', copy.deepcopy(self.child))
+
         assert not inspect.isclass(self.child), '`child` has not been instantiated.'
+        assert self.child.source is None, (
+            "The `source` argument is not meaningful when applied to a `child=` field. "
+            "Remove `source=` from the field declaration."
+        )
+
         super(DictField, self).__init__(*args, **kwargs)
         self.child.bind(field_name='', parent=self)
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1416,6 +1416,15 @@ class TestListField(FieldValues):
     ]
     field = serializers.ListField(child=serializers.IntegerField())
 
+    def test_no_source_on_child(self):
+        with pytest.raises(AssertionError) as exc_info:
+            serializers.ListField(child=serializers.IntegerField(source='other'))
+
+        assert str(exc_info.value) == (
+            "The `source` argument is not meaningful when applied to a `child=` field. "
+            "Remove `source=` from the field declaration."
+        )
+
 
 class TestEmptyListField(FieldValues):
     """
@@ -1460,6 +1469,15 @@ class TestDictField(FieldValues):
         ({'a': 1, 'b': '2', 3: 3}, {'a': '1', 'b': '2', '3': '3'}),
     ]
     field = serializers.DictField(child=serializers.CharField())
+
+    def test_no_source_on_child(self):
+        with pytest.raises(AssertionError) as exc_info:
+            serializers.DictField(child=serializers.CharField(source='other'))
+
+        assert str(exc_info.value) == (
+            "The `source` argument is not meaningful when applied to a `child=` field. "
+            "Remove `source=` from the field declaration."
+        )
 
 
 class TestUnvalidatedDictField(FieldValues):


### PR DESCRIPTION
Closes #3292