### PR TITLE
Update ModelSerializer fields behavior

### DIFF
--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -321,6 +321,21 @@ class TestRegularFieldMappings(TestCase):
 
         ExampleSerializer()
 
+    def test_fields_and_exclude_behavior(self):
+        class ImplicitFieldsSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = RegularFieldsModel
+
+        class ExplicitFieldsSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = RegularFieldsModel
+                fields = '__all__'
+
+        implicit = ImplicitFieldsSerializer()
+        explicit = ExplicitFieldsSerializer()
+
+        assert implicit.data == explicit.data
+
 
 @pytest.mark.skipif(django.VERSION < (1, 8),
                     reason='DurationField is only available for django1.8+')


### PR DESCRIPTION
Ref #3335

`ModelSerializer`s without explicit `fields` or `exclude` will raise an exception in the future similar to what Django `ModelForm`s do.

According to https://github.com/tomchristie/django-rest-framework/issues/3335#issuecomment-135460961 the deprecation path might be as follows:

> - 3.3 is compatible with 3.2 and add a `PendingDeprecationWarning`
- 3.4 would escalate these warnings to DeprecationWarning, which is loud by default.
- 3.5 would remove the deprecated bits of API entirely.