### PR TITLE
Update ModelSerializer fields behavior

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -483,6 +483,12 @@ The names in the `fields` option will normally map to model fields on the model 
 
 Alternatively names in the `fields` options can map to properties or methods which take no arguments that exist on the model class.
 
+---
+
+**Note**: Before version 3.3, the `'__all__'` shortcut did not exist, but omitting the fields attribute had the same effect. Omitting both fields and exclude is now deprecated, but will continue to work as before until version 3.5
+
+---
+
 ## Specifying nested serialization
 
 The default `ModelSerializer` uses primary keys for relationships, but you can also easily generate nested representations using the `depth` option:

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -453,14 +453,31 @@ To do so, open the Django shell, using `python manage.py shell`, then import the
 
 ## Specifying which fields to include
 
-If you only want a subset of the default fields to be used in a model serializer, you can do so using `fields` or `exclude` options, just as you would with a `ModelForm`.
+It is strongly recommended that you explicitly set all fields that should be edited in the serializer using the `fields` attribute. Failure to do so can easily lead to security problems when a serializer unexpectedly allows a user to set certain fields, especially when new fields are added to a model.
+
+The alternative approach would be to include all fields automatically, or blacklist only some. This fundamental approach is known to be much less secure and has led to serious exploits on major websites (e.g. [GitHub][github-vuln-blog]).
+
+There are, however, two shortcuts available for cases where you can guarantee these security concerns do not apply to you:
+
+1. Set the `fields` attribute to the special value `'__all__'` to indicate that all fields in the model should be used.
 
 For example:
 
     class AccountSerializer(serializers.ModelSerializer):
         class Meta:
             model = Account
-            fields = ('id', 'account_name', 'users', 'created')
+            fields = '__all__'
+
+2. Set the exclude attribute of the ModelForm’s inner Meta class to a list of fields to be excluded from the form.
+
+For example:
+
+    class AccountSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = Account
+            exclude = 'users'
+
+In the example above, if the `Account` model had 3 fields `account_name`, `users`, and `created`, this will result in the fields `account_name` and `created` to be serialized.
 
 The names in the `fields` option will normally map to model fields on the model class.
 
@@ -1035,6 +1052,7 @@ The [django-rest-framework-gis][django-rest-framework-gis] package provides a `G
 The [django-rest-framework-hstore][django-rest-framework-hstore] package provides an `HStoreSerializer` to support [django-hstore][django-hstore] `DictionaryField` model field and its `schema-mode` feature.
 
 [cite]: https://groups.google.com/d/topic/django-users/sVFaOfQi4wY/discussion
+[github-vuln-blog]: https://github.com/blog/1068-public-key-security-vulnerability-and-mitigation
 [relations]: relations.md
 [model-managers]: https://docs.djangoproject.com/en/dev/topics/db/managers/
 [encapsulation-blogpost]: http://www.dabapps.com/blog/django-models-and-encapsulation/

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -432,6 +432,7 @@ Declaring a `ModelSerializer` looks like this:
     class AccountSerializer(serializers.ModelSerializer):
         class Meta:
             model = Account
+            fields = ('id', 'account_name', 'users', 'created')
 
 By default, all the model fields on the class will be mapped to a corresponding serializer fields.
 
@@ -453,13 +454,16 @@ To do so, open the Django shell, using `python manage.py shell`, then import the
 
 ## Specifying which fields to include
 
-It is strongly recommended that you explicitly set all fields that should be edited in the serializer using the `fields` attribute. Failure to do so can easily lead to security problems when a serializer unexpectedly allows a user to set certain fields, especially when new fields are added to a model.
+If you only want a subset of the default fields to be used in a model serializer, you can do so using `fields` or `exclude` options, just as you would with a `ModelForm`. It is strongly recommended that you explicitly set all fields that should be serialized using the `fields` attribute. This will make it less likely to result in unintentionally exposing data when your models change.
 
-The alternative approach would be to include all fields automatically, or blacklist only some. This fundamental approach is known to be much less secure and has led to serious exploits on major websites (e.g. [GitHub][github-vuln-blog]).
+For example:
 
-There are, however, two shortcuts available for cases where you can guarantee these security concerns do not apply to you:
+    class AccountSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = Account
+            fields = ('id', 'account_name', 'users', 'created')
 
-1. Set the `fields` attribute to the special value `'__all__'` to indicate that all fields in the model should be used.
+You can also set the `fields` attribute to the special value `'__all__'` to indicate that all fields in the model should be used.
 
 For example:
 
@@ -468,26 +472,20 @@ For example:
             model = Account
             fields = '__all__'
 
-2. Set the exclude attribute of the ModelForm’s inner Meta class to a list of fields to be excluded from the form.
+You can set the `exclude` attribute of the to a list of fields to be excluded from the serializer.
 
 For example:
 
     class AccountSerializer(serializers.ModelSerializer):
         class Meta:
             model = Account
-            exclude = 'users'
+            exclude = ('users',)
 
 In the example above, if the `Account` model had 3 fields `account_name`, `users`, and `created`, this will result in the fields `account_name` and `created` to be serialized.
 
-The names in the `fields` option will normally map to model fields on the model class.
+The names in the `fields` and `exclude` attributes will normally map to model fields on the model class.
 
 Alternatively names in the `fields` options can map to properties or methods which take no arguments that exist on the model class.
-
----
-
-**Note**: Before version 3.3, the `'__all__'` shortcut did not exist, but omitting the fields attribute had the same effect. Omitting both fields and exclude is now deprecated, but will continue to work as before until version 3.5
-
----
 
 ## Specifying nested serialization
 
@@ -1058,7 +1056,6 @@ The [django-rest-framework-gis][django-rest-framework-gis] package provides a `G
 The [django-rest-framework-hstore][django-rest-framework-hstore] package provides an `HStoreSerializer` to support [django-hstore][django-hstore] `DictionaryField` model field and its `schema-mode` feature.
 
 [cite]: https://groups.google.com/d/topic/django-users/sVFaOfQi4wY/discussion
-[github-vuln-blog]: https://github.com/blog/1068-public-key-security-vulnerability-and-mitigation
 [relations]: relations.md
 [model-managers]: https://docs.djangoproject.com/en/dev/topics/db/managers/
 [encapsulation-blogpost]: http://www.dabapps.com/blog/django-models-and-encapsulation/

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -321,6 +321,21 @@ class TestRegularFieldMappings(TestCase):
 
         ExampleSerializer()
 
+    def test_fields_and_exclude_behavior(self):
+        class ImplicitFieldsSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = RegularFieldsModel
+
+        class ExplicitFieldsSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = RegularFieldsModel
+                fields = '__all__'
+
+        implicit = ImplicitFieldsSerializer()
+        explicit = ExplicitFieldsSerializer()
+
+        assert implicit.data == explicit.data
+
 
 @pytest.mark.skipif(django.VERSION < (1, 8),
                     reason='DurationField is only available for django1.8+')


### PR DESCRIPTION
Ref #3335

`ModelSerializer`s without explicit `fields` or `exclude` will raise an exception in the future similar to what Django `ModelForm`s do.

According to https://github.com/tomchristie/django-rest-framework/issues/3335#issuecomment-135460961 the deprecation path might be as follows:

> - 3.3 is compatible with 3.2 and add a `PendingDeprecationWarning`
- 3.4 would escalate these warnings to DeprecationWarning, which is loud by default.
- 3.5 would remove the deprecated bits of API entirely.