### PR TITLE
backport of #2492 from tomchristie ref #1850: _closable_objects as an…

### DIFF
--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -91,4 +91,5 @@ class Response(SimpleTemplateResponse):
         for key in ('accepted_renderer', 'renderer_context', 'data'):
             if key in state:
                 del state[key]
+        state['_closable_objects'] = []
         return state


### PR DESCRIPTION
I'm stuck with a 2.4.x version of DRF in production and would appreciate if you could merge this backport that fixes a problem with DRF and caching into the legacy branch.
Thank you.