### PR TITLE
Replacing self.tag with self.tag_name in Generic Relationships documentation.

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -501,7 +501,7 @@ For example, given the following model for a tag, which has a generic relationsh
         tagged_object = GenericForeignKey('content_type', 'object_id')
 
         def __unicode__(self):
-            return self.tag
+            return self.tag_name
 
 And the following two models, which may be have associated tags:
 


### PR DESCRIPTION
Closes #3357.

![django_rest_generic_relationships](https://cloud.githubusercontent.com/assets/3136908/9637437/9dc16580-5155-11e5-8c67-fcab16b7d9e9.jpg)
