### PR TITLE
DurationField accepts integers

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1189,7 +1189,7 @@ class DurationField(Field):
     def to_internal_value(self, value):
         if isinstance(value, datetime.timedelta):
             return value
-        parsed = parse_duration(value)
+        parsed = parse_duration(six.text_type(value))
         if parsed is not None:
             return parsed
         self.fail('invalid', format='[DD] [HH:[MM:]]ss[.uuuuuu]')

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1069,6 +1069,7 @@ class TestDurationField(FieldValues):
         '3 08:32:01.000123': datetime.timedelta(days=3, hours=8, minutes=32, seconds=1, microseconds=123),
         '08:01': datetime.timedelta(minutes=8, seconds=1),
         datetime.timedelta(days=3, hours=8, minutes=32, seconds=1, microseconds=123): datetime.timedelta(days=3, hours=8, minutes=32, seconds=1, microseconds=123),
+        3600: datetime.timedelta(hours=1),
     }
     invalid_inputs = {
         'abc': ['Duration has wrong format. Use one of these formats instead: [DD] [HH:[MM:]]ss[.uuuuuu].'],


### PR DESCRIPTION
#### Description
When sending an integer value for a duration field, I get a 500 because `parse_duration` blows up.

This PR makes `DurationField` accept integer values instead. I'm open to restricting `DurationField` to string values, but then we should return a 400 with an error message.

#### Test
```bash
./runtests.py TestDurationField
```