### PR TITLE
Don't pass `allow_empty` to `ListSerializer`'s children.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -113,12 +113,13 @@ class BaseSerializer(Field):
             kwargs['child'] = cls()
             return CustomListSerializer(*args, **kwargs)
         """
-        allow_empty = kwargs.pop('allow_empty', True)
+        allow_empty = kwargs.pop('allow_empty', None)
         child_serializer = cls(*args, **kwargs)
         list_kwargs = {
             'child': child_serializer,
-            'allow_empty': allow_empty,
         }
+        if allow_empty is not None:
+            list_kwargs['allow_empty'] = allow_empty
         list_kwargs.update(dict([
             (key, value) for key, value in kwargs.items()
             if key in LIST_SERIALIZER_KWARGS

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -113,8 +113,12 @@ class BaseSerializer(Field):
             kwargs['child'] = cls()
             return CustomListSerializer(*args, **kwargs)
         """
+        allow_empty = kwargs.pop('allow_empty', True)
         child_serializer = cls(*args, **kwargs)
-        list_kwargs = {'child': child_serializer}
+        list_kwargs = {
+            'child': child_serializer,
+            'allow_empty': allow_empty,
+        }
         list_kwargs.update(dict([
             (key, value) for key, value in kwargs.items()
             if key in LIST_SERIALIZER_KWARGS


### PR DESCRIPTION
This should fix #3361.
Root cause is `allow_empty` applies to the `ListSerializer` but not for its children.