### PR TITLE
Correctly handle [] and {} as invalid inputs to BooleanField

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -608,10 +608,13 @@ class BooleanField(Field):
         super(BooleanField, self).__init__(**kwargs)
 
     def to_internal_value(self, data):
-        if data in self.TRUE_VALUES:
-            return True
-        elif data in self.FALSE_VALUES:
-            return False
+        try:
+            if data in self.TRUE_VALUES:
+                return True
+            elif data in self.FALSE_VALUES:
+                return False
+        except TypeError:  # Input is an unhashable type
+            pass
         self.fail('invalid', input=data)
 
     def to_representation(self, value):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -466,6 +466,18 @@ class TestBooleanField(FieldValues):
     }
     field = serializers.BooleanField()
 
+    def test_disallow_unhashable_collection_types(self):
+        inputs = (
+            [],
+            {},
+        )
+        field = serializers.BooleanField()
+        for input_value in inputs:
+            with pytest.raises(serializers.ValidationError) as exc_info:
+                field.run_validation(input_value)
+            expected = ['"{0}" is not a valid boolean.'.format(input_value)]
+            assert exc_info.value.detail == expected
+
 
 class TestNullBooleanField(FieldValues):
     """


### PR DESCRIPTION
An uncaught `TypeError` occurs when an unhashable value is provided as input to a `BooleanField`.

### Code to reproduce

```python
from django.conf import settings
settings.configure(INSTALLED_APPS=['rest_framework'])
import django
django.setup()
from rest_framework import serializers

bfield = serializers.BooleanField()

print(bfield.to_internal_value([]))
```

### Expected

A `ValidationError` with the message '"[]" is not a valid boolean."

### Actual 

An uncaught `TypeError` occurs.