### PR TITLE
CharField should not accept collections as valid input

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -661,7 +661,8 @@ class CharField(Field):
     default_error_messages = {
         'blank': _('This field may not be blank.'),
         'max_length': _('Ensure this field has no more than {max_length} characters.'),
-        'min_length': _('Ensure this field has at least {min_length} characters.')
+        'min_length': _('Ensure this field has at least {min_length} characters.'),
+        'invalid': _('{input} is not a valid string.'),
     }
     initial = ''
 
@@ -686,6 +687,9 @@ class CharField(Field):
             if not self.allow_blank:
                 self.fail('blank')
             return ''
+        if not isinstance(data, (six.text_type, six.binary_type, type(None))):
+            if data is not empty:
+                self.fail('invalid', input=data)
         return super(CharField, self).run_validation(data)
 
     def to_internal_value(self, data):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -501,10 +501,11 @@ class TestCharField(FieldValues):
     Valid and invalid values for `CharField`.
     """
     valid_inputs = {
-        1: '1',
         'abc': 'abc'
     }
     invalid_inputs = {
+        1: ['1 is not a valid string.'],
+        42.0: ['42.0 is not a valid string.'],
         '': ['This field may not be blank.']
     }
     outputs = {
@@ -527,6 +528,21 @@ class TestCharField(FieldValues):
         with pytest.raises(serializers.ValidationError) as exc_info:
             field.run_validation('   ')
         assert exc_info.value.detail == ['This field may not be blank.']
+
+    def test_collection_types_are_invalid_input(self):
+        field = serializers.CharField()
+        input_values = (
+            42,
+            {},
+            [],
+            tuple(),
+            set(),
+        )
+        for value in input_values:
+            with pytest.raises(serializers.ValidationError) as exc_info:
+                field.run_validation(value)
+            expected = ['{0} is not a valid string.'.format(value)]
+            assert exc_info.value.detail == expected
 
 
 class TestEmailField(FieldValues):


### PR DESCRIPTION
This issue came up on the marshmallow issue tracker (https://github.com/marshmallow-code/marshmallow/issues/231), so I thought I'd pass it along here.

It seems incorrect for `CharField` to take numbers and collections as valid input.

### Code to reproduce

```python
from django.conf import settings
settings.configure(INSTALLED_APPS=['rest_framework'])
import django
django.setup()
from rest_framework import serializers as ser
from rest_framework.exceptions import ValidationError

field = ser.CharField()

inputs = (
    42,
    42.0,
    {},
    []
)

for val in inputs:
    try:
        field.run_validation(val)
    except ValidationError as err:
        print(err.detail[0])
```

### Expected

Validation fails with messages like `"{} is not a valid string."`.

### Actual

Numbers and collections pass validation.