### PR TITLE
Update transifex-client requirement to latest release version 0.11b3

### DIFF
--- a/requirements/requirements-packaging.txt
+++ b/requirements/requirements-packaging.txt
@@ -5,4 +5,4 @@ wheel==0.24.0
 twine==1.4.0
 
 # Transifex client for managing translation resources.
-transifex-client==0.10
+transifex-client==0.11b3


### PR DESCRIPTION
This pins the `transifex-client` to `0.11b3`. This allows the install of the `requirements/requirements-packaging.txt` on python 3.4.

Without this change the install of the devel requirements fail:

```shell
Collecting transifex-client==0.10 (from -r requirements/requirements-packaging.txt (line 8))
  Downloading transifex-client-0.10.tar.gz (68kB)
    100% |████████████████████████████████| 69kB 26.6MB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/private/var/folders/zz/zyxvpxvq6csfxvn_n32txkg4rpqcls/T/pip-build-vs8d_8zq/transifex-client/setup.py", line 14, in <module>
        if long_description.startswith(BOM):
    TypeError: startswith first arg must be str or a tuple of str, not bytes

    ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/zz/zyxvpxvq6csfxvn_n32txkg4rpqcls/T/pip-build-vs8d_8zq/transifex-client
```