### PR TITLE
Exclude Guardian testing against Django master

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,3 +39,25 @@ commands = mkdocs build
 deps =
        -rrequirements/requirements-testing.txt
        -rrequirements/requirements-documentation.txt
+
+# Specify explicitly to exclude Django Guardian against Django master (various Pythons)
+[testenv:py27-djangomaster]
+deps =
+       https://github.com/django/django/archive/master.tar.gz
+       -rrequirements/requirements-testing.txt
+       markdown==2.5.2
+       django-filter==0.10.0
+[testenv:py34-djangomaster]
+deps =
+       https://github.com/django/django/archive/master.tar.gz
+       -rrequirements/requirements-testing.txt
+       markdown==2.5.2
+       django-filter==0.10.0
+
+[testenv:py35-djangomaster]
+deps =
+       https://github.com/django/django/archive/master.tar.gz
+       -rrequirements/requirements-testing.txt
+       markdown==2.5.2
+       django-filter==0.10.0
+


### PR DESCRIPTION
Fixes #3406

Excluding Django Guardian clears up the test run against Django `master`

> 3 failed, 287 passed, 2 warnings, **456 error in 220.90 seconds**

vs

> 1 failed, 735 passed, 10 skipped, 2 warnings in 7.39 seconds

* Made against v3.3 branch. 
* Easy enough to re-add when Guardian fixes this. 
* There's probably some neater way of specifying the exclude in tox config — but I couldn't think of it offhand. 