### PR TITLE
Guard against calling `serializer.data` before `serializer.save()`

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -166,6 +166,12 @@ class BaseSerializer(Field):
             "For example: 'serializer.save(owner=request.user)'.'"
         )
 
+        assert not hasattr(self, '_data'), (
+            "You cannot call `.save()` after accessing `serializer.data`."
+            "If you need to access data before committing to the database then "
+            "inspect 'serializer.validated_data' instead. "
+        )
+
         validated_data = dict(
             list(self.validated_data.items()) +
             list(kwargs.items())

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -51,6 +51,15 @@ class TestSerializer:
         with pytest.raises(AttributeError):
             serializer.data
 
+    def test_data_access_before_save_raises_error(self):
+        def create(validated_data):
+            return validated_data
+        serializer = self.Serializer(data={'char': 'abc', 'integer': 123})
+        serializer.create = create
+        assert serializer.is_valid()
+        assert serializer.data == {'char': 'abc', 'integer': 123}
+        with pytest.raises(AssertionError):
+            serializer.save()
 
 class TestValidateMethod:
     def test_non_field_error_validate_method(self):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -61,6 +61,7 @@ class TestSerializer:
         with pytest.raises(AssertionError):
             serializer.save()
 
+
 class TestValidateMethod:
     def test_non_field_error_validate_method(self):
         class ExampleSerializer(serializers.Serializer):


### PR DESCRIPTION
- Added test_data_access_before_save_raises_error test