### PR TITLE
Use model error_messages when available

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -193,7 +193,15 @@ def get_field_kwargs(field_name, model_field):
         ]
 
     if getattr(model_field, 'unique', False):
-        validator = UniqueValidator(queryset=model_field.model._default_manager)
+        unique_error_message = model_field.error_messages.get('unique', None)
+        if unique_error_message:
+            unique_error_message = unique_error_message % {
+                'model_name': model_field.model._meta.object_name,
+                'field_label': model_field.verbose_name
+            }
+        validator = UniqueValidator(
+            queryset=model_field.model._default_manager,
+            message=unique_error_message)
         validator_kwarg.append(validator)
 
     if validator_kwarg:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -48,7 +48,7 @@ class TestUniquenessValidation(TestCase):
         data = {'username': 'existing'}
         serializer = UniquenessSerializer(data=data)
         assert not serializer.is_valid()
-        assert serializer.errors == {'username': ['This field must be unique.']}
+        assert serializer.errors == {'username': ['UniquenessModel with this username already exists.']}
 
     def test_is_unique(self):
         data = {'username': 'other'}


### PR DESCRIPTION
In the automatically applied UniqueValidator, use the error message from
error_messages defined in the model instead of the generic default
UniqueValidator message.

This fixes #2878.