### PR TITLE
Use serializers.ValidationError in AuthTokenSerializer

### DIFF
--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import authenticate
 from django.utils.translation import ugettext_lazy as _
 
-from rest_framework import exceptions, serializers
+from rest_framework import serializers
 
 
 class AuthTokenSerializer(serializers.Serializer):
@@ -18,13 +18,13 @@ class AuthTokenSerializer(serializers.Serializer):
             if user:
                 if not user.is_active:
                     msg = _('User account is disabled.')
-                    raise exceptions.ValidationError(msg)
+                    raise serializers.ValidationError(msg)
             else:
                 msg = _('Unable to log in with provided credentials.')
-                raise exceptions.ValidationError(msg)
+                raise serializers.ValidationError(msg)
         else:
             msg = _('Must include "username" and "password".')
-            raise exceptions.ValidationError(msg)
+            raise serializers.ValidationError(msg)
 
         attrs['user'] = user
         return attrs


### PR DESCRIPTION
Per django rest framework docs, and to prevent confusion with Django's ValidationError, `serializers.ValidationError` is preferred to `exceptions.ValidationError`.