### PR TITLE
Small doc typo `throttles` --> `throttling`

### DIFF
--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -184,7 +184,7 @@ If the `.wait()` method is implemented and the request is throttled, then a `Ret
 
 The following is an example of a rate throttle, that will randomly throttle 1 in every 10 requests.
 
-    class RandomRateThrottle(throttles.BaseThrottle):
+    class RandomRateThrottle(throttling.BaseThrottle):
         def allow_request(self, request, view):
             return random.randint(1, 10) == 1
 


### PR DESCRIPTION
Super small, just reading through and noticed it.

Thanks for keeping the api-guide so up to date!