### PR TITLE
Serializers with many=True should return empty list rather than empty dict

### DIFF
--- a/tests/test_serializer_bulk_update.py
+++ b/tests/test_serializer_bulk_update.py
@@ -46,6 +46,7 @@ class BulkCreateSerializerTests(TestCase):
         serializer = self.BookSerializer(data=data, many=True)
         self.assertEqual(serializer.is_valid(), True)
         self.assertEqual(serializer.validated_data, data)
+        self.assertEqual(serializer.errors, [])
 
     def test_bulk_create_errors(self):
         """
@@ -76,6 +77,7 @@ class BulkCreateSerializerTests(TestCase):
         serializer = self.BookSerializer(data=data, many=True)
         self.assertEqual(serializer.is_valid(), False)
         self.assertEqual(serializer.errors, expected_errors)
+        self.assertEqual(serializer.validated_data, [])
 
     def test_invalid_list_datatype(self):
         """


### PR DESCRIPTION
Follow up proposal fix for #3434 and #3437