### PR TITLE
Fix codecov on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ script:
 
 after_success:
     - pip install codecov
-    - codecov
+    - codecov -e TOX_ENV

--- a/runtests.py
+++ b/runtests.py
@@ -93,7 +93,11 @@ if __name__ == "__main__":
         except ValueError:
             pass
         else:
-            pytest_args = ['--cov', 'rest_framework'] + pytest_args
+            pytest_args = [
+                '--cov-report',
+                'xml',
+                '--cov',
+                'rest_framework'] + pytest_args
 
         if first_arg.startswith('-'):
             # `runtests.py [flags]`


### PR DESCRIPTION
Codecov is not actually working correctly on Travis CI if you look at the output of the `codecov` command on one of the builds: https://travis-ci.org/tomchristie/django-rest-framework/jobs/84089157

You can see why this is here: https://github.com/rackerlabs/mimic/pull/427#issuecomment-142523645

This PR adds the arguments necessary to `pytest-cov` to generate the `coverage` xml report within the `tox` execution context. Then when `codecov` is run outside of the `tox` context it finds the xml coverage report.