### PR TITLE
Serialize mapping attributes

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -75,7 +75,14 @@ def get_attribute(instance, attrs):
             return None
         try:
             if isinstance(instance, collections.Mapping):
-                instance = instance[attr]
+                try:
+                    instance = instance[attr]
+                except KeyError as keyerror:
+                    # Does the mapping has a method or property with that name?
+                    try:
+                        instance = getattr(instance, attr)
+                    except AttributeError:
+                        raise keyerror
             else:
                 instance = getattr(instance, attr)
         except ObjectDoesNotExist:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -309,3 +309,28 @@ class TestCacheSerializerData:
         pickled = pickle.dumps(serializer.data)
         data = pickle.loads(pickled)
         assert data == {'field1': 'a', 'field2': 'b'}
+
+
+class TestMapping:
+    def setup(self):
+        class ExampleSerializer(serializers.Serializer):
+            entries = serializers.ListField()
+            last_entry = serializers.CharField()
+        self.Serializer = ExampleSerializer
+        self.data = {'entries': ['a', 'b', 'c']}
+        self.expected = {'entries': ['a', 'b', 'c'], 'last_entry': 'c'}
+
+    def test_mapping_with_method(self):
+        class Mapping(dict):
+            def last_entry(self):
+                return self['entries'][-1]
+        serializer = self.Serializer(Mapping(self.data))
+        assert serializer.data == self.expected
+
+    def test_mapping_with_property(self):
+        class Mapping(dict):
+            @property
+            def last_entry(self):
+                return self['entries'][-1]
+        serializer = self.Serializer(Mapping(self.data))
+        assert serializer.data == self.expected


### PR DESCRIPTION
I am trying to serialize a `dict` subclass with some custom properties. The serialization fails because current `Field.get_attribute` implementation does not consider attributes for `collections.Mapping` instances. Here is a simplified example:

```python
class ExampleSerializer(serializers.Serializer):
    entries = serializers.ListField()
    last_entry = serializers.CharField()

class Mapping(dict):
    @property
    def last_entry(self):
        return self['entries'][-1]

instance = Mapping({'entries': [...]})
serializer = ExampleSerializer(instance)
serializer.data  # raises KeyError
```

This pull request modifies `Field.get_attribute` to check attributes on `collections.Mapping` instances. 