### PR TITLE
Update compat.py

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -81,8 +81,9 @@ except ImportError:
 # Fixes (#1712). We keep the try/except for the test suite.
 guardian = None
 try:
-    import guardian
-    import guardian.shortcuts  # Fixes #1624
+    if 'guardian' in settings.INSTALLED_APPS:
+        import guardian
+        import guardian.shortcuts  # Fixes #1624
 except ImportError:
     pass
 


### PR DESCRIPTION
try to import guardian if it's in INSTALLED_APPS.

Importing guardian when not in INSTALLED_APPS raising django.core.exceptions.ImproperlyConfigured because guardian is requiring some configuration in django