### PR TITLE
fix PostgreSQL fields DataError in unique validator

### DIFF
--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -65,7 +65,7 @@ class UniqueValidator(object):
         try:
             exists = queryset.exists()
         except DataError:
-            return
+            exists = False
 
         if exists:
             raise ValidationError(self.message)

--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -8,6 +8,7 @@ object creation, and makes it possible to switch between using the implicit
 """
 from __future__ import unicode_literals
 
+from django.db import DataError
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework.compat import unicode_to_repr
@@ -59,7 +60,14 @@ class UniqueValidator(object):
         queryset = self.queryset
         queryset = self.filter_queryset(value, queryset)
         queryset = self.exclude_current_instance(queryset)
-        if queryset.exists():
+
+        # catch DataError for PostgrSQL fields
+        try:
+            exists = queryset.exists()
+        except DataError:
+            return
+
+        if exists:
             raise ValidationError(self.message)
 
     def __repr__(self):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -79,7 +79,7 @@ class TestUniquenessValidation(TestCase):
         data = {'ip': 'test', 'username': 'test'}
         serializer = UniquenessSerializer(data=data)
         assert not serializer.is_valid()
-        assert serializer.errors == {'ip': [u'Enter a valid IPv4 address.', u'Enter a valid IPv4 or IPv6 address.']}
+        assert serializer.errors == {'ip': ['Enter a valid IPv4 address.', 'Enter a valid IPv4 or IPv6 address.']}
 
 
 # Tests for `UniqueTogetherValidator`

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -15,6 +15,7 @@ def dedent(blocktext):
 
 class UniquenessModel(models.Model):
     username = models.CharField(unique=True, max_length=100)
+    ip = models.GenericIPAddressField(protocol='IPv4', unique=True, blank=True, null=True)
 
 
 class UniquenessSerializer(serializers.ModelSerializer):
@@ -41,6 +42,7 @@ class TestUniquenessValidation(TestCase):
             UniquenessSerializer():
                 id = IntegerField(label='ID', read_only=True)
                 username = CharField(max_length=100, validators=[<UniqueValidator(queryset=UniquenessModel.objects.all())>])
+                ip = IPAddressField(allow_null=True, required=False, validators=[<django.core.validators.RegexValidator object>, <UniqueValidator(queryset=UniquenessModel.objects.all())>])
         """)
         assert repr(serializer) == expected
 
@@ -72,6 +74,12 @@ class TestUniquenessValidation(TestCase):
         serializer.data
         self.assertEqual(
             AnotherUniquenessModel._meta.get_field('code').validators, [])
+
+    def test_data_error(self):
+        data = {'ip': 'test', 'username': 'test'}
+        serializer = UniquenessSerializer(data=data)
+        assert not serializer.is_valid()
+        assert serializer.errors == {'ip': [u'Enter a valid IPv4 address.', u'Enter a valid IPv4 or IPv6 address.']}
 
 
 # Tests for `UniqueTogetherValidator`


### PR DESCRIPTION
For https://github.com/tomchristie/django-rest-framework/issues/3381

We get DataError only in internal PostgreSQL fields validation, so test will not raise DataError exception in other databases and will be success anyway. Maybe i should remove it?