### PR TITLE
Added view name to has_permission error message

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -118,9 +118,9 @@ class DjangoModelPermissions(BasePermission):
             queryset = getattr(view, 'queryset', None)
 
         assert queryset is not None, (
-            'Cannot apply DjangoModelPermissions on a view that '
+            'Cannot apply DjangoModelPermissions on view "%s" that '
             'does not have `.queryset` property or overrides the '
-            '`.get_queryset()` method.')
+            '`.get_queryset()` method.' % view.get_view_name())
 
         perms = self.get_required_permissions(request.method, queryset.model)
 


### PR DESCRIPTION
When this error occurs in a project with a large number of views, it is difficult to pinpoint in which view this error might be happening. By explicitly including the view name in the error message the developer can more easily identify the cause of the problem. Without including this the error message is close to useless as it requires source code analysis or Googling. There are many examples of these kinds of errors in DRF and Django itself, but we have to start somewhere.