### PR TITLE
Fix the Django 1.9 compatibility with the Meta api

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -95,6 +95,21 @@ else:
         return opts.get_all_related_many_to_many_objects()
 
 
+# Compatibility for the *field* instance returned by either
+# the old `Options.get_all_related_objects` or our own implementation above
+def get_relation_accessor_name(relation):
+    if not hasattr(relation, 'get_accessor_name'):
+        # special case for the `OneToOneField` instances
+        return relation.name
+    return relation.get_accessor_name()
+
+def get_relation_field(relation):
+    if not hasattr(relation, 'get_accessor_name'):
+        # special case for the `OneToOneField` instances
+        return relation
+    return relation.field
+
+
 # django-filter is optional
 try:
     import django_filters

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -71,6 +71,30 @@ except ImportError:
     JSONField = None
 
 
+# Models Options old meta api
+# Django 1.8 introduced the `Options.get_fields` method that can be used to
+# implement *old* meta api methods
+# See: https://docs.djangoproject.com/en/1.9/ref/models/meta/#migrating-from-the-old-api
+if django.VERSION >= (1, 8):
+    def get_all_related_objects(opts):
+        return [
+            f for f in opts.get_fields()
+            if (f.one_to_many or f.one_to_one) and f.auto_created
+        ]
+
+    def get_all_related_many_to_many_objects(opts):
+        return [
+            f for f in opts.get_fields(include_hidden=True)
+            if f.many_to_many and f.auto_created
+        ]
+else:
+    def get_all_related_objects(opts):
+        return opts.get_all_related_objects()
+
+    def get_all_related_many_to_many_objects(opts):
+        return opts.get_all_related_many_to_many_objects()
+
+
 # django-filter is optional
 try:
     import django_filters

--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -147,7 +147,7 @@ def _get_reverse_relationships(opts):
     # The backward implementation can be found in the Django Documentation
     # See: https://docs.djangoproject.com/en/1.9/ref/models/meta/#migrating-from-the-old-api
     all_related_to_many_objects = [
-         f for f in opts.get_fields(include_hidden=True)
+        f for f in opts.get_fields(include_hidden=True)
         if f.many_to_many and f.auto_created
     ]
 

--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -14,10 +14,8 @@ from django.db import models
 from django.utils import six
 
 from rest_framework.compat import (
-    get_all_related_objects,
-    get_all_related_many_to_many_objects,
-    get_relation_accessor_name,
-    get_relation_field
+    get_all_related_many_to_many_objects, get_all_related_objects,
+    get_relation_accessor_name, get_relation_field
 )
 
 FieldInfo = namedtuple('FieldResult', [

--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -126,7 +126,15 @@ def _get_reverse_relationships(opts):
     # See: https://code.djangoproject.com/ticket/24208
 
     reverse_relations = OrderedDict()
-    for relation in opts.get_all_related_objects():
+
+    # The backward implementation can be found in the Django Documentation
+    # See: https://docs.djangoproject.com/en/1.9/ref/models/meta/#migrating-from-the-old-api
+    related_objects = [
+        f for f in opts.get_fields()
+        if (f.one_to_many or f.one_to_one) and f.auto_created
+    ]
+
+    for relation in related_objects:
         accessor_name = relation.get_accessor_name()
         related = getattr(relation, 'related_model', relation.model)
         reverse_relations[accessor_name] = RelationInfo(
@@ -136,8 +144,15 @@ def _get_reverse_relationships(opts):
             has_through_model=False
         )
 
+    # The backward implementation can be found in the Django Documentation
+    # See: https://docs.djangoproject.com/en/1.9/ref/models/meta/#migrating-from-the-old-api
+    all_related_to_many_objects = [
+         f for f in opts.get_fields(include_hidden=True)
+        if f.many_to_many and f.auto_created
+    ]
+
     # Deal with reverse many-to-many relationships.
-    for relation in opts.get_all_related_many_to_many_objects():
+    for relation in all_related_to_many_objects:
         accessor_name = relation.get_accessor_name()
         related = getattr(relation, 'related_model', relation.model)
         reverse_relations[accessor_name] = RelationInfo(

--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -13,6 +13,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.utils import six
 
+from rest_framework.compat import (
+    get_all_related_objects, get_all_related_many_to_many_objects
+)
+
 FieldInfo = namedtuple('FieldResult', [
     'pk',  # Model field instance
     'fields',  # Dict of field name -> model field instance
@@ -126,15 +130,7 @@ def _get_reverse_relationships(opts):
     # See: https://code.djangoproject.com/ticket/24208
 
     reverse_relations = OrderedDict()
-
-    # The backward implementation can be found in the Django Documentation
-    # See: https://docs.djangoproject.com/en/1.9/ref/models/meta/#migrating-from-the-old-api
-    related_objects = [
-        f for f in opts.get_fields()
-        if (f.one_to_many or f.one_to_one) and f.auto_created
-    ]
-
-    for relation in related_objects:
+    for relation in get_all_related_objects(opts):
         accessor_name = relation.get_accessor_name()
         related = getattr(relation, 'related_model', relation.model)
         reverse_relations[accessor_name] = RelationInfo(
@@ -144,15 +140,8 @@ def _get_reverse_relationships(opts):
             has_through_model=False
         )
 
-    # The backward implementation can be found in the Django Documentation
-    # See: https://docs.djangoproject.com/en/1.9/ref/models/meta/#migrating-from-the-old-api
-    all_related_to_many_objects = [
-        f for f in opts.get_fields(include_hidden=True)
-        if f.many_to_many and f.auto_created
-    ]
-
     # Deal with reverse many-to-many relationships.
-    for relation in all_related_to_many_objects:
+    for relation in get_all_related_many_to_many_objects(opts):
         accessor_name = relation.get_accessor_name()
         related = getattr(relation, 'related_model', relation.model)
         reverse_relations[accessor_name] = RelationInfo(

--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -14,7 +14,10 @@ from django.db import models
 from django.utils import six
 
 from rest_framework.compat import (
-    get_all_related_objects, get_all_related_many_to_many_objects
+    get_all_related_objects,
+    get_all_related_many_to_many_objects,
+    get_relation_accessor_name,
+    get_relation_field
 )
 
 FieldInfo = namedtuple('FieldResult', [
@@ -131,26 +134,28 @@ def _get_reverse_relationships(opts):
 
     reverse_relations = OrderedDict()
     for relation in get_all_related_objects(opts):
-        accessor_name = relation.get_accessor_name()
+        accessor_name = get_relation_accessor_name(relation)
+        field = get_relation_field(relation)
         related = getattr(relation, 'related_model', relation.model)
         reverse_relations[accessor_name] = RelationInfo(
             model_field=None,
             related_model=related,
-            to_many=relation.field.rel.multiple,
+            to_many=field.rel.multiple,
             has_through_model=False
         )
 
     # Deal with reverse many-to-many relationships.
     for relation in get_all_related_many_to_many_objects(opts):
-        accessor_name = relation.get_accessor_name()
+        accessor_name = get_relation_accessor_name(relation)
+        field = get_relation_field(relation)
         related = getattr(relation, 'related_model', relation.model)
         reverse_relations[accessor_name] = RelationInfo(
             model_field=None,
             related_model=related,
             to_many=True,
             has_through_model=(
-                (getattr(relation.field.rel, 'through', None) is not None) and
-                not relation.field.rel.through._meta.auto_created
+                (getattr(field.rel, 'through', None) is not None) and
+                not field.rel.through._meta.auto_created
             )
         )
 


### PR DESCRIPTION
Use backward compatible implementation for the meta api calls, as suggested in the [documentation](https://docs.djangoproject.com/en/1.9/ref/models/meta/#migrating-from-the-old-api).

Cheers