### PR TITLE
Deserialization of nested representations does not work when source is equal to '*'

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -292,6 +292,8 @@ class BaseSerializer(WritableField):
             field.initialize(parent=self, field_name=field_name)
             try:
                 field.field_from_native(data, files, field_name, reverted_data)
+                if field.errors:
+                    self._errors[field_name] = [field.errors]
             except ValidationError as err:
                 self._errors[field_name] = list(err.messages)
 
@@ -432,6 +434,9 @@ class BaseSerializer(WritableField):
         Override default so that the serializer can be used as a writable
         nested field across relationships.
         """
+
+        self._errors = {}
+
         if self.read_only:
             return
 


### PR DESCRIPTION
This issue belongs to Django Rest Framework 2.4, I haven't tried with 3.x.

Having a serializer that produces a nested representation with a plain object (source='*') works correctly for serializing, deserializing works as well when the representation does not have any errors, in case the representation has errors a validation error should be generated, instead when asking if the data is valid the following error is raised:

```
    def restore_fields(self, data, files):
        """
            Core of deserialization, together with `restore_object`.
            Converts a dictionary of data into a dictionary of deserialized fields.
            """
        reverted_data = {}
    
        if data is not None and not isinstance(data, dict):
            self._errors['non_field_errors'] = ['Invalid data']
            return None
    
        for field_name, field in self.fields.items():
            field.initialize(parent=self, field_name=field_name)
            try:
                field.field_from_native(data, files, field_name, reverted_data)
            except ValidationError as err:
>               self._errors[field_name] = list(err.messages)
E               TypeError: 'NoneType' object does not support item assignment
```
 
The main issue is that the attribute _errors is not initialized for nested serializers, after resolving this there is another problem, the errors are not being passed to the parent serializer. 
This pull request addresses both issues and adds a test that recreates the problem.
