### PR TITLE
ListField does not enforce that input is a list

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1461,7 +1461,7 @@ class ListField(Field):
         """
         if html.is_html_input(data):
             data = html.parse_html_list(data)
-        if isinstance(data, type('')) or not hasattr(data, '__iter__'):
+        if not isinstance(data, list):
             self.fail('not_a_list', input_type=type(data).__name__)
         if not self.allow_empty and len(data) == 0:
             self.fail('empty')

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from sets import Set
 
 import collections
 import copy
@@ -1462,7 +1461,7 @@ class ListField(Field):
         """
         if html.is_html_input(data):
             data = html.parse_html_list(data)
-        if not isinstance(data, (list, tuple, Set)):
+        if not isinstance(data, (list, tuple, set)):
             self.fail('not_a_list', input_type=type(data).__name__)
         if not self.allow_empty and len(data) == 0:
             self.fail('empty')

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1461,7 +1461,7 @@ class ListField(Field):
         """
         if html.is_html_input(data):
             data = html.parse_html_list(data)
-        if not isinstance(data, (list, tuple, set)):
+        if isinstance(data, type('')) or isinstance(data, collections.Mapping) or not hasattr(data, '__iter__'):
             self.fail('not_a_list', input_type=type(data).__name__)
         if not self.allow_empty and len(data) == 0:
             self.fail('empty')

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from sets import Set
 
 import collections
 import copy
@@ -1461,7 +1462,7 @@ class ListField(Field):
         """
         if html.is_html_input(data):
             data = html.parse_html_list(data)
-        if not isinstance(data, list):
+        if not isinstance(data, (list, tuple, Set)):
             self.fail('not_a_list', input_type=type(data).__name__)
         if not self.allow_empty and len(data) == 0:
             self.fail('empty')

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1437,7 +1437,8 @@ class TestListField(FieldValues):
     ]
     invalid_inputs = [
         ('not a list', ['Expected a list of items but got type "str".']),
-        ([1, 2, 'error'], ['A valid integer is required.'])
+        ([1, 2, 'error'], ['A valid integer is required.']),
+        ({'one': 'two'}, ['Expected a list of items but got type "dict".'])
     ]
     outputs = [
         ([1, 2, 3], [1, 2, 3]),
@@ -1453,6 +1454,14 @@ class TestListField(FieldValues):
             "The `source` argument is not meaningful when applied to a `child=` field. "
             "Remove `source=` from the field declaration."
         )
+
+    def test_collection_types_are_invalid_input(self):
+        field = serializers.ListField(child=serializers.CharField())
+        input_value = ({'one': 'two'})
+
+        with pytest.raises(serializers.ValidationError) as exc_info:
+            field.to_internal_value(input_value)
+        assert exc_info.value.detail == [u'Expected a list of items but got type "dict".']
 
 
 class TestEmptyListField(FieldValues):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1461,7 +1461,7 @@ class TestListField(FieldValues):
 
         with pytest.raises(serializers.ValidationError) as exc_info:
             field.to_internal_value(input_value)
-        assert exc_info.value.detail == [u'Expected a list of items but got type "dict".']
+        assert exc_info.value.detail == ['Expected a list of items but got type "dict".']
 
 
 class TestEmptyListField(FieldValues):


### PR DESCRIPTION
# Purpose

A dictionary is allowed as input in a ListField.  If a dictionary is received as input, the keys of the object are retained, and the values are ignored.  I assume the ListField should enforce that the input is an array, especially because the error message in `to_internal_value` includes "not a list" if something is wrong with the data.

# Changes

Enforces that data cannot be a collections.Mapping.

