### PR TITLE
Fixed typos on _errors vs errors()

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -157,7 +157,7 @@ class BaseSerializer(Field):
             'You must call `.is_valid()` before calling `.save()`.'
         )
 
-        assert not self.errors, (
+        assert not self._errors, (
             'You cannot call `.save()` on a serializer with invalid data.'
         )
 
@@ -218,7 +218,7 @@ class BaseSerializer(Field):
                 self._errors = {}
 
         if self._errors and raise_exception:
-            raise ValidationError(self.errors)
+            raise ValidationError(self._errors)
 
         return not bool(self._errors)
 


### PR DESCRIPTION
These two lines should either be self.errors() or self._errors. I went with the latter.  This fixes bugs that got introduced in 3.1 to 3.2 that would cause 400 errors on invalid requests to become mysterious 500 errors.