### PR TITLE
adding support for multiple values for search filter

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -136,8 +136,13 @@ class SearchFilter(BaseFilterBackend):
         Search terms are set by a ?search=... query parameter,
         and may be comma and/or whitespace delimited.
         """
-        params = request.query_params.get(self.search_param, '')
-        return params.replace(',', ' ').split()
+        params = request.query_params.getlist(self.search_param, '')
+        if params == '':
+            return []
+        elif len(params) == 1:
+            return params[0].replace(',', ' ').split()
+        else:
+            return params
 
     def construct_search(self, field_name):
         if field_name.startswith('^'):


### PR DESCRIPTION
This PR adds support for multiple search params, instead of just one.
```
/api/v1/model?search=first&search=last
```
With current master, this will create a query only for the `last` parameter. You could add more params using space or ','. I think it's better to use the fact that we can specify more values for one param instead of using space  or commas, especially when we would like to search using those characters.

I've left backward compatibility for just one parameter given to split across spaces or commas, but I would remove this out in the future.

What do you think guys?

All the best,
Michal