### PR TITLE
Fixed AssertionError for OPTIONS call on list-view that accepts PUT

### DIFF
--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -85,7 +85,11 @@ class SimpleMetadata(BaseMetadata):
                     view.check_permissions(view.request)
                 # Test object permissions
                 if method == 'PUT' and hasattr(view, 'get_object'):
-                    view.get_object()
+                    # List/Detail views add a .detail property to the view function.
+                    # If the view is a list view, detail will be False, and this
+                    # check should be skipped.
+                    if getattr(view.put, 'detail', True):
+                        view.get_object()
             except (exceptions.APIException, PermissionDenied, Http404):
                 pass
             else:


### PR DESCRIPTION
For issue #3356 

An OPTIONS request on a ``@list_route`` decorated view with a PUT method raises an AssertionError, because the ``determine_actions`` method was trying to access ``get_object()``. I added a check to this method to ensure that the view was not a ``@list_route`` decorated view before trying to check object permissions.