### PR TITLE
Correctly handle False in NestedBoundField.as_form_field()

### DIFF
--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -112,7 +112,7 @@ class NestedBoundField(BoundField):
             if isinstance(value, (list, dict)):
                 values[key] = value
             else:
-                values[key] = '' if value is None else force_text(value)
+                values[key] = '' if (value is None or value is False) else force_text(value)
         return self.__class__(self._field, values, self.errors, self._prefix)
 
 

--- a/tests/test_bound_fields.py
+++ b/tests/test_bound_fields.py
@@ -45,6 +45,16 @@ class TestSimpleBoundField:
         assert serializer['amount'].errors is None
         assert serializer['amount'].name == 'amount'
 
+    def test_as_form_fields(self):
+        class ExampleSerializer(serializers.Serializer):
+            bool_field = serializers.BooleanField()
+            null_field = serializers.IntegerField(allow_null=True)
+
+        serializer = ExampleSerializer(data={'bool_field': False, 'null_field': None})
+        assert serializer.is_valid()
+        assert serializer['bool_field'].as_form_field().value == ''
+        assert serializer['null_field'].as_form_field().value == ''
+
 
 class TestNestedBoundField:
     def test_nested_empty_bound_field(self):
@@ -67,3 +77,16 @@ class TestNestedBoundField:
         assert serializer['nested']['amount'].value is None
         assert serializer['nested']['amount'].errors is None
         assert serializer['nested']['amount'].name == 'nested.amount'
+
+    def test_as_form_fields(self):
+        class Nested(serializers.Serializer):
+            bool_field = serializers.BooleanField()
+            null_field = serializers.IntegerField(allow_null=True)
+
+        class ExampleSerializer(serializers.Serializer):
+            nested = Nested()
+
+        serializer = ExampleSerializer(data={'nested': {'bool_field': False, 'null_field': None}})
+        assert serializer.is_valid()
+        assert serializer['nested']['bool_field'].as_form_field().value == ''
+        assert serializer['nested']['null_field'].as_form_field().value == ''


### PR DESCRIPTION
`False` was getting sent to `force_text`, which converts it into the string `'False'`. When rendering as HTML, this was causing checkboxes to be checked by default when they shouldn't be.

`BoundField.as_form_field()` correctly handles `False` so I did the same thing here.

Fixes https://github.com/tomchristie/django-rest-framework/issues/3523