### PR TITLE
Add section permalinks to docs

### DIFF
--- a/docs_theme/css/default.css
+++ b/docs_theme/css/default.css
@@ -413,3 +413,7 @@ ul.sponsor {
 #mkdocs_search_modal article p{
   word-wrap: break-word;
 }
+
+.toclink {
+  color: #333;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,10 @@ repo_url: https://github.com/tomchristie/django-rest-framework
 
 theme_dir: docs_theme
 
+markdown_extensions:
+ - toc:
+    anchorlink: True
+
 pages:
  - Home: 'index.md'
  - Tutorial:


### PR DESCRIPTION
This patch tells `mkdocs` to add permalinks to section headers in the docs.

The link styles only show on hover:

![screen shot 2015-10-27 at 3 25 23 pm](https://cloud.githubusercontent.com/assets/101698/10771504/25d4252c-7cbf-11e5-816b-c16eef5e7478.png)

Thanks for DRF!