### PR TITLE
Allow HTML to render when no filter_class is defined.

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -117,9 +117,9 @@ class DjangoFilterBackend(BaseFilterBackend):
         return queryset
 
     def to_html(self, request, queryset, view):
-        cls = self.get_filter_class(view, queryset)
-        if cls:
-            filter_instance = cls(request.query_params, queryset=queryset)
+        filter_class = self.get_filter_class(view, queryset)
+        if filter_class:
+            filter_instance = filter_class(request.query_params, queryset=queryset)
         else:
             filter_instance = None
         context = Context({

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -118,7 +118,10 @@ class DjangoFilterBackend(BaseFilterBackend):
 
     def to_html(self, request, queryset, view):
         cls = self.get_filter_class(view, queryset)
-        filter_instance = cls(request.query_params, queryset=queryset)
+        if cls:
+            filter_instance = cls(request.query_params, queryset=queryset)
+        else:
+            filter_instance = None
         context = Context({
             'filter': filter_instance
         })


### PR DESCRIPTION
Previously it required a filter_class,
or else it would error when calling `cls()`.
This now sets the `filter` context to `None`
if one does not exist.

This fixes #3559