### PR TITLE
Fix trans template tag error on admin

### DIFF
--- a/rest_framework/templates/rest_framework/admin.html
+++ b/rest_framework/templates/rest_framework/admin.html
@@ -1,4 +1,5 @@
 {% load staticfiles %}
+{% load i18n %}
 {% load rest_framework %}
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
Trans template tag requires `{% load i18n %}` at top of template.