### PR TITLE
Add compat util for DecimalValidator

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -185,6 +185,11 @@ if django.VERSION >= (1, 8):
 else:
     DurationField = duration_string = parse_duration = None
 
+try:
+    # DecimalValidator is unavailable in Django < 1.9
+    from django.core.validators import DecimalValidator
+except ImportError:
+    DecimalValidator = None
 
 def set_rollback():
     if hasattr(transaction, 'set_rollback'):

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -8,6 +8,7 @@ from django.core import validators
 from django.db import models
 from django.utils.text import capfirst
 
+from rest_framework.compat import DecimalValidator
 from rest_framework.validators import UniqueValidator
 
 NUMERIC_FIELD_TYPES = (
@@ -132,7 +133,7 @@ def get_field_kwargs(field_name, model_field):
     if isinstance(model_field, models.DecimalField):
         validator_kwarg = [
             validator for validator in validator_kwarg
-            if not isinstance(validator, validators.DecimalValidator)
+            if DecimalValidator and not isinstance(validator, DecimalValidator)
         ]
 
     # Ensure that max_length is passed explicitly as a keyword arg,


### PR DESCRIPTION
DecimalValidator was introduced in Django 1.9.

Resolves #3562