### PR TITLE
Add help texts to ModelSerializer property fields

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1160,7 +1160,7 @@ class ModelSerializer(Serializer):
         Create a read only field for model methods and properties.
         """
         field_class = ReadOnlyField
-        kwargs = {'help_text': getattr(model, field_name).__doc__}
+        field_kwargs = {'help_text': getattr(model, field_name).__doc__}
 
         return field_class, field_kwargs
 

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1160,7 +1160,7 @@ class ModelSerializer(Serializer):
         Create a read only field for model methods and properties.
         """
         field_class = ReadOnlyField
-        field_kwargs = {}
+        kwargs = {'help_text': getattr(model, field_name).__doc__}
 
         return field_class, field_kwargs
 


### PR DESCRIPTION
If a field of a model wich is a read-only property is included in a ModelSerializer, automátically set its help text to the docstring of the property function. 
I used this to work with the documentation tool django-rest-swagger.

Example:
```python
class MyModel(models.Model):
    # ....
    @property
     def read_only_field(self):
         """ Just a test """
         return "TEST"

class MySerializer(serializers.ModelSerializer):
    class Meta:
        model = MyModel
        fields = ( # ....
                        'read_only_field')

>>> s = MySerializer()
>>> s.fields['read_only_field'].help_text
"Just a test"


```