### PR TITLE
Test against Django 1.8.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
         django17: Django==1.7.10
-        django18: Django==1.8.4
+        django18: Django==1.8.6
         django19: https://www.djangoproject.com/download/1.9b1/tarball/
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt


### PR DESCRIPTION
Bugfix release 1.8.6 was just [released](https://docs.djangoproject.com/en/1.8/releases/1.8.6/).