### PR TITLE
Fix regression causing raw data form to not display

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -173,7 +173,7 @@
                     </div>
                   {% endif %}
 
-                  <div {% if raw_data_post_form %}class="tab-pane"{% endif %} id="post-generic-content-form">
+                  <div {% if post_form %}class="tab-pane"{% endif %} id="post-generic-content-form">
                     {% with form=raw_data_post_form %}
                       <form action="{{ request.get_full_path }}" method="POST" class="form-horizontal">
                         <fieldset>


### PR DESCRIPTION
34eb18b498e20ab1f869365cca6880186d64e966 introduced  #3578 that causes raw data form to not display when there is no html form tab.

This change reverts a specific change in the referred to commit that changed the logic of when to show the HTML and|or Raw Data POST forms as tabs in the API browser.

The correct logic is to show the Raw Data form as a tab if there is also an HTML form to render (i.e. there's two tabs in total). Otherwise display the Raw Data form as an unstyled div.

The faulty logic attempted to show the the Raw Data form as a tab whether or not there was a second tab containing the HTML form. As a result of Bootstrap's default styling on tab-pane (display: none), the raw data form would not be displayed.

See #3578 for screenshots.