### PR TITLE
Markdown compat

### DIFF
--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,4 +1,4 @@
 # Optional packages which may be used with REST framework.
-markdown==2.5.2
+markdown==2.6.4
 django-guardian==1.3.0
 django-filter==0.10.0

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -160,8 +160,7 @@ try:
         """
 
         extensions = ['headerid(level=2)']
-        safe_mode = False
-        md = markdown.Markdown(extensions=extensions, safe_mode=safe_mode)
+        md = markdown.Markdown(extensions=extensions)
         return md.convert(text)
 except ImportError:
     apply_markdown = None

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -159,7 +159,7 @@ try:
         of '#' style headers to <h2>.
         """
 
-        extensions = ['headerid(level=2)']
+        extensions = ['markdown.extensions.headerid(level=2)']
         md = markdown.Markdown(extensions=extensions)
         return md.convert(text)
 except ImportError:

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -152,16 +152,19 @@ if 'patch' not in View.http_method_names:
 try:
     import markdown
 
+    if markdown.version <= '2.2':
+        HEADERID_EXT_PATH = 'headerid'
+    else:
+        HEADERID_EXT_PATH = 'markdown.extensions.headerid'
 
     def apply_markdown(text):
         """
         Simple wrapper around :func:`markdown.markdown` to set the base level
         of '#' style headers to <h2>.
         """
-
-        extensions = ['markdown.extensions.headerid']
+        extensions = [HEADERID_EXT_PATH]
         extension_configs = {
-            'markdown.extensions.headerid': {
+            HEADERID_EXT_PATH: {
                 'level': '2'
             }
         }

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -159,8 +159,15 @@ try:
         of '#' style headers to <h2>.
         """
 
-        extensions = ['markdown.extensions.headerid(level=2)']
-        md = markdown.Markdown(extensions=extensions)
+        extensions = ['markdown.extensions.headerid']
+        extension_configs = {
+            'markdown.extensions.headerid': {
+                'level': '2'
+            }
+        }
+        md = markdown.Markdown(
+            extensions=extensions, extension_configs=extension_configs
+        )
         return md.convert(text)
 except ImportError:
     apply_markdown = None


### PR DESCRIPTION
The current `apply_markdown` generates the following `DeprecationWarning`s:

```
markdown/__init__.py:143: DeprecationWarning: "safe_mode" is deprecated in Python-Markdown. Use an HTML sanitizer (like Bleach http://bleach.readthedocs.org/) if you are parsing untrusted markdown text. See the 2.6 release notes for more info

markdown/__init__.py:222: DeprecationWarning: Setting configs in the Named Extension string is deprecated. It is recommended that you pass an instance of the extension class to Markdown or use the "extension_configs" keyword. The current behavior will raise an error in version 2.7. See the Release Notes for Python-Markdown version 2.6 for more info.

markdown/__init__.py:259: DeprecationWarning: Using short names for Markdown's builtin extensions is deprecated. Use the full path to the extension with Python's dot notation (eg: "markdown.extensions.headerid" instead of "headerid"). The current behavior will raise an error in version 2.7. See the Release Notes for Python-Markdown version 2.6 for more info.
```

These three commits correct them per the [Python-Markdown 2.6 release notes](http://pythonhosted.org/Markdown/release-2.6.html).