### PR TITLE
RelatedField get_queryset and context

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -330,6 +330,8 @@ To implement a custom relational field, you should override `RelatedField`, and 
 
 If you want to implement a read-write relational field, you must also implement the `.to_internal_value(self, data)` method.
 
+To provide a dynamic queryset based on the `context`, you can also override `.get_queryset(self)` instead of specifying `.queryset` on the class or when initializing the field.
+
 ## Example
 
 For example, we could define a relational field to serialize a track to a custom string representation, using its ordering, title, and duration.

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -62,6 +62,14 @@ class RelatedField(Field):
         self.queryset = kwargs.pop('queryset', self.queryset)
         self.html_cutoff = kwargs.pop('html_cutoff', self.html_cutoff)
         self.html_cutoff_text = kwargs.pop('html_cutoff_text', self.html_cutoff_text)
+
+        default_get_queryset = getattr(RelatedField.get_queryset, '__func__',
+                                       RelatedField.get_queryset)  # Python 2/3
+        if self.get_queryset.__func__ == default_get_queryset:
+            assert self.queryset is not None or kwargs.get('read_only', None), (
+                'Relational field must provide a `queryset` argument, '
+                'or set read_only=`True`.'
+            )
         assert not (self.queryset is not None and kwargs.get('read_only', None)), (
             'Relational fields should not provide a `queryset` argument, '
             'when setting read_only=`True`.'
@@ -108,10 +116,6 @@ class RelatedField(Field):
 
     def get_queryset(self):
         queryset = self.queryset
-        assert queryset is not None, (
-            'Relational field must provide a `queryset` argument, '
-            'or set read_only=`True`.'
-        )
         if isinstance(queryset, (QuerySet, Manager)):
             # Ensure queryset is re-evaluated whenever used.
             # Note that actually a `Manager` class may also be used as the

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -18,7 +18,16 @@ from rest_framework.fields import (
     Field, empty, get_attribute, is_simple_callable, iter_options
 )
 from rest_framework.reverse import reverse
-from rest_framework.utils import html, overridden
+from rest_framework.utils import html
+
+
+def method_overridden(method_name, klass, instance):
+    """
+    Determine if a method has been overridden.
+    """
+    method = getattr(klass, method_name)
+    default_method = getattr(method, '__func__', method)  # Python 3 compat
+    return default_method is not getattr(instance, method_name).__func__
 
 
 class Hyperlink(six.text_type):
@@ -63,7 +72,7 @@ class RelatedField(Field):
         self.html_cutoff = kwargs.pop('html_cutoff', self.html_cutoff)
         self.html_cutoff_text = kwargs.pop('html_cutoff_text', self.html_cutoff_text)
 
-        if not overridden.method_overridden('get_queryset', RelatedField, self):
+        if not method_overridden('get_queryset', RelatedField, self):
             assert self.queryset is not None or kwargs.get('read_only', None), (
                 'Relational field must provide a `queryset` argument, '
                 'or set read_only=`True`.'

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -18,7 +18,7 @@ from rest_framework.fields import (
     Field, empty, get_attribute, is_simple_callable, iter_options
 )
 from rest_framework.reverse import reverse
-from rest_framework.utils import html
+from rest_framework.utils import html, overridden
 
 
 class Hyperlink(six.text_type):
@@ -63,9 +63,7 @@ class RelatedField(Field):
         self.html_cutoff = kwargs.pop('html_cutoff', self.html_cutoff)
         self.html_cutoff_text = kwargs.pop('html_cutoff_text', self.html_cutoff_text)
 
-        default_get_queryset = getattr(RelatedField.get_queryset, '__func__',
-                                       RelatedField.get_queryset)  # Python 2/3
-        if self.get_queryset.__func__ == default_get_queryset:
+        if not overridden.method_overridden('get_queryset', RelatedField, self):
             assert self.queryset is not None or kwargs.get('read_only', None), (
                 'Relational field must provide a `queryset` argument, '
                 'or set read_only=`True`.'

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -62,10 +62,6 @@ class RelatedField(Field):
         self.queryset = kwargs.pop('queryset', self.queryset)
         self.html_cutoff = kwargs.pop('html_cutoff', self.html_cutoff)
         self.html_cutoff_text = kwargs.pop('html_cutoff_text', self.html_cutoff_text)
-        assert self.queryset is not None or kwargs.get('read_only', None), (
-            'Relational field must provide a `queryset` argument, '
-            'or set read_only=`True`.'
-        )
         assert not (self.queryset is not None and kwargs.get('read_only', None)), (
             'Relational fields should not provide a `queryset` argument, '
             'when setting read_only=`True`.'
@@ -112,6 +108,10 @@ class RelatedField(Field):
 
     def get_queryset(self):
         queryset = self.queryset
+        assert queryset is not None, (
+            'Relational field must provide a `queryset` argument, '
+            'or set read_only=`True`.'
+        )
         if isinstance(queryset, (QuerySet, Manager)):
             # Ensure queryset is re-evaluated whenever used.
             # Note that actually a `Manager` class may also be used as the

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -75,7 +75,7 @@ class RelatedField(Field):
         if not method_overridden('get_queryset', RelatedField, self):
             assert self.queryset is not None or kwargs.get('read_only', None), (
                 'Relational field must provide a `queryset` argument, '
-                'or set read_only=`True`.'
+                'override `get_queryset`, or set read_only=`True`.'
             )
         assert not (self.queryset is not None and kwargs.get('read_only', None)), (
             'Relational fields should not provide a `queryset` argument, '

--- a/rest_framework/utils/overridden.py
+++ b/rest_framework/utils/overridden.py
@@ -1,0 +1,7 @@
+def method_overridden(method_name, klass, instance):
+    """
+    Determine if a method has been overridden.
+    """
+    method = getattr(klass, method_name)
+    default_method = getattr(method, '__func__', method)  # Python 3 compat
+    return default_method is not getattr(instance, method_name).__func__

--- a/rest_framework/utils/overridden.py
+++ b/rest_framework/utils/overridden.py
@@ -1,7 +1,0 @@
-def method_overridden(method_name, klass, instance):
-    """
-    Determine if a method has been overridden.
-    """
-    method = getattr(klass, method_name)
-    default_method = getattr(method, '__func__', method)  # Python 3 compat
-    return default_method is not getattr(instance, method_name).__func__

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -176,6 +176,14 @@ class TestSlugRelatedField(APISimpleTestCase):
         representation = self.field.to_representation(self.instance)
         assert representation == self.instance.name
 
+    def test_no_queryset_init(self):
+        class NoQuerySetSlugRelatedField(serializers.SlugRelatedField):
+            def get_queryset(this):
+                return self.queryset
+
+        field = NoQuerySetSlugRelatedField(slug_field='name')
+        field.to_internal_value(self.instance.name)
+
 
 class TestManyRelatedField(APISimpleTestCase):
     def setUp(self):


### PR DESCRIPTION
Currently `get_queryset` is not a part of the documented API of `RelatedField`. This pull request makes it a documented part of the API, and adds a test using that feature with a subclass of `SlugRelatedField`.