### PR TITLE
Don't specify basepython

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,6 @@ envlist =
        {py27,py34,py35}-django{19}
 
 [testenv]
-basepython =
-            py27: python2.7
-            py32: python3.2
-            py33: python3.3
-            py34: python3.4
-            py35: python3.5
-
 commands = ./runtests.py --fast {posargs} --coverage
 setenv =
        PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
tox automatically includes basepython definitions for all the common python versions, and will recognize it in factors of envs in the envlist.