### PR TITLE
Fixes testrunner content negotiation failures on Django 1.8.5

### DIFF
--- a/rest_framework/negotiation.py
+++ b/rest_framework/negotiation.py
@@ -93,5 +93,12 @@ class DefaultContentNegotiation(BaseContentNegotiation):
         Given the incoming request, return a tokenised list of media
         type strings.
         """
-        header = request.META.get('HTTP_ACCEPT', '*/*')
+        header = request.META.get('HTTP_ACCEPT')
+        if not header:
+            if 'headers' in request.META.keys():
+                header = request.META['headers'].get('Accept', '*/*')
+            else:
+                header = '*/*'
+
+        header = request.query_params.get(self.settings.URL_ACCEPT_OVERRIDE, header)
         return [token.strip() for token in header.split(',')]

--- a/rest_framework/negotiation.py
+++ b/rest_framework/negotiation.py
@@ -100,5 +100,4 @@ class DefaultContentNegotiation(BaseContentNegotiation):
             else:
                 header = '*/*'
 
-        header = request.query_params.get(self.settings.URL_ACCEPT_OVERRIDE, header)
         return [token.strip() for token in header.split(',')]


### PR DESCRIPTION
There was a small issue with content negotiation under Django 1.8.5(haven't tested earlier versions tho). Here's what happens:

 - I'm using custom versioning with mediatypes like `application/vnd.myapp.api.v(int)+json`
 - in normal traffic everything was OK both in production(uWSGI) and dev servers
 - in tests no matter what I've passed in the Accept header, API would return the "default" JSON response - looked like content negotiation died for no apparent reason

versioning code: http://pastebin.com/KdeEHGff
testcase: http://pastebin.com/jreDfe0v

Cause: Django's test runner passes headers to a view in a different way WSGIs do it - headers aren't passed in `request.META['HTTP_*']` but in `request.META['headers']`, as a dictionary. DRF default negotiation assumed that if Accept header wasn't passed the WSGI way, it's not there at all and returned the dummy response.