### PR TITLE
Login form autofocus

### DIFF
--- a/rest_framework/templates/rest_framework/login_base.html
+++ b/rest_framework/templates/rest_framework/login_base.html
@@ -25,7 +25,7 @@
                   <input type="text" name="username" maxlength="100"
                       autocapitalize="off"
                       autocorrect="off" class="form-control textinput textInput"
-                      id="id_username" required
+                      id="id_username" required autofocus
                       {% if form.username.value %}value="{{ form.username.value }}"{% endif %}>
                   {% if form.username.errors %}
                     <p class="text-error">


### PR DESCRIPTION
I would be handy if the login input of the login form was auto-selected when landing on the page. 
This is easily done by adding the HTML5 tag `autofocus`.