### PR TITLE
Fix module name with Python 3.5 (#3534)

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -186,7 +186,10 @@ class TestUserSetter(TestCase):
         try:
             self.request.user
         except AttributeError as error:
-            self.assertEqual(str(error), "'module' object has no attribute 'MISSPELLED_NAME_THAT_DOESNT_EXIST'")
+            assert str(error) in (
+                "'module' object has no attribute 'MISSPELLED_NAME_THAT_DOESNT_EXIST'",  # Python < 3.5
+                "module 'rest_framework' has no attribute 'MISSPELLED_NAME_THAT_DOESNT_EXIST'",  # Python >= 3.5
+            )
         else:
             assert False, 'AttributeError not raised'
 


### PR DESCRIPTION
This should fix our test suite under Python 3.5.
Fix #3534