### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ from rest_framework import serializers, viewsets, routers
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
-        fields = ('username', 'email', 'is_staff')
+        fields = ('url', 'username', 'email', 'is_staff')
 
 
 # ViewSets define the view behavior.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ from rest_framework import serializers, viewsets, routers
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
-        fields = ('url', 'username', 'email', 'is_staff')
+        fields = ('username', 'email', 'is_staff')
 
 
 # ViewSets define the view behavior.

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,7 +135,7 @@ Here's our project's root `urls.py` module:
         url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
     ]
 
-You can now open the API in your browser at [http://127.0.0.1:8000/](http://127.0.0.1:8000/), and view your new 'users' API. If you use the login control in the top right corner you'll also be able to add, create and delete users from the system.
+Do not use a namespace when you include your router urls as they are not currently supported. You can now open the API in your browser at [http://127.0.0.1:8000/](http://127.0.0.1:8000/), and view your new 'users' API. If you use the login control in the top right corner you'll also be able to add, create and delete users from the system.
 
 ## Quickstart
 


### PR DESCRIPTION
Added documentation warning about using a namespace with the example's router urls include, as discussed in Issue #3645.