### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ from rest_framework import serializers, viewsets, routers
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
-        fields = ('username', 'email', 'is_staff')
+        fields = ('url', 'username', 'email', 'is_staff')
 
 
 # ViewSets define the view behavior.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ from rest_framework import serializers, viewsets, routers
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
-        fields = ('url', 'username', 'email', 'is_staff')
+        fields = ('username', 'email', 'is_staff')
 
 
 # ViewSets define the view behavior.

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,7 +135,7 @@ Here's our project's root `urls.py` module:
         url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
     ]
 
-Do not use a namespace when you include your router urls as they are not currently supported. You can now open the API in your browser at [http://127.0.0.1:8000/](http://127.0.0.1:8000/), and view your new 'users' API. If you use the login control in the top right corner you'll also be able to add, create and delete users from the system.
+If you choose to use a namespace when including your router urls you will need to do some additional work, as documented in [Using include with routers](http://www.django-rest-framework.org/api-guide/routers/#using-include-with-routers). You can now open the API in your browser at [http://127.0.0.1:8000/](http://127.0.0.1:8000/), and view your new 'users' API. If you use the login control in the top right corner you'll also be able to add, create and delete users from the system.
 
 ## Quickstart
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,7 +135,7 @@ Here's our project's root `urls.py` module:
         url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
     ]
 
-You can now open the API in your browser at [http://127.0.0.1:8000/](http://127.0.0.1:8000/), and view your new 'users' API. If you use the login control in the top right corner you'll also be able to add, create and delete users from the system.
+Do not use a namespace when you include your router urls as they are not currently supported. You can now open the API in your browser at [http://127.0.0.1:8000/](http://127.0.0.1:8000/), and view your new 'users' API. If you use the login control in the top right corner you'll also be able to add, create and delete users from the system.
 
 ## Quickstart
 


### PR DESCRIPTION
Following up on https://github.com/tomchristie/django-rest-framework/pull/3651#issuecomment-157564935. I agree that namespaces require further learning on the user's part, in addition to the README. That said, this is a very common use-case where a new user tries to use include with router urls. This could be for any of the following reasons:

- The user comes from a Django background and is familiar with namespaces already
- The user sees the namespace used on the very next line (url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))) and wants to do the same for the router include line
- The user is new to Django REST framework and has very likely not gone through the router documentation yet

This fix warns the new user about using include with router urls and links to the relevant documentation, avoiding a lot of new user frustration.