### PR TITLE
Fix overzealous RelatedField queryset validation

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -322,16 +322,6 @@ class Field(object):
         Called when a field is added to the parent serializer instance.
         """
 
-        # In order to enforce a consistent style, we error if a redundant
-        # 'source' argument has been used. For example:
-        # my_field = serializer.CharField(source='my_field')
-        assert self.source != field_name, (
-            "It is redundant to specify `source='%s'` on field '%s' in "
-            "serializer '%s', because it is the same as the field name. "
-            "Remove the `source` keyword argument." %
-            (field_name, self.__class__.__name__, parent.__class__.__name__)
-        )
-
         self.field_name = field_name
         self.parent = parent
 

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -65,10 +65,6 @@ class RelatedField(Field):
         self.queryset = kwargs.pop('queryset', self.queryset)
         self.html_cutoff = kwargs.pop('html_cutoff', self.html_cutoff)
         self.html_cutoff_text = kwargs.pop('html_cutoff_text', self.html_cutoff_text)
-        assert self.queryset is not None or kwargs.get('read_only', None), (
-            'Relational field must provide a `queryset` argument, '
-            'or set read_only=`True`.'
-        )
         kwargs.pop('many', None)
         kwargs.pop('allow_empty', None)
         super(RelatedField, self).__init__(**kwargs)

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -69,10 +69,6 @@ class RelatedField(Field):
             'Relational field must provide a `queryset` argument, '
             'or set read_only=`True`.'
         )
-        assert not (self.queryset is not None and kwargs.get('read_only', None)), (
-            'Relational fields should not provide a `queryset` argument, '
-            'when setting read_only=`True`.'
-        )
         kwargs.pop('many', None)
         kwargs.pop('allow_empty', None)
         super(RelatedField, self).__init__(**kwargs)

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -314,7 +314,7 @@ def get_validation_error_detail(exc):
         # If errors may be a dict we use the standard {key: list of values}.
         # Here we ensure that all the values are *lists* of errors.
         return {
-            key: value if isinstance(value, list) else [value]
+            key: value if isinstance(value, (list, dict)) else [value]
             for key, value in exc.detail.items()
         }
     elif isinstance(exc.detail, list):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -49,6 +49,24 @@ class ShouldValidateModelSerializer(serializers.ModelSerializer):
         fields = ('renamed',)
 
 
+class TestNestedValidationError(TestCase):
+    def test_nested_validation_error_detail(self):
+        """
+        Ensure nested validation error detail is rendered correctly.
+        """
+        e = serializers.ValidationError({
+            'nested': {
+                'field': ['error'],
+            }
+        })
+
+        self.assertEqual(serializers.get_validation_error_detail(e), {
+            'nested': {
+                'field': ['error'],
+            }
+        })
+
+
 class TestPreSaveValidationExclusionsSerializer(TestCase):
     def test_renamed_fields_are_model_validated(self):
         """


### PR DESCRIPTION
Otherwise if you want to subclass RelatedField in a read+write capacity you end up with this weird situation:
```
    class MyField(serializers.RelatedField):
        def __init__(self, **kwargs):
            if not kwargs.get('read_only'):
                kwargs.setdefault('queryset', MyModel.objects.all())
            super(MyField, self).__init__(**kwargs)
```

This commit removes the check preventing you from just supplying the queryset anyway. (Why shouldn't you?)

Every single relatedfield subclass we have (lots) has an obvious default queryset kwarg, so it seems this can't be an uncommon case.