### PR TITLE
Make tests pass on Windows too

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,5 +2,6 @@
 skip=.tox
 atomic=true
 multi_line_output=5
+known_standard_library=types
 known_third_party=pytest,django
 known_first_party=rest_framework

--- a/requirements/requirements-codestyle.txt
+++ b/requirements/requirements-codestyle.txt
@@ -3,4 +3,4 @@ flake8==2.4.0
 pep8==1.5.7
 
 # Sort and lint imports
-isort==3.9.6
+isort==4.2.2

--- a/requirements/requirements-packaging.txt
+++ b/requirements/requirements-packaging.txt
@@ -5,4 +5,4 @@ wheel==0.24.0
 twine==1.4.0
 
 # Transifex client for managing translation resources.
-transifex-client==0.11b3
+transifex-client==0.11

--- a/rest_framework/utils/representation.py
+++ b/rest_framework/utils/representation.py
@@ -40,7 +40,7 @@ def smart_repr(value):
     # <django.core.validators.RegexValidator object at 0x1047af050>
     # Should be presented as
     # <django.core.validators.RegexValidator object>
-    value = re.sub(' at 0x[0-9a-f]{4,32}>', '>', value)
+    value = re.sub(' at 0x[0-9A-Fa-f]{4,32}>', '>', value)
 
     return value
 


### PR DESCRIPTION
These are refined versions of the commits that previously lived in #3668.

## Upgrade transifex-client dependency to 0.11

Version 0.11b3's setup.py had an undeclared dependency on `py2exe` when running on Windows (see https://github.com/transifex/transifex-client/blob/0.11b3/setup.py#L23), which made it impossible to install without having a working `py2exe` to begin with.

This has been fixed in 0.11 proper.

## Upgrade isort to 4.2.2.

This gets rid of a file encoding bug that occurs on Windows boxes where the default implied encoding is cp1252, but the files themselves aren't. The actual patch that seems to fix this is
https://github.com/timothycrosley/isort/commit/1057d5e12edbb3030045b7a7a8c82f0848635fef
but it seems like a good idea to upgrade to the latest and greatest.

## Add `types` to isort's standard library list.

This re-stabilizes sorting after upgrading to 4.2.2.

## Fix `smart_repr()` to also clean upper-case hex addresses.

Windows Pythons seem to like printing addresses in upper-case, while Linux Pythons like lower-case hexes.

This led to an amusing (for a given value of "amusing", anyway) situation where some repr tests would fail if the objects they were testing happened to be allocated at an address with a hex digit in the range A..F.
