### PR TITLE
Updated NestedBoundField to also handle empty string when rendering its form

### DIFF
--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -90,7 +90,7 @@ class NestedBoundField(BoundField):
     """
 
     def __init__(self, field, value, errors, prefix=''):
-        if value is None:
+        if value is None or value is '':
             value = {}
         super(NestedBoundField, self).__init__(field, value, errors, prefix)
 


### PR DESCRIPTION
If a NestedBoundField field has a value of `None` and is inside another NestedBoundField field, it will have its value converted to an empty string while the form of its enclosing field is being rendered. So, NestedBoundField fields with an empty string value must be handled the same way as NestedBoundField fields with a `None` value.