### PR TITLE
Fixed #3679 -- UUID Validation

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -769,9 +769,11 @@ class UUIDField(Field):
             try:
                 if isinstance(data, six.integer_types):
                     return uuid.UUID(int=data)
-                else:
+                elif isinstance(data, six.string_types):
                     return uuid.UUID(hex=data)
-            except (ValueError, TypeError):
+                else:
+                    self.fail('invalid', value=data)
+            except (ValueError):
                 self.fail('invalid', value=data)
         return data
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -609,7 +609,8 @@ class TestUUIDField(FieldValues):
         284758210125106368185219588917561929842: uuid.UUID('d63a6fb6-88d5-40c7-a91c-9edf73283072')
     }
     invalid_inputs = {
-        '825d7aeb-05a9-45b5-a5b7': ['"825d7aeb-05a9-45b5-a5b7" is not a valid UUID.']
+        '825d7aeb-05a9-45b5-a5b7': ['"825d7aeb-05a9-45b5-a5b7" is not a valid UUID.'],
+        (1, 2, 3): ['"(1, 2, 3)" is not a valid UUID.']
     }
     outputs = {
         uuid.UUID('825d7aeb-05a9-45b5-a5b7-05df87923cda'): '825d7aeb-05a9-45b5-a5b7-05df87923cda'


### PR DESCRIPTION
Fixed #3679 

Added validation to UUIDField to properly catch invalid input types (lists, tuples, etc).
Also added a new invalid input to UUIDField test.  Not sure I'm entirely happy with
the patch as it currently is, since it seems to have some unnecessary redundancy
but I figured I go ahead and push it up now since it does work.  Comments and
suggestions are appreciated.