### PR TITLE
Add missing csrf_token in AdminRenderer post form.

### DIFF
--- a/rest_framework/templates/rest_framework/admin.html
+++ b/rest_framework/templates/rest_framework/admin.html
@@ -166,6 +166,7 @@
       <form action="{{ request.get_full_path }}" method="POST" enctype="multipart/form-data" class="form-horizontal" novalidate>
         <div class="modal-body">
           <fieldset>
+            {% csrf_token %}
             {{ post_form }}
           </fieldset>
         </div>


### PR DESCRIPTION
CSRF token was missing during object creation through Create form in AdminRenderer. An analogous csrf_token tag in the base browsable API form was introduced in 41182c6f.