### PR TITLE
Fixed versioning regexp

### DIFF
--- a/docs/api-guide/versioning.md
+++ b/docs/api-guide/versioning.md
@@ -135,7 +135,7 @@ Your URL conf must include a pattern that matches the version with a `'version'`
             name='bookings-list'
         ),
         url(
-            r'^(?P<version>[v1|v2]+)/bookings/(?P<pk>[0-9]+)/$',
+            r'^(?P<version>(v1|v2))/bookings/(?P<pk>[0-9]+)/$',
             bookings_detail,
             name='bookings-detail'
         )


### PR DESCRIPTION
booking list regexp was fixed in https://github.com/tomchristie/django-rest-framework/commit/8b97bb8f68970881190a3b62cf53495cc0e20786 but single booking wasn't for some reason, and `v1v2/bookings/123/` shouldn't be allowed here