### PR TITLE
Add app_name to rest_framework.urls.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,7 @@ If you're intending to use the browsable API you'll probably also want to add RE
         url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
     ]
 
-Note that the URL path can be whatever you want, but you must include `'rest_framework.urls'` with the `'rest_framework'` namespace.
+Note that the URL path can be whatever you want, but you must include `'rest_framework.urls'` with the `'rest_framework'` namespace. You may leave out the namespace in Django 1.9+, and REST framework will set it for you.
 
 ## Example
 

--- a/docs/tutorial/4-authentication-and-permissions.md
+++ b/docs/tutorial/4-authentication-and-permissions.md
@@ -146,7 +146,7 @@ And, at the end of the file, add a pattern to include the login and logout views
                                    namespace='rest_framework')),
     ]
 
-The `r'^api-auth/'` part of pattern can actually be whatever URL you want to use.  The only restriction is that the included urls must use the `'rest_framework'` namespace.
+The `r'^api-auth/'` part of pattern can actually be whatever URL you want to use.  The only restriction is that the included urls must use the `'rest_framework'` namespace. In Django 1.9+, REST framework will set the namespace, so you may leave it out.
 
 Now if you open up the browser again and refresh the page you'll see a 'Login' link in the top right of the page.  If you log in as one of the users you created earlier, you'll be able to create code snippets again.
 

--- a/rest_framework/urls.py
+++ b/rest_framework/urls.py
@@ -9,8 +9,8 @@ your API requires authentication:
         url(r'^auth/', include('rest_framework.urls', namespace='rest_framework'))
     ]
 
-The urls must be namespaced as 'rest_framework', and you should make sure
-your authentication settings include `SessionAuthentication`.
+In Django versions older than 1.9, the urls must be namespaced as 'rest_framework',
+and you should make sure your authentication settings include `SessionAuthentication`.
 """
 from __future__ import unicode_literals
 
@@ -19,6 +19,7 @@ from django.contrib.auth import views
 
 template_name = {'template_name': 'rest_framework/login.html'}
 
+app_name = 'rest_framework'
 urlpatterns = [
     url(r'^login/$', views.login, template_name, name='login'),
     url(r'^logout/$', views.logout, template_name, name='logout'),


### PR DESCRIPTION
This allows users in Django 1.9+ to include the authentication urls
without specifying the namespace, as in:

```python
urlpatterns = [
    ...
    url(r'^auth/', include('rest_framework.urls'))
]
```

The urls will still be namespaced, but will use the namespace set by the `app_name`. 