### PR TITLE
Fixed suggestion for format in test renderer

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -780,7 +780,7 @@ class MultiPartRenderer(BaseRenderer):
                 assert not isinstance(value, dict), (
                     "Test data contained a dictionary value for key '%s', "
                     "but multipart uploads do not support nested data. "
-                    "You may want to consider using format='JSON' in this "
+                    "You may want to consider using format='json' in this "
                     "test case." % key
                 )
         return encode_multipart(self.BOUNDARY, data)


### PR DESCRIPTION
Rendered would suggest using `format='JSON'` when the right argument is `format='json'`.