### PR TITLE
Fix tox build against python 3.5 by upgrading pytest.

### DIFF
--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -1,4 +1,4 @@
 # PyTest for running the tests.
-pytest==2.6.4
-pytest-django==2.8.0
+pytest==2.8.5
+pytest-django==2.9.1
 pytest-cov==1.8.1


### PR DESCRIPTION
With the current versions for pytest I get errors while collecting some files against python3.5:

    .tox/py35-django19/lib/python3.5/site-packages/_pytest/assertion/rewrite.py:682: in visit_Name
        locs = ast.Call(self.builtin("locals"), [], [], None, None)
    E   TypeError: Call constructor takes either 0 or 3 positional arguments