### PR TITLE
Display py.test internal warnings

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -8,8 +8,8 @@ import sys
 import pytest
 
 PYTEST_ARGS = {
-    'default': ['tests', '--tb=short', '-s'],
-    'fast': ['tests', '--tb=short', '-q', '-s'],
+    'default': ['tests', '--tb=short', '-s', '-rw'],
+    'fast': ['tests', '--tb=short', '-q', '-s', '-rw'],
 }
 
 FLAKE8_ARGS = ['rest_framework', 'tests', '--ignore=E501']

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
        {py27,py34,py35}-django{19}
 
 [testenv]
-commands = ./runtests.py --fast {posargs} --coverage
+commands = ./runtests.py --fast {posargs} --coverage -rw
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =


### PR DESCRIPTION
This is pretty much the first step to ensure we don't skip some tests.
At the moment, it's not possible to mark them as errors (https://github.com/pytest-dev/pytest/issues/1173) however, it's better to show them rather than leave them hidden.

In particular since we already have two of them which may break some tests:

    WC1 [...]/django-rest-framework/tests/test_model_serializer.py cannot collect test class 'TestMetaClassModel' because it has a __init__ constructor
    WC1 [...]/django-rest-framework/tests/browsable_api/test_browsable_nested_api.py cannot collect test class 'TestNestedSerializerSerializer' because it has a __init__ constructor
