### PR TITLE
Move urls.py changes down and add necessary import

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -48,12 +48,6 @@ We'll need to add our new `snippets` app and the `rest_framework` app to `INSTAL
         'snippets',
     )
 
-We also need to wire up the root urlconf, in the `tutorial/urls.py` file, to include our snippet app's URLs.
-
-    urlpatterns = [
-        url(r'^', include('snippets.urls')),
-    ]
-
 Okay, we're ready to roll.
 
 ## Creating a model to work with
@@ -298,6 +292,14 @@ Finally we need to wire these views up.  Create the `snippets/urls.py` file:
     urlpatterns = [
         url(r'^snippets/$', views.snippet_list),
         url(r'^snippets/(?P<pk>[0-9]+)/$', views.snippet_detail),
+    ]
+    
+We also need to wire up the root urlconf, in the `tutorial/urls.py` file, to include our snippet app's URLs.
+    
+    from django.conf.urls import url, include
+    
+    urlpatterns = [
+        url(r'^', include('snippets.urls')),
     ]
 
 It's worth noting that there are a couple of edge cases we're not dealing with properly at the moment.  If we send malformed `json`, or if a request is made with a method that the view doesn't handle, then we'll end up with a 500 "server error" response.  Still, this'll do for now.


### PR DESCRIPTION
If you follow the current tutorial precisely the user will end up with an error when they try to run the first migration. In order to work as written, the part where tutorial/urls.py is edited needs to be moved after the new snippets/urls.py file is created. This has no effect on the first part of the tutorial as the urls.py file is not needed until the web interface is created in the second half.

Additionally, it is helpful to note that 'include' needs to be added to the pre-existing imports as it is not part of the generated file from Django.