### PR TITLE
Include 'initial' attribute of serializer fields in metadata responses

### DIFF
--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -124,7 +124,8 @@ class SimpleMetadata(BaseMetadata):
         attrs = [
             'read_only', 'label', 'help_text',
             'min_length', 'max_length',
-            'min_value', 'max_value'
+            'min_value', 'max_value',
+            'initial'
         ]
 
         for attr in attrs:

--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -130,7 +130,7 @@ class SimpleMetadata(BaseMetadata):
 
         for attr in attrs:
             value = getattr(field, attr, None)
-            if value is not None and value != '':
+            if value is not None and value != '' and value != []:
                 field_info[attr] = force_text(value, strings_only=True)
 
         if getattr(field, 'child', None):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -69,7 +69,8 @@ class TestMetadata:
                 min_value=1, max_value=1000
             )
             char_field = serializers.CharField(
-                required=False, min_length=3, max_length=40
+                required=False, min_length=3, max_length=40,
+                initial='initial value'
             )
             list_field = serializers.ListField(
                 child=serializers.ListField(
@@ -128,7 +129,8 @@ class TestMetadata:
                         'read_only': False,
                         'label': 'Char field',
                         'min_length': 3,
-                        'max_length': 40
+                        'max_length': 40,
+                        'initial': 'initial value'
                     },
                     'list_field': {
                         'type': 'list',


### PR DESCRIPTION
Frontend applications may now use the response of an OPTIONS request so as to populate the fields for "add/new/create" type of forms with initial values based on the 'initial' attribute of the serializer's fields.