### PR TITLE
Subclass AutoFilterSet from self.default_filter_set

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -99,7 +99,7 @@ class DjangoFilterBackend(BaseFilterBackend):
             return filter_class
 
         if filter_fields:
-            class AutoFilterSet(FilterSet):
+            class AutoFilterSet(self.default_filter_set):
                 class Meta:
                     model = queryset.model
                     fields = filter_fields


### PR DESCRIPTION
A regression was introduced here: https://github.com/tomchristie/django-rest-framework/commit/aeb57913c9f2a7ad1ffc1db825c3e6f44b4818ee

The super class of `AutoFilterSet` was change to just `FilterSet`, which causes custom default filter sets to be ignored. This PR fixes the regression.