### PR TITLE
fix TypeError: list indices must be integers, not str

### DIFF
--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -201,7 +201,7 @@ class APISettings(object):
 
         try:
             # Check if present in user settings
-            val = self.user_settings[attr]
+            val = self.user_settings[0][attr]
         except KeyError:
             # Fall back to defaults
             val = self.defaults[attr]


### PR DESCRIPTION
Making this change allowed me to run the server after going through the quickstart tutorial.