### PR TITLE
Update bootstrap version in browsable-api.md

### DIFF
--- a/docs/topics/browsable-api.md
+++ b/docs/topics/browsable-api.md
@@ -17,7 +17,7 @@ By default, the API will return the format specified by the headers, which in th
 
 ## Customizing
 
-The browsable API is built with [Twitter's Bootstrap][bootstrap] (v 2.1.1), making it easy to customize the look-and-feel.
+The browsable API is built with [Twitter's Bootstrap][bootstrap] (v 3.3.5), making it easy to customize the look-and-feel.
 
 To customize the default style, create a template called `rest_framework/api.html` that extends from `rest_framework/base.html`.  For example:
 


### PR DESCRIPTION
I was quite confused for a while because I was using Bootstrap v2.1.1 themes, which I assumed would work with the v2.1.1 that the [Customizing](http://www.django-rest-framework.org/topics/browsable-api/#customizing) section of the documentation claims django-rest-framework uses. However, this resulted in very odd visuals.

It wasn't until I searched github and found that the framework has apparently abandoned v2.1.1 for quite some time, and is apparently on v3.3.5 as of https://github.com/tomchristie/django-rest-framework/pull/3547, that I realized what was wrong.

So, this simple fix updates the version of Bootstrap mentioned in the docs.

Another alternative to this fix may be to simply mention that REST framework uses "bootstrap 3", in which case the docs are less likely to become inadvertently outdated.