### PR TITLE
Add 'default' value in OPTIONS

### DIFF
--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -131,6 +131,9 @@ class SimpleMetadata(BaseMetadata):
         for attr in attrs:
             value = getattr(field, attr, None)
             if value is not None and value != '' and value != empty:
+                if hasattr(value, '__call__'):
+                    value.set_context(field)
+                    value = value()
                 field_info[attr] = force_text(value, strings_only=True)
 
         if getattr(field, 'child', None):

--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -15,6 +15,7 @@ from django.http import Http404
 from django.utils.encoding import force_text
 
 from rest_framework import exceptions, serializers
+from rest_framework.fields import empty
 from rest_framework.request import clone_request
 from rest_framework.utils.field_mapping import ClassLookupDict
 
@@ -123,13 +124,13 @@ class SimpleMetadata(BaseMetadata):
 
         attrs = [
             'read_only', 'label', 'help_text',
-            'min_length', 'max_length',
+            'min_length', 'max_length', 'default',
             'min_value', 'max_value'
         ]
 
         for attr in attrs:
             value = getattr(field, attr, None)
-            if value is not None and value != '':
+            if value is not None and value != '' and value != empty:
                 field_info[attr] = force_text(value, strings_only=True)
 
         if getattr(field, 'child', None):

--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -131,7 +131,7 @@ class SimpleMetadata(BaseMetadata):
         for attr in attrs:
             value = getattr(field, attr, None)
             if value is not None and value != '' and value != empty:
-                if hasattr(value, '__call__'):
+                if callable(value):
                     value.set_context(field)
                     value = value()
                 field_info[attr] = force_text(value, strings_only=True)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -69,7 +69,7 @@ class TestMetadata:
                 min_value=1, max_value=1000
             )
             char_field = serializers.CharField(
-                required=False, min_length=3, max_length=40
+                required=False, min_length=3, max_length=40, default='Cookie'
             )
             list_field = serializers.ListField(
                 child=serializers.ListField(
@@ -128,7 +128,8 @@ class TestMetadata:
                         'read_only': False,
                         'label': 'Char field',
                         'min_length': 3,
-                        'max_length': 40
+                        'max_length': 40,
+                        'default': 'Cookie'
                     },
                     'list_field': {
                         'type': 'list',

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -77,6 +77,7 @@ class TestMetadata:
                 )
             )
             nested_field = NestedField()
+            defaultuser_field = serializers.HiddenField(default=serializers.CurrentUserDefault())
 
         class ExampleView(views.APIView):
             """Example view."""
@@ -84,7 +85,10 @@ class TestMetadata:
                 pass
 
             def get_serializer(self):
-                return ExampleSerializer()
+                if self.request:
+                    return ExampleSerializer(context={'request': self.request})
+                else:
+                    return ExampleSerializer()
 
         view = ExampleView.as_view()
         response = view(request=request)
@@ -166,6 +170,13 @@ class TestMetadata:
                                 'label': 'B'
                             }
                         }
+                    },
+                    'defaultuser_field': {
+                        'type': 'field',
+                        'required': False,
+                        'read_only': False,
+                        'label': 'Defaultuser field',
+                        'default': 'AnonymousUser'
                     }
                 }
             }


### PR DESCRIPTION
For some frameworks who rely on automatic form generation (Angular, Polymer..) we need to see the default option provided in `OPTIONS` metadata.

I saw your concerns on Model's default attribute in #2683 so I have not included this on ModelSerializer for now.

But I think DRF shoul'd pass the model's `default` attribute in the `rest_framework.field.Field` when using a ModelSerializer to let thoses frameworks know what will be the value if not provided.