### PR TITLE
Min/MaxValueValidator is no longer transferred from a model's DecimalField

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -133,7 +133,7 @@ def get_field_kwargs(field_name, model_field):
     if isinstance(model_field, models.DecimalField) and DecimalValidator:
         validator_kwarg = [
             validator for validator in validator_kwarg
-            if DecimalValidator and not isinstance(validator, DecimalValidator)
+            if not isinstance(validator, DecimalValidator)
         ]
 
     # Ensure that max_length is passed explicitly as a keyword arg,

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -130,7 +130,7 @@ def get_field_kwargs(field_name, model_field):
 
     # Our decimal validation is handled in the field code, not validator code.
     # (In Django 1.9+ this differs from previous style)
-    if isinstance(model_field, models.DecimalField):
+    if isinstance(model_field, models.DecimalField) and DecimalValidator:
         validator_kwarg = [
             validator for validator in validator_kwarg
             if DecimalValidator and not isinstance(validator, DecimalValidator)

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -884,7 +884,7 @@ class TestDecimalFieldMappings(TestCase):
 
         serializer = TestSerializer()
 
-        assert len(serializer.fields['decimal_field'].validators) == 0
+        assert len(serializer.fields['decimal_field'].validators) == 2
 
     @pytest.mark.skipif(DecimalValidator is None,
                         reason='DecimalValidator is available in Django 1.9+')

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -899,3 +899,29 @@ class TestDecimalFieldMappings(TestCase):
         serializer = TestSerializer()
 
         assert len(serializer.fields['decimal_field'].validators) == 2
+
+    def test_min_value_is_passed(self):
+        """
+        Test that the `MinValueValidator` is converted to the `min_value`
+        argument for the field.
+        """
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = DecimalFieldModel
+
+        serializer = TestSerializer()
+
+        assert serializer.fields['decimal_field'].min_value == 1
+
+    def test_max_value_is_passed(self):
+        """
+        Test that the `MaxValueValidator` is converted to the `max_value`
+        argument for the field.
+        """
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = DecimalFieldModel
+
+        serializer = TestSerializer()
+
+        assert serializer.fields['decimal_field'].max_value == 3

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -22,7 +22,7 @@ from django.utils import six
 
 from rest_framework import serializers
 from rest_framework.compat import DurationField as ModelDurationField
-from rest_framework.compat import DecimalValidator, unicode_repr
+from rest_framework.compat import unicode_repr
 
 
 def dedent(blocktext):
@@ -872,25 +872,9 @@ class DecimalFieldModel(models.Model):
 
 
 class TestDecimalFieldMappings(TestCase):
-    @pytest.mark.skipif(DecimalValidator is not None,
-                        reason='DecimalValidator is available in Django 1.9+')
-    def test_decimal_field_has_no_decimal_validator(self):
-        """
-        Test that a DecimalField has no validators before Django 1.9.
-        """
-        class TestSerializer(serializers.ModelSerializer):
-            class Meta:
-                model = DecimalFieldModel
-
-        serializer = TestSerializer()
-
-        assert len(serializer.fields['decimal_field'].validators) == 2
-
-    @pytest.mark.skipif(DecimalValidator is None,
-                        reason='DecimalValidator is available in Django 1.9+')
     def test_decimal_field_has_decimal_validator(self):
         """
-        Test that a DecimalField has DecimalValidator in Django 1.9+.
+        Test that a `DecimalField` has no `DecimalValidator`.
         """
         class TestSerializer(serializers.ModelSerializer):
             class Meta:


### PR DESCRIPTION
After upgrading from DRF 3.2.5 to 3.3.2, a bunch of our tests started failing because the `min_value` and `max_value` are no longer being transferred over to the automatically generated fields. This is a regression that does not appear to be documented anywhere, and there is still code that is supposed to be setting these arguments.

- [x] Create regression test demonstrating the issue
- [x] Fix the issue