### PR TITLE
Allow for JSON encoding of datetime.tzinfo objects

### DIFF
--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -2,3 +2,4 @@
 markdown==2.5.2
 django-guardian==1.3.2
 django-filter==0.10.0
+pytz==2015.7

--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -47,7 +47,7 @@ class JSONEncoder(json.JSONEncoder):
         elif isinstance(obj, decimal.Decimal):
             # Serializers will coerce decimals to strings by default.
             return float(obj)
-        elif isinstance(obj, uuid.UUID):
+        elif isinstance(obj, (datetime.tzinfo, uuid.UUID)):
             return six.text_type(obj)
         elif isinstance(obj, QuerySet):
             return tuple(obj)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -8,8 +8,8 @@ from collections import MutableMapping, OrderedDict
 from django.conf.urls import include, url
 from django.core.cache import cache
 from django.db import models
-from django.test import TestCase
-from django.utils import six
+from django.test import TestCase, override_settings
+from django.utils import six, timezone
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import permissions, serializers, status
@@ -360,6 +360,13 @@ class JSONRendererTests(TestCase):
         renderer = JSONRenderer()
         content = renderer.render(obj, 'application/json; indent=2')
         self.assertEqual(strip_trailing_whitespace(content.decode('utf-8')), _indented_repr)
+
+    @override_settings(TIME_ZONE='America/Los_Angeles')
+    def test_render_tzinfo_object(self):
+        tzinfo = timezone.get_current_timezone()
+        renderer = JSONRenderer()
+        content = renderer.render(tzinfo)
+        self.assertEqual(content, b'"America/Los_Angeles"')
 
 
 class UnicodeJSONRendererTests(TestCase):


### PR DESCRIPTION
This is a rebased, cleaned up redo of #3752, in order to resolve https://github.com/mfogel/django-timezone-field/issues/29