### PR TITLE
don't import authtoken model until needed

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -185,9 +185,10 @@ class TokenAuthentication(BaseAuthentication):
         return self.authenticate_credentials(token)
 
     def authenticate_credentials(self, key):
+        model = self.get_model()
         try:
-            token = self.get_model().objects.select_related('user').get(key=key)
-        except self.model.DoesNotExist:
+            token = model.objects.select_related('user').get(key=key)
+        except model.DoesNotExist:
             raise exceptions.AuthenticationFailed(_('Invalid token.'))
 
         if not token.user.is_active:

--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -10,7 +10,6 @@ from django.middleware.csrf import CsrfViewMiddleware
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import HTTP_HEADER_ENCODING, exceptions
-from rest_framework.authtoken.models import Token
 
 
 def get_authorization_header(request):
@@ -149,7 +148,14 @@ class TokenAuthentication(BaseAuthentication):
         Authorization: Token 401f7ac837da42b97f613d789819ff93537bee6a
     """
 
-    model = Token
+    model = None
+
+    def get_model(self):
+        if self.model is not None:
+            return self.model
+        from rest_framework.authtoken.models import Token
+        return Token
+
     """
     A custom token model may be used, but must have the following properties.
 
@@ -180,7 +186,7 @@ class TokenAuthentication(BaseAuthentication):
 
     def authenticate_credentials(self, key):
         try:
-            token = self.model.objects.select_related('user').get(key=key)
+            token = self.get_model().objects.select_related('user').get(key=key)
         except self.model.DoesNotExist:
             raise exceptions.AuthenticationFailed(_('Invalid token.'))
 

--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -21,14 +21,6 @@ class Token(models.Model):
     user = models.OneToOneField(AUTH_USER_MODEL, related_name='auth_token')
     created = models.DateTimeField(auto_now_add=True)
 
-    class Meta:
-        # Work around for a bug in Django:
-        # https://code.djangoproject.com/ticket/19422
-        #
-        # Also see corresponding ticket:
-        # https://github.com/tomchristie/django-rest-framework/issues/705
-        abstract = 'rest_framework.authtoken' not in settings.INSTALLED_APPS
-
     def save(self, *args, **kwargs):
         if not self.key:
             self.key = self.generate_key()

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -6,10 +6,10 @@ import base64
 
 from django.conf.urls import include, url
 from django.contrib.auth.models import User
+from django.db import models
 from django.http import HttpResponse
 from django.test import TestCase
 from django.utils import six
-from django.db import models
 
 from rest_framework import (
     HTTP_HEADER_ENCODING, exceptions, permissions, renderers, status

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -162,6 +162,12 @@ class TokenAuthTests(TestCase):
         response = self.csrf_client.post('/token/', {'example': 'example'}, HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_fail_post_form_passing_nonexistent_token_auth(self):
+        # use a nonexistent token key
+        auth = 'Token wxyz6789'
+        response = self.csrf_client.post('/token/', {'example': 'example'}, HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
     def test_fail_post_form_passing_invalid_token_auth(self):
         # add an 'invalid' unicode character
         auth = 'Token ' + self.key + "¸"

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -9,6 +9,7 @@ from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.test import TestCase
 from django.utils import six
+from django.db import models
 
 from rest_framework import (
     HTTP_HEADER_ENCODING, exceptions, permissions, renderers, status
@@ -23,6 +24,15 @@ from rest_framework.test import APIClient, APIRequestFactory
 from rest_framework.views import APIView
 
 factory = APIRequestFactory()
+
+
+class CustomToken(models.Model):
+    key = models.CharField(max_length=40, primary_key=True)
+    user = models.OneToOneField(User)
+
+
+class CustomTokenAuthentication(TokenAuthentication):
+    model = CustomToken
 
 
 class MockView(APIView):
@@ -42,6 +52,7 @@ urlpatterns = [
     url(r'^session/$', MockView.as_view(authentication_classes=[SessionAuthentication])),
     url(r'^basic/$', MockView.as_view(authentication_classes=[BasicAuthentication])),
     url(r'^token/$', MockView.as_view(authentication_classes=[TokenAuthentication])),
+    url(r'^customtoken/$', MockView.as_view(authentication_classes=[CustomTokenAuthentication])),
     url(r'^auth-token/$', 'rest_framework.authtoken.views.obtain_auth_token'),
     url(r'^auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]
@@ -142,9 +153,11 @@ class SessionAuthTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
-class TokenAuthTests(TestCase):
+class BaseTokenAuthTests(object):
     """Token authentication"""
     urls = 'tests.test_authentication'
+    model = None
+    path = None
 
     def setUp(self):
         self.csrf_client = APIClient(enforce_csrf_checks=True)
@@ -154,30 +167,30 @@ class TokenAuthTests(TestCase):
         self.user = User.objects.create_user(self.username, self.email, self.password)
 
         self.key = 'abcd1234'
-        self.token = Token.objects.create(key=self.key, user=self.user)
+        self.token = self.model.objects.create(key=self.key, user=self.user)
 
     def test_post_form_passing_token_auth(self):
         """Ensure POSTing json over token auth with correct credentials passes and does not require CSRF"""
         auth = 'Token ' + self.key
-        response = self.csrf_client.post('/token/', {'example': 'example'}, HTTP_AUTHORIZATION=auth)
+        response = self.csrf_client.post(self.path, {'example': 'example'}, HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_fail_post_form_passing_nonexistent_token_auth(self):
         # use a nonexistent token key
         auth = 'Token wxyz6789'
-        response = self.csrf_client.post('/token/', {'example': 'example'}, HTTP_AUTHORIZATION=auth)
+        response = self.csrf_client.post(self.path, {'example': 'example'}, HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_fail_post_form_passing_invalid_token_auth(self):
         # add an 'invalid' unicode character
         auth = 'Token ' + self.key + "¸"
-        response = self.csrf_client.post('/token/', {'example': 'example'}, HTTP_AUTHORIZATION=auth)
+        response = self.csrf_client.post(self.path, {'example': 'example'}, HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_post_json_passing_token_auth(self):
         """Ensure POSTing form over token auth with correct credentials passes and does not require CSRF"""
         auth = "Token " + self.key
-        response = self.csrf_client.post('/token/', {'example': 'example'}, format='json', HTTP_AUTHORIZATION=auth)
+        response = self.csrf_client.post(self.path, {'example': 'example'}, format='json', HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_post_json_makes_one_db_query(self):
@@ -185,29 +198,34 @@ class TokenAuthTests(TestCase):
         auth = "Token " + self.key
 
         def func_to_test():
-            return self.csrf_client.post('/token/', {'example': 'example'}, format='json', HTTP_AUTHORIZATION=auth)
+            return self.csrf_client.post(self.path, {'example': 'example'}, format='json', HTTP_AUTHORIZATION=auth)
 
         self.assertNumQueries(1, func_to_test)
 
     def test_post_form_failing_token_auth(self):
         """Ensure POSTing form over token auth without correct credentials fails"""
-        response = self.csrf_client.post('/token/', {'example': 'example'})
+        response = self.csrf_client.post(self.path, {'example': 'example'})
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_post_json_failing_token_auth(self):
         """Ensure POSTing json over token auth without correct credentials fails"""
-        response = self.csrf_client.post('/token/', {'example': 'example'}, format='json')
+        response = self.csrf_client.post(self.path, {'example': 'example'}, format='json')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TokenAuthTests(BaseTokenAuthTests, TestCase):
+    model = Token
+    path = '/token/'
 
     def test_token_has_auto_assigned_key_if_none_provided(self):
         """Ensure creating a token with no key will auto-assign a key"""
         self.token.delete()
-        token = Token.objects.create(user=self.user)
+        token = self.model.objects.create(user=self.user)
         self.assertTrue(bool(token.key))
 
     def test_generate_key_returns_string(self):
         """Ensure generate_key returns a string"""
-        token = Token()
+        token = self.model()
         key = token.generate_key()
         self.assertTrue(isinstance(key, six.string_types))
 
@@ -240,6 +258,11 @@ class TokenAuthTests(TestCase):
                                {'username': self.username, 'password': self.password})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['token'], self.key)
+
+
+class CustomTokenAuthTests(BaseTokenAuthTests, TestCase):
+    model = CustomToken
+    path = '/customtoken/'
 
 
 class IncorrectCredentialsTests(TestCase):


### PR DESCRIPTION
This PR updates the usage of the authtoken model for better compatibility with Django 1.9, specifically to make it possible to define module-level app APIs that rely on `rest_framework` with the default authentication settings (which import `rest_framework.authentication`).

Some background: it is forbidden in Django 1.9 to import models before the app infrastructure has finished loading.  This makes it a bit tricky when implementing module-level shortcut APIs like Django's `admin.site`, wq.db's [`rest.router`](https://wq.io/docs/router) interface, and the [`rest_pandas`](https://github.com/wq/django-rest-pandas/blob/master/rest_pandas/__init__.py) module (though the latter isn't strictly a Django "app").  Any code imported in the `__init__.py` for those modules needs to defer importing models until they are needed (c.f. [django/django#2228](https://github.com/django/django/pull/2228/files)).

Currently, `rest_framework.authentication` imports the `Token` model at the top level and therefore cannot be imported in Django 1.9 until after apps are done initializing (see the traceback below).  This patch simply defers loading the `Token` model until it is needed, thus avoiding the import error.  As a side effect, this also means that `rest_framework.authtoken.models` is never imported unless it is being used, which means the workaround for #705 is no longer needed.  This issue is similar but not the same - in #705, the error occured when `authtoken` was not in `INSTALLED_APPS`, whereas this issue will occur whether or not `authtoken` is in `INSTALLED_APPS`.

```pytb
  (test initialization stuff...)
  File "/local/path/wq.db/tests/__init__.py", line 10, in <module>
    django.setup()
  File "/usr/local/lib/python3.4/dist-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python3.4/dist-packages/django/apps/registry.py", line 85, in populate
    app_config = AppConfig.create(entry)
  File "/usr/local/lib/python3.4/dist-packages/django/apps/config.py", line 90, in create
    module = import_module(entry)
  File "/usr/lib/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/local/path/wq.db/wq/db/rest/__init__.py", line 2, in <module>
    from .routers import ModelRouter, router  # NOQA
  File "/local/path/wq.db/wq/db/rest/routers.py", line 7, in <module>
    from rest_framework.routers import DefaultRouter, Route
  File "/usr/local/lib/python3.4/dist-packages/rest_framework/routers.py", line 25, in <module>
    from rest_framework import views
  File "/usr/local/lib/python3.4/dist-packages/rest_framework/views.py", line 98, in <module>
    class APIView(View):
  File "/usr/local/lib/python3.4/dist-packages/rest_framework/views.py", line 103, in APIView
    authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES
  File "/usr/local/lib/python3.4/dist-packages/rest_framework/settings.py", line 203, in __getattr__
    val = perform_import(val, attr)
  File "/usr/local/lib/python3.4/dist-packages/rest_framework/settings.py", line 148, in perform_import
    return [import_from_string(item, setting_name) for item in val]
  File "/usr/local/lib/python3.4/dist-packages/rest_framework/settings.py", line 148, in <listcomp>
    return [import_from_string(item, setting_name) for item in val]
  File "/usr/local/lib/python3.4/dist-packages/rest_framework/settings.py", line 160, in import_from_string
    module = importlib.import_module(module_path)
  File "/usr/lib/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/usr/local/lib/python3.4/dist-packages/rest_framework/authentication.py", line 13, in <module>
    from rest_framework.authtoken.models import Token
  File "/usr/local/lib/python3.4/dist-packages/rest_framework/authtoken/models.py", line 16, in <module>
    class Token(models.Model):
  File "/usr/local/lib/python3.4/dist-packages/django/db/models/base.py", line 94, in __new__
    app_config = apps.get_containing_app_config(module)
  File "/usr/local/lib/python3.4/dist-packages/django/apps/registry.py", line 239, in get_containing_app_config
    self.check_apps_ready()
  File "/usr/local/lib/python3.4/dist-packages/django/apps/registry.py", line 124, in check_apps_ready
    raise AppRegistryNotReady("Apps aren't loaded yet.")
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```