### PR TITLE
Fixes incorrect snippet endpoint in serialization tutorial

### DIFF
--- a/docs/tutorial/1-serialization.md
+++ b/docs/tutorial/1-serialization.md
@@ -358,7 +358,7 @@ Finally, we can get a list of all of the snippets:
 
 Or we can get a particular snippet by referencing its id:
 
-    http http://127.0.0.1:8000/snippets/2/
+    http http://127.0.0.1:8000/snippets/2
 
     HTTP/1.1 200 OK
     ...


### PR DESCRIPTION
There is a block showing how to get a particular snippet's data using httpie. The trailing slash on the URL causes a 404 to be returned. This commit removes that trailing slash.