### PR TITLE
Typo fix in docs/api-guide/relations.md

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -459,7 +459,7 @@ In cases where the cutoff is being enforced you may want to instead use a plain 
 
     assigned_to = serializers.SlugRelatedField(
        queryset=User.objects.all(),
-       slug field='username',
+       slug_field='username',
        style={'base_template': 'input.html'}
     )
 


### PR DESCRIPTION
`slug field` in code snippet was replaced to `slug_field`