### PR TITLE
Do not escape html help_text in browsable api

### DIFF
--- a/rest_framework/templates/rest_framework/horizontal/checkbox.html
+++ b/rest_framework/templates/rest_framework/horizontal/checkbox.html
@@ -15,7 +15,7 @@
     {% endif %}
 
     {% if field.help_text %}
-      <span class="help-block">{{ field.help_text }}</span>
+      <span class="help-block">{{ field.help_text|safe }}</span>
     {% endif %}
   </div>
 </div>

--- a/rest_framework/templates/rest_framework/horizontal/checkbox_multiple.html
+++ b/rest_framework/templates/rest_framework/horizontal/checkbox_multiple.html
@@ -31,7 +31,7 @@
   {% endif %}
 
   {% if field.help_text %}
-    <span class="help-block">{{ field.help_text }}</span>
+    <span class="help-block">{{ field.help_text|safe }}</span>
   {% endif %}
   </div>
 </div>

--- a/rest_framework/templates/rest_framework/horizontal/input.html
+++ b/rest_framework/templates/rest_framework/horizontal/input.html
@@ -15,7 +15,7 @@
     {% endif %}
 
     {% if field.help_text %}
-      <span class="help-block">{{ field.help_text }}</span>
+      <span class="help-block">{{ field.help_text|safe }}</span>
     {% endif %}
   </div>
 </div>

--- a/rest_framework/templates/rest_framework/horizontal/radio.html
+++ b/rest_framework/templates/rest_framework/horizontal/radio.html
@@ -49,7 +49,7 @@
     {% endif %}
 
     {% if field.help_text %}
-      <span class="help-block">{{ field.help_text }}</span>
+      <span class="help-block">{{ field.help_text|safe }}</span>
     {% endif %}
   </div>
 </div>

--- a/rest_framework/templates/rest_framework/horizontal/select.html
+++ b/rest_framework/templates/rest_framework/horizontal/select.html
@@ -28,7 +28,7 @@
     {% endif %}
 
     {% if field.help_text %}
-      <span class="help-block">{{ field.help_text }}</span>
+      <span class="help-block">{{ field.help_text|safe }}</span>
     {% endif %}
   </div>
 </div>

--- a/rest_framework/templates/rest_framework/horizontal/select_multiple.html
+++ b/rest_framework/templates/rest_framework/horizontal/select_multiple.html
@@ -30,7 +30,7 @@
     {% endif %}
 
     {% if field.help_text %}
-      <span class="help-block">{{ field.help_text }}</span>
+      <span class="help-block">{{ field.help_text|safe }}</span>
     {% endif %}
   </div>
 </div>

--- a/rest_framework/templates/rest_framework/horizontal/textarea.html
+++ b/rest_framework/templates/rest_framework/horizontal/textarea.html
@@ -15,7 +15,7 @@
     {% endif %}
 
     {% if field.help_text %}
-      <span class="help-block">{{ field.help_text }}</span>
+      <span class="help-block">{{ field.help_text|safe }}</span>
     {% endif %}
   </div>
 </div>

--- a/rest_framework/templates/rest_framework/raw_data_form.html
+++ b/rest_framework/templates/rest_framework/raw_data_form.html
@@ -5,7 +5,7 @@
     {{ field.label_tag|add_class:"col-sm-2 control-label" }}
     <div class="col-sm-10">
       {{ field|add_class:"form-control" }}
-      <span class="help-block">{{ field.help_text }}</span>
+      <span class="help-block">{{ field.help_text|safe }}</span>
     </div>
   </div>
 {% endfor %}

--- a/rest_framework/templates/rest_framework/vertical/checkbox.html
+++ b/rest_framework/templates/rest_framework/vertical/checkbox.html
@@ -13,6 +13,6 @@
   {% endif %}
 
   {% if field.help_text %}
-    <span class="help-block">{{ field.help_text }}</span>
+    <span class="help-block">{{ field.help_text|safe }}</span>
   {% endif %}
 </div>

--- a/rest_framework/templates/rest_framework/vertical/checkbox_multiple.html
+++ b/rest_framework/templates/rest_framework/vertical/checkbox_multiple.html
@@ -30,6 +30,6 @@
   {% endif %}
 
   {% if field.help_text %}
-    <span class="help-block">{{ field.help_text }}</span>
+    <span class="help-block">{{ field.help_text|safe }}</span>
   {% endif %}
 </div>

--- a/rest_framework/templates/rest_framework/vertical/input.html
+++ b/rest_framework/templates/rest_framework/vertical/input.html
@@ -12,6 +12,6 @@
   {% endif %}
 
   {% if field.help_text %}
-    <span class="help-block">{{ field.help_text }}</span>
+    <span class="help-block">{{ field.help_text|safe }}</span>
   {% endif %}
 </div>

--- a/rest_framework/templates/rest_framework/vertical/radio.html
+++ b/rest_framework/templates/rest_framework/vertical/radio.html
@@ -51,6 +51,6 @@
     {% endif %}
 
     {% if field.help_text %}
-      <span class="help-block">{{ field.help_text }}</span>
+      <span class="help-block">{{ field.help_text|safe }}</span>
     {% endif %}
 </div>

--- a/rest_framework/templates/rest_framework/vertical/select.html
+++ b/rest_framework/templates/rest_framework/vertical/select.html
@@ -27,6 +27,6 @@
   {% endif %}
 
   {% if field.help_text %}
-    <span class="help-block">{{ field.help_text }}</span>
+    <span class="help-block">{{ field.help_text|safe }}</span>
   {% endif %}
 </div>

--- a/rest_framework/templates/rest_framework/vertical/select_multiple.html
+++ b/rest_framework/templates/rest_framework/vertical/select_multiple.html
@@ -27,6 +27,6 @@
     {% endif %}
 
     {% if field.help_text %}
-      <span class="help-block">{{ field.help_text }}</span>
+      <span class="help-block">{{ field.help_text|safe }}</span>
     {% endif %}
 </div>

--- a/rest_framework/templates/rest_framework/vertical/textarea.html
+++ b/rest_framework/templates/rest_framework/vertical/textarea.html
@@ -12,6 +12,6 @@
   {% endif %}
 
   {% if field.help_text %}
-    <span class="help-block">{{ field.help_text }}</span>
+    <span class="help-block">{{ field.help_text|safe }}</span>
   {% endif %}
 </div>


### PR DESCRIPTION
Some fields in django forms (SetPasswordForm for example, new_password1 field) have html help_text. I think in browsable api help_text must be rendered as is.