### PR TITLE
PY2: DateField.to_representation can't work with unicode value

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1139,7 +1139,7 @@ class DateField(Field):
         )
 
         if output_format.lower() == ISO_8601:
-            if (isinstance(value, str)):
+            if isinstance(value, six.string_types):
                 value = datetime.datetime.strptime(value, '%Y-%m-%d').date()
             return value.isoformat()
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 import django
 import pytest
 from django.http import QueryDict
-from django.utils import timezone
+from django.utils import six, timezone
 
 import rest_framework
 from rest_framework import serializers
@@ -895,6 +895,7 @@ class TestDateField(FieldValues):
     outputs = {
         datetime.date(2001, 1, 1): '2001-01-01',
         '2001-01-01': '2001-01-01',
+        six.text_type('2016-01-10'): '2016-01-10',
         None: None,
         '': None,
     }


### PR DESCRIPTION
Hello!

Seems like `DateField.to_representation` doesn't work with `unicode` values on Python 2.*, but it can accept `str` values. I think it should work with `unicode` too.

Here is example:
```
from rest_framework import serializers.

class Example(object):
    def __init__(self, created):
        self.created = created

class ExampleSerializer(serializers.Serializer):
    created = serializers.DateTimeField()

example = Example(created=u'2016-01-10')
es = ExampleSerializer(example)
print(es.data)
```

Traceback:
```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/Users/m1kola/.virtualenvs/drf_dev/lib/python2.7/site-packages/rest_framework/serializers.py", line 503, in data
    ret = super(Serializer, self).data
  File "/Users/m1kola/.virtualenvs/drf_dev/lib/python2.7/site-packages/rest_framework/serializers.py", line 239, in data
    self._data = self.to_representation(self.instance)
  File "/Users/m1kola/.virtualenvs/drf_dev/lib/python2.7/site-packages/rest_framework/serializers.py", line 472, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
  File "/Users/m1kola/.virtualenvs/drf_dev/lib/python2.7/site-packages/rest_framework/fields.py", line 1068, in to_representation
    value = value.isoformat()
AttributeError: 'unicode' object has no attribute 'isoformat'
```

I can reproduce this behaviour on 3.3.1 and master.