### PR TITLE
Fix parsing multipart data using a nested serializer with list

### DIFF
--- a/rest_framework/utils/html.py
+++ b/rest_framework/utils/html.py
@@ -80,10 +80,12 @@ def parse_html_dict(dictionary, prefix=''):
     """
     ret = MultiValueDict()
     regex = re.compile(r'^%s\.(.+)$' % re.escape(prefix))
-    for field, value in dictionary.items():
+    for field in dictionary:
         match = regex.match(field)
         if not match:
             continue
         key = match.groups()[0]
-        ret[key] = value
+        value = dictionary.getlist(field)
+        ret.setlist(key, value)
+
     return ret

--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -167,3 +167,32 @@ class TestNestedSerializerWithMany:
 
         expected_errors = {'not_allow_empty': {'non_field_errors': [serializers.ListSerializer.default_error_messages['empty']]}}
         assert serializer.errors == expected_errors
+
+
+class TestNestedSerializerWithList:
+    def setup(self):
+        class NestedSerializer(serializers.Serializer):
+            example = serializers.MultipleChoiceField(choices=[1, 2, 3])
+
+        class TestSerializer(serializers.Serializer):
+            nested = NestedSerializer()
+
+        self.Serializer = TestSerializer
+
+    def test_nested_serializer_with_list_json(self):
+        input_data = {
+            'nested': {
+                'example': [1, 2],
+            }
+        }
+        serializer = self.Serializer(data=input_data)
+
+        assert serializer.is_valid()
+        assert serializer.validated_data['nested']['example'] == set([1, 2])
+
+    def test_nested_serializer_with_list_multipart(self):
+        input_data = QueryDict('nested.example=1&nested.example=2')
+        serializer = self.Serializer(data=input_data)
+
+        assert serializer.is_valid()
+        assert serializer.validated_data['nested']['example'] == set([1, 2])


### PR DESCRIPTION
Parsing multipart data using a nested serializer with a list can result in incorrect behavior. If the list contains more than one item, only the last item will be saved.

Here is an example:

```python
class NestedSerializer(serializers.Serializer):
    example = serializers.MultipleChoiceField(choices=[1, 2, 3])

class TestSerializer(serializers.Serializer):
    nested = NestedSerializer()
```

When you send the following data formatted as JSON everything will be fine:

```python
{
    'nested': {
        'example': [1, 2],
    }
}
#   --->
{
    'nested': {
        'example': [1, 2],
    }
}
```

However, when you send the same data formatted as multipart data the serialized object will only take the last element of the list:

```python
{
    'nested.example': [1, 2]
}
#   --->
{
    'nested' {
        'example': 2,
    }
}
```

The bug is situated in `parse_html_dict(dictionary, prefix='')` in `rest_framework.utils.html`. This function takes and returns a new `MultiValueDict`. A key in a `MultiValueDict` can have multiple values, this is how a list is represented. When accessing a key in a `MultiValueDict` only the last element of the list is returned.

This can be easily solved by using .getlist() and .setlist() when getting and setting the value of the `MultiValueDict`.

Closes #3710.