### PR TITLE
Do not use select field to display list of users

### DIFF
--- a/rest_framework/authtoken/admin.py
+++ b/rest_framework/authtoken/admin.py
@@ -7,6 +7,7 @@ class TokenAdmin(admin.ModelAdmin):
     list_display = ('key', 'user', 'created')
     fields = ('user',)
     ordering = ('-created',)
+    raw_id_fields = ('user',)
 
 
 admin.site.register(Token, TokenAdmin)


### PR DESCRIPTION
When generating authtoken from admin interface, the defaut html form
is unusable in presence of a large user base.