### PR TITLE
QueryParameterVersioning does not use default version

### DIFF
--- a/rest_framework/versioning.py
+++ b/rest_framework/versioning.py
@@ -166,7 +166,7 @@ class QueryParameterVersioning(BaseVersioning):
     invalid_version_message = _('Invalid version in query parameter.')
 
     def determine_version(self, request, *args, **kwargs):
-        version = request.query_params.get(self.version_param)
+        version = request.query_params.get(self.version_param, self.default_version)
         if not self.is_allowed_version(version):
             raise exceptions.NotFound(self.invalid_version_message)
         return version


### PR DESCRIPTION
QueryParameterVersioning does not fall back to the value used in the `DEFAULT_VERSION` setting, while other versioning schemes do. This looks like a minor change, and incorporates the `self.default_version` set in the superclass.

I'll sheepishly admit that I edited this inline without running any tests or anything, so please let me know if this needs more work.