### PR TITLE
add update_data in UpdateModelMixin

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -65,10 +65,13 @@ class UpdateModelMixin(object):
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop('partial', False)
         instance = self.get_object()
-        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer = self.get_serializer(instance, data=self.update_data(request), partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
         return Response(serializer.data)
+
+    def update_data(self, request):
+        return request.data
 
     def perform_update(self, serializer):
         serializer.save()


### PR DESCRIPTION
add an `update_data` method in `UpdateModelMixin` so that i can add addition fields in update data before calling `get_serializer` like this:

    def update_data(self, request):
        data = copy.copy(request.data)
        data['user_id'] = request.user.id
        return data
