### PR TITLE
django.test.Client compatibility for POST

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -371,7 +371,7 @@ class Request(object):
         if not _hasattr(self, '_data'):
             self._load_data_and_files()
         if is_form_media_type(self.content_type):
-            return self.data
+            return self.data or self._request.POST
         return QueryDict('', encoding=self._request._encoding)
 
     @property


### PR DESCRIPTION
when using `django.test.Client` to issue a POST request, the `request.POST` is filled, but `request.body` is not filled

use the original request's `POST` parameter as the fallback in case data cannot be decoded