### PR TITLE
Maintain py32 test builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,19 @@ language: python
 sudo: false
 
 env:
-    global:
-      - VIRTUALENV_NO_PIP=True
-    matrix:
-      - TOX_ENV=py27-lint
-      - TOX_ENV=py27-docs
-      - TOX_ENV=py35-django19
-      - TOX_ENV=py34-django19
-      - TOX_ENV=py27-django19
-      - TOX_ENV=py34-django18
-      - TOX_ENV=py33-django18
-      - TOX_ENV=py32-django18
-      - TOX_ENV=py27-django18
-      - TOX_ENV=py34-django17
-      - TOX_ENV=py33-django17
-      - TOX_ENV=py32-django17
-      - TOX_ENV=py27-django17
+  - TOX_ENV=py27-lint
+  - TOX_ENV=py27-docs
+  - TOX_ENV=py35-django19
+  - TOX_ENV=py34-django19
+  - TOX_ENV=py27-django19
+  - TOX_ENV=py34-django18
+  - TOX_ENV=py33-django18
+  - TOX_ENV=py32-django18
+  - TOX_ENV=py27-django18
+  - TOX_ENV=py34-django17
+  - TOX_ENV=py33-django17
+  - TOX_ENV=py32-django17
+  - TOX_ENV=py27-django17
 
 matrix:
     # Python 3.5 not yet available on travis, watch this to see when it is.

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,22 @@ language: python
 sudo: false
 
 env:
-    - TOX_ENV=py27-lint
-    - TOX_ENV=py27-docs
-    - TOX_ENV=py35-django19
-    - TOX_ENV=py34-django19
-    - TOX_ENV=py27-django19
-    - TOX_ENV=py34-django18
-    - TOX_ENV=py33-django18
-    - TOX_ENV=py32-django18
-    - TOX_ENV=py27-django18
-    - TOX_ENV=py34-django17
-    - TOX_ENV=py33-django17
-    - TOX_ENV=py32-django17
-    - TOX_ENV=py27-django17
+    global:
+      - VIRTUALENV_NO_PIP=True
+    matrix:
+      - TOX_ENV=py27-lint
+      - TOX_ENV=py27-docs
+      - TOX_ENV=py35-django19
+      - TOX_ENV=py34-django19
+      - TOX_ENV=py27-django19
+      - TOX_ENV=py34-django18
+      - TOX_ENV=py33-django18
+      - TOX_ENV=py32-django18
+      - TOX_ENV=py27-django18
+      - TOX_ENV=py34-django17
+      - TOX_ENV=py33-django17
+      - TOX_ENV=py32-django17
+      - TOX_ENV=py27-django17
 
 matrix:
     # Python 3.5 not yet available on travis, watch this to see when it is.

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
     - env: TOX_ENV=py35-django19
 
 install:
+  # Virtualenv < 14 is required to keep the Python 3.2 builds running.
   - pip install tox "virtualenv<14"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,19 @@ language: python
 sudo: false
 
 env:
-  - TOX_ENV=py27-lint
-  - TOX_ENV=py27-docs
-  - TOX_ENV=py35-django19
-  - TOX_ENV=py34-django19
-  - TOX_ENV=py27-django19
-  - TOX_ENV=py34-django18
-  - TOX_ENV=py33-django18
-  - TOX_ENV=py32-django18
-  - TOX_ENV=py27-django18
-  - TOX_ENV=py34-django17
-  - TOX_ENV=py33-django17
-  - TOX_ENV=py32-django17
-  - TOX_ENV=py27-django17
+    - TOX_ENV=py27-lint
+    - TOX_ENV=py27-docs
+    - TOX_ENV=py35-django19
+    - TOX_ENV=py34-django19
+    - TOX_ENV=py27-django19
+    - TOX_ENV=py34-django18
+    - TOX_ENV=py33-django18
+    - TOX_ENV=py32-django18
+    - TOX_ENV=py27-django18
+    - TOX_ENV=py34-django17
+    - TOX_ENV=py33-django17
+    - TOX_ENV=py32-django17
+    - TOX_ENV=py27-django17
 
 matrix:
     # Python 3.5 not yet available on travis, watch this to see when it is.

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - env: TOX_ENV=py35-django19
 
 install:
-  - pip install tox
+  - pip install tox "virtualenv<14"
 
 script:
     - tox -e $TOX_ENV


### PR DESCRIPTION
This is to avoid pip8 installation.