### PR TITLE
Turn style assertions into warnings, so they can be opted out of.

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -8,6 +8,7 @@ import inspect
 import json
 import re
 import uuid
+import warnings
 from collections import OrderedDict
 
 from django.conf import settings
@@ -325,12 +326,13 @@ class Field(object):
         # In order to enforce a consistent style, we error if a redundant
         # 'source' argument has been used. For example:
         # my_field = serializer.CharField(source='my_field')
-        assert self.source != field_name, (
-            "It is redundant to specify `source='%s'` on field '%s' in "
-            "serializer '%s', because it is the same as the field name. "
-            "Remove the `source` keyword argument." %
-            (field_name, self.__class__.__name__, parent.__class__.__name__)
-        )
+        if field_name == self.source:
+            warnings.warn(
+                "It is redundant to specify `source='%s'` on field '%s' in "
+                "serializer '%s', because it is the same as the field name. "
+                "Remove the `source` keyword argument." %
+                (field_name, self.__class__.__name__, parent.__class__.__name__),
+            )
 
         self.field_name = field_name
         self.parent = parent

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import warnings
 from collections import OrderedDict
 
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
@@ -80,10 +81,11 @@ class RelatedField(Field):
                 'Relational field must provide a `queryset` argument, '
                 'override `get_queryset`, or set read_only=`True`.'
             )
-        assert not (self.queryset is not None and kwargs.get('read_only', None)), (
-            'Relational fields should not provide a `queryset` argument, '
-            'when setting read_only=`True`.'
-        )
+        if self.queryset is not None and kwargs.get('read_only'):
+            warnings.warn(
+                'Relational fields should not provide a `queryset` argument, '
+                'when setting read_only=`True`.'
+            )
         kwargs.pop('many', None)
         kwargs.pop('allow_empty', None)
         super(RelatedField, self).__init__(**kwargs)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -90,9 +90,10 @@ class TestSource:
     def test_redundant_source(self):
         class ExampleSerializer(serializers.Serializer):
             example_field = serializers.CharField(source='example_field')
-        with pytest.raises(AssertionError) as exc_info:
+        with pytest.warns(UserWarning) as record:
             ExampleSerializer().fields
-        assert str(exc_info.value) == (
+        assert len(record) == 1
+        assert record[0].message.args[0] == (
             "It is redundant to specify `source='example_field'` on field "
             "'CharField' in serializer 'ExampleSerializer', because it is the "
             "same as the field name. Remove the `source` keyword argument."


### PR DESCRIPTION

DRF raises assertions when your code style is wrong. Unfortunately the way this is implemented, it makes certain complex use-cases much more difficult than they have to be.

Looks like f1b28b4d63beaeb770e7468329e22de56f8d3c31 just improved the situation by allowing RelatedField to have a `get_queryset()` method and not require a `queryset=` kwarg.

This PR fixes two other frustrating assertions I've been working around. They are replaced with warnings, so will provide similar value in enforcing code style, but now you can opt-out by changing your logging config if you know what you're doing.

This was previously #3666, in which I just removed the warnings altogether, but this is a better fix (and I put it on its own branch so it's independent of other stuff in our fork.)