### PR TITLE
#3859 add pre lookup prefixes

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -218,16 +218,18 @@ class SimpleRouter(BaseRouter):
 
         https://github.com/alanjds/drf-nested-routers
         """
-        base_regex = '(?P<{lookup_prefix}{lookup_url_kwarg}>{lookup_value})'
+        base_regex = '{pre_lookup_prefix}(?P<{lookup_prefix}{lookup_url_kwarg}>{lookup_value})'
         # Use `pk` as default field, unset set.  Default regex should not
         # consume `.json` style suffixes and should break at '/' boundaries.
         lookup_field = getattr(viewset, 'lookup_field', 'pk')
         lookup_url_kwarg = getattr(viewset, 'lookup_url_kwarg', None) or lookup_field
         lookup_value = getattr(viewset, 'lookup_value_regex', '[^/.]+')
+        pre_lookup_prefix = getattr(viewset, 'pre_lookup_prefix', '')
         return base_regex.format(
             lookup_prefix=lookup_prefix,
             lookup_url_kwarg=lookup_url_kwarg,
-            lookup_value=lookup_value
+            lookup_value=lookup_value,
+            pre_lookup_prefix=pre_lookup_prefix
         )
 
     def get_urls(self):


### PR DESCRIPTION
Added ability to construct urlpatterns to detail views with not consumed prefix. It is may be used for removing clashing with `@list_routes` and object lookups. See #3859.