### PR TITLE
fix wrong position of CursorPagination if ordering filed is a BooleanField

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -678,6 +678,11 @@ class CursorPagination(BasePagination):
 
     def _get_position_from_instance(self, instance, ordering):
         attr = getattr(instance, ordering[0].lstrip('-'))
+        # if ordering is a BooleanField, which mean attr is True/False,
+        # six.text_type(attr) will return u'True'/u'False'. And this will result
+        # wrong filter in paginate_queryset()
+        if isinstance(attr, bool):
+            return '1' if attr else '0'
         return six.text_type(attr)
 
     def get_paginated_response(self, data):


### PR DESCRIPTION
I used CursorPagination in my project, and I wanted to order by `is_read`(a BooleanField) and `id`.

Sometimes, after several pages, response has no data, but it SHOULD have some. I looked into the sql query, the where clause was like this, `where is_read > 1`. There must be something wrong.

After a few work on it, I found the `_get_position_from_instance` not handle `bool` type correct. So I send this pull request. Hope it helps.