### PR TITLE
Fix syntax errors in docs example

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -96,9 +96,9 @@ Two examples here are `'input_type'` and `'base_template'`:
 
     # Use a radio input instead of a select input.
     color_channel = serializers.ChoiceField(
-        choices=['red', 'green', 'blue']
-        style = {'base_template': 'radio.html'}
-    }
+        choices=['red', 'green', 'blue'],
+        style={'base_template': 'radio.html'}
+    )
 
 For more details see the [HTML & Forms][html-and-forms] documentation.
 


### PR DESCRIPTION
- Add missing comma in kwargs
- Remove spaces around keyword / parameter equals
- Replace incorrect curly brace with parenthesis