### PR TITLE
Fix resolving var 'value', was missing 'field'

### DIFF
--- a/rest_framework/templates/rest_framework/vertical/checkbox.html
+++ b/rest_framework/templates/rest_framework/vertical/checkbox.html
@@ -1,7 +1,7 @@
 <div class="form-group {% if field.errors %}has-error{% endif %}">
   <div class="checkbox">
     <label>
-      <input type="checkbox" name="{{ field.name }}" value="true" {% if value %}checked{% endif %}>
+      <input type="checkbox" name="{{ field.name }}" value="true" {% if field.value %}checked{% endif %}>
         {% if field.label %}{{ field.label }}{% endif %}
     </label>
   </div>


### PR DESCRIPTION
> Exception while resolving variable 'value' in template 'rest_framework/vertical/checkbox.html'.

I checked all the other templates and this appears to be the only case of a missing 'field'.