### PR TITLE
Improve relation choices limiting (using html_cutoff)

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -164,6 +164,9 @@ class RelatedField(Field):
             # even when accessed with a read-only field.
             return {}
 
+        if self.html_cutoff is not None:
+            queryset = queryset[:self.html_cutoff]
+
         return OrderedDict([
             (
                 six.text_type(self.to_representation(item)),


### PR DESCRIPTION
When we're showing the HTML form field for related objects and we're trying to generate the choices for the select field, it doesn't seem to make sense to grab every single record in a table, only to display `html_cutoff` (default: 1000) of them and completely ignore the rest.

Instead, we should limit the number of objects we want from the database to the number of objects we're planning on displaying. This changeset makes the semantics of retrieving related objects the same as for displaying related objects. In other words, we limit the queryset to the first `html_cutoff` objects. That way we aren't pulling back more objects than necessary, because this can kill performance for tables with "lots" of records (~500k in my case, [~400k for others](https://github.com/tomchristie/django-rest-framework/issues/3329#issue-103045398)).

Closes #3329.