### PR TITLE
enhancement #3886 Internationalization in admin interface for authtoken

### DIFF
--- a/rest_framework/authtoken/__init__.py
+++ b/rest_framework/authtoken/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'rest_framework.authtoken.apps.AuthTokenConfig'

--- a/rest_framework/authtoken/apps.py
+++ b/rest_framework/authtoken/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class AuthTokenConfig(AppConfig):
+    name = 'rest_framework.authtoken'
+    verbose_name = _("Auth Token")

--- a/rest_framework/authtoken/models.py
+++ b/rest_framework/authtoken/models.py
@@ -4,6 +4,7 @@ import os
 from django.conf import settings
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
+from django.utils.translation import ugettext_lazy as _
 
 # Prior to Django 1.5, the AUTH_USER_MODEL setting does not exist.
 # Note that we don't perform this code in the compat module due to
@@ -17,10 +18,10 @@ class Token(models.Model):
     """
     The default authorization token model.
     """
-    key = models.CharField(max_length=40, primary_key=True)
+    key = models.CharField(_("Key"), max_length=40, primary_key=True)
     user = models.OneToOneField(AUTH_USER_MODEL, related_name='auth_token',
-                                on_delete=models.CASCADE)
-    created = models.DateTimeField(auto_now_add=True)
+                                on_delete=models.CASCADE, verbose_name=_("User"))
+    created = models.DateTimeField(_("Created"), auto_now_add=True)
 
     class Meta:
         # Work around for a bug in Django:
@@ -29,6 +30,8 @@ class Token(models.Model):
         # Also see corresponding ticket:
         # https://github.com/tomchristie/django-rest-framework/issues/705
         abstract = 'rest_framework.authtoken' not in settings.INSTALLED_APPS
+        verbose_name = _("Token")
+        verbose_name_plural = _("Tokens")
 
     def save(self, *args, **kwargs):
         if not self.key:

--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -5,8 +5,8 @@ from rest_framework import serializers
 
 
 class AuthTokenSerializer(serializers.Serializer):
-    username = serializers.CharField()
-    password = serializers.CharField(style={'input_type': 'password'})
+    username = serializers.CharField(label=_("Username"))
+    password = serializers.CharField(label=_("Password"), style={'input_type': 'password'})
 
     def validate(self, attrs):
         username = attrs.get('username')


### PR DESCRIPTION
+ verbose_name in models.Token fields
+ Meta-options verbose_name & verbose_name_plural
+ Labels in AuthTokenSerializer fields in case of usages in Brousable API
+ provide AppConfig class as described in django documentation with verbose_name came through ugettext_lazy