### PR TITLE
changed imports with accordance to django 1.9.*

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -61,7 +61,7 @@ Right, we'd better write some views then.  Open `tutorial/quickstart/views.py` a
 
     from django.contrib.auth.models import User, Group
     from rest_framework import viewsets
-    from tutorial.quickstart.serializers import UserSerializer, GroupSerializer
+    from quickstart.serializers import UserSerializer, GroupSerializer
 
 
     class UserViewSet(viewsets.ModelViewSet):
@@ -89,7 +89,7 @@ Okay, now let's wire up the API URLs.  On to `tutorial/urls.py`...
 
     from django.conf.urls import url, include
     from rest_framework import routers
-    from tutorial.quickstart import views
+    from quickstart import views
 
     router = routers.DefaultRouter()
     router.register(r'users', views.UserViewSet)


### PR DESCRIPTION
using the quick start guide the way it was written gives error with django 1.9.2 . Hence , the imports are changed to stay in accordance to the latest django release .