### PR TITLE
Also handle own permission denied exception

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -84,7 +84,7 @@ def exception_handler(exc, context):
         set_rollback()
         return Response(data, status=status.HTTP_404_NOT_FOUND)
 
-    elif isinstance(exc, PermissionDenied):
+    elif isinstance(exc, PermissionDenied) or isinstance(exc, exceptions.PermissionDenied):
         msg = _('Permission denied.')
         data = {'detail': six.text_type(msg)}
 


### PR DESCRIPTION
Not only should `django.core.exceptions.PermissionDenied` result in a 403_FORBIDDEN, but make this also happen for our own `rest_framework.exceptions.PermissionDenied `

see https://github.com/tomchristie/django-rest-framework/issues/3893 for a more complete explanation of the issue.