### PR TITLE
Use 'password123' as password for new users in the tutorial

### DIFF
--- a/docs/tutorial/4-authentication-and-permissions.md
+++ b/docs/tutorial/4-authentication-and-permissions.md
@@ -206,7 +206,7 @@ If we try to create a snippet without authenticating, we'll get an error:
 
 We can make a successful request by including the username and password of one of the users we created earlier.
 
-    http -a tom:password POST http://127.0.0.1:8000/snippets/ code="print 789"
+    http -a tom:password123 POST http://127.0.0.1:8000/snippets/ code="print 789"
 
     {
         "id": 5,

--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -28,7 +28,7 @@ Now sync your database for the first time:
 
     python manage.py migrate
 
-We'll also create an initial user named `admin` with a password of `password`. We'll authenticate as that user later in our example.
+We'll also create an initial user named `admin` with a password of `password123`. We'll authenticate as that user later in our example.
 
     python manage.py createsuperuser
 
@@ -134,7 +134,7 @@ We're now ready to test the API we've built.  Let's fire up the server from the 
 
 We can now access our API, both from the command-line, using tools like `curl`...
 
-    bash: curl -H 'Accept: application/json; indent=4' -u admin:password http://127.0.0.1:8000/users/
+    bash: curl -H 'Accept: application/json; indent=4' -u admin:password123 http://127.0.0.1:8000/users/
     {
         "count": 2,
         "next": null,
@@ -157,7 +157,7 @@ We can now access our API, both from the command-line, using tools like `curl`..
 
 Or using the [httpie][httpie], command line tool...
 
-    bash: http -a username:password http://127.0.0.1:8000/users/
+    bash: http -a username:password123 http://127.0.0.1:8000/users/
 
     HTTP/1.1 200 OK
     ...


### PR DESCRIPTION
Trying to create a new user on Django 1.9.x with the password 'password'
will fail with the error message 'This password is too common.'. Because
of that it is necessary to change the used password from 'password' to
'password123'.