### PR TITLE
Attempt to address Django 2.0 deprecate warnings related to field.rel

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -268,3 +268,16 @@ def get_all_related_many_to_many_objects(opts):
         return opts.get_all_related_many_to_many_objects()
     else:
         return [r for r in opts.related_objects if r.field.many_to_many]
+
+def get_remote_field(field):
+    """
+    Django 1.9 removed usage of Rel objects, see
+    https://github.com/django/django/pull/4241
+
+    :param field: Field
+    :return: remote field
+    """
+    if django.VERSION < (1, 9):
+        return field.rel
+    else:
+        return field.remote_field

--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -80,16 +80,16 @@ def get_field_info(model):
 
 def _get_pk(opts):
     pk = opts.pk
-    while pk.rel and pk.rel.parent_link:
+    while pk.remote_field and pk.remote_field.parent_link:
         # If model is a child via multi-table inheritance, use parent's pk.
-        pk = pk.rel.to._meta.pk
+        pk = pk.remote_field.to._meta.pk
 
     return pk
 
 
 def _get_fields(opts):
     fields = OrderedDict()
-    for field in [field for field in opts.fields if field.serialize and not field.rel]:
+    for field in [field for field in opts.fields if field.serialize and not field.remote_field]:
         fields[field.name] = field
 
     return fields
@@ -104,10 +104,10 @@ def _get_forward_relationships(opts):
     Returns an `OrderedDict` of field names to `RelationInfo`.
     """
     forward_relations = OrderedDict()
-    for field in [field for field in opts.fields if field.serialize and field.rel]:
+    for field in [field for field in opts.fields if field.serialize and field.remote_field]:
         forward_relations[field.name] = RelationInfo(
             model_field=field,
-            related_model=_resolve_model(field.rel.to),
+            related_model=_resolve_model(field.remote_field.to),
             to_many=False,
             to_field=_get_to_field(field),
             has_through_model=False
@@ -117,12 +117,12 @@ def _get_forward_relationships(opts):
     for field in [field for field in opts.many_to_many if field.serialize]:
         forward_relations[field.name] = RelationInfo(
             model_field=field,
-            related_model=_resolve_model(field.rel.to),
+            related_model=_resolve_model(field.remote_field.to),
             to_many=True,
             # manytomany do not have to_fields
             to_field=None,
             has_through_model=(
-                not field.rel.through._meta.auto_created
+                not field.remote_field.through._meta.auto_created
             )
         )
 
@@ -144,7 +144,7 @@ def _get_reverse_relationships(opts):
         reverse_relations[accessor_name] = RelationInfo(
             model_field=None,
             related_model=related,
-            to_many=relation.field.rel.multiple,
+            to_many=relation.field.remote_field.multiple,
             to_field=_get_to_field(relation.field),
             has_through_model=False
         )
@@ -160,8 +160,8 @@ def _get_reverse_relationships(opts):
             # manytomany do not have to_fields
             to_field=None,
             has_through_model=(
-                (getattr(relation.field.rel, 'through', None) is not None) and
-                not relation.field.rel.through._meta.auto_created
+                (getattr(relation.field.remote_field, 'through', None) is not None) and
+                not relation.field.remote_field.through._meta.auto_created
             )
         )
 


### PR DESCRIPTION
This is related to https://github.com/django/django/pull/4241

```
rest_framework/utils/model_meta.py:83: RemovedInDjango20Warning: Usage of field.rel has been deprecated. Use field.remote_field instead.
  while pk.rel and pk.rel.parent_link:
rest_framework/utils/model_meta.py:92: RemovedInDjango20Warning: Usage of field.rel has been deprecated. Use field.remote_field instead.
  for field in [field for field in opts.fields if field.serialize and not field.rel]:
rest_framework/utils/model_meta.py:107: RemovedInDjango20Warning: Usage of field.rel has been deprecated. Use field.remote_field instead.
  for field in [field for field in opts.fields if field.serialize and field.rel]:
rest_framework/utils/model_meta.py:147: RemovedInDjango20Warning: Usage of field.rel has been deprecated. Use field.remote_field instead.
  to_many=relation.field.rel.multiple,
rest_framework/utils/model_meta.py:163: RemovedInDjango20Warning: Usage of field.rel has been deprecated. Use field.remote_field instead.
  (getattr(relation.field.rel, 'through', None) is not None) and
rest_framework/utils/model_meta.py:164: RemovedInDjango20Warning: Usage of field.rel has been deprecated. Use field.remote_field instead.
  not relation.field.rel.through._meta.auto_created
```

I'm not sure how best to handle this for versions prior to Django 1.9