### PR TITLE
Fixed _force_text_recursive typo

### DIFF
--- a/rest_framework/exceptions.py
+++ b/rest_framework/exceptions.py
@@ -28,7 +28,7 @@ def _force_text_recursive(data):
         ]
         if isinstance(data, ReturnList):
             return ReturnList(ret, serializer=data.serializer)
-        return data
+        return ret
     elif isinstance(data, dict):
         ret = {
             key: _force_text_recursive(value)
@@ -36,7 +36,7 @@ def _force_text_recursive(data):
         }
         if isinstance(data, ReturnDict):
             return ReturnDict(ret, serializer=data.serializer)
-        return data
+        return ret
     return force_text(data)
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,21 @@
+from __future__ import unicode_literals
+
+from django.test import TestCase
+from django.utils.translation import ugettext_lazy as _
+
+from rest_framework.exceptions import _force_text_recursive
+
+
+class ExceptionTestCase(TestCase):
+
+    def test_force_text_recursive(self):
+
+        s = "sfdsfggiuytraetfdlklj"
+        self.assertEqual(_force_text_recursive(_(s)), s)
+        self.assertEqual(type(_force_text_recursive(_(s))), type(s))
+
+        self.assertEqual(_force_text_recursive({'a': _(s)})['a'], s)
+        self.assertEqual(type(_force_text_recursive({'a': _(s)})['a']), type(s))
+
+        self.assertEqual(_force_text_recursive([[_(s)]])[0][0], s)
+        self.assertEqual(type(_force_text_recursive([[_(s)]])[0][0]), type(s))


### PR DESCRIPTION
Looks like a typo. 
Steps to reproduce:

    >>> from django.utils.translation import ugettext_lazy as _
    >>> from rest_framework.exceptions import _force_text_recursive
    >>> _force_text_recursive(_("fdsf"))
    'fdsf'
    >>> _force_text_recursive({'a': _("fdsf")})
    {'a': <django.utils.functional.lazy.<locals>.__proxy__ object at 0x10ba73e80>}