### PR TITLE
Fixes vertical html layout for BooleanField

### DIFF
--- a/rest_framework/templates/rest_framework/vertical/checkbox.html
+++ b/rest_framework/templates/rest_framework/vertical/checkbox.html
@@ -1,7 +1,7 @@
 <div class="form-group {% if field.errors %}has-error{% endif %}">
   <div class="checkbox">
     <label>
-      <input type="checkbox" name="{{ field.name }}" value="true" {% if value %}checked{% endif %}>
+      <input type="checkbox" name="{{ field.name }}" value="true" {% if field.value %}checked{% endif %}>
         {% if field.label %}{{ field.label }}{% endif %}
     </label>
   </div>


### PR DESCRIPTION
`HTMLFormRenderer` renders `BooleanField` field as not checked if vertical layout are used.