### PR TITLE
Remove version string from base template

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -37,7 +37,7 @@
           <span>
             {% block branding %}
               <a class='navbar-brand' rel="nofollow" href='http://www.django-rest-framework.org'>
-                  Django REST framework <span class="version">{{ version }}</span>
+                  Django REST framework
               </a>
             {% endblock %}
           </span>


### PR DESCRIPTION
Closes #3878.

I just removed it from the template. I left the version string in the context so if people want to include it they can.