### PR TITLE
Remove version string from admin template

### DIFF
--- a/rest_framework/templates/rest_framework/admin.html
+++ b/rest_framework/templates/rest_framework/admin.html
@@ -36,7 +36,7 @@
                         <span>
                             {% block branding %}
                                 <a class='navbar-brand' rel="nofollow" href='http://www.django-rest-framework.org'>
-                                    Django REST framework <span class="version">{{ version }}</span>
+                                    Django REST framework
                                 </a>
                             {% endblock %}
                         </span>


### PR DESCRIPTION
Should be the last instance of publicly accessible version strings - takes care of #3878.