### PR TITLE
Drop EOL Django 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ env:
     - TOX_ENV=py33-django18
     - TOX_ENV=py32-django18
     - TOX_ENV=py27-django18
-    - TOX_ENV=py34-django17
-    - TOX_ENV=py33-django17
-    - TOX_ENV=py32-django17
-    - TOX_ENV=py27-django17
 
 matrix:
   fast_finish: true

--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -40,6 +40,12 @@ You can determine your currently installed version using `pip freeze`:
 
 ## 3.3.x series
 
+### 3.4
+
+**Unreleased**
+
+* Dropped support for EOL Django 1.7 ([#3933][gh3933])
+
 ### 3.3.2
 
 **Date**: [14th December 2015][3.3.2-milestone].

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ addopts=--tb=short
 [tox]
 envlist =
        py27-{lint,docs},
-       {py27,py32,py33,py34}-django{17,18},
+       {py27,py32,py33,py34}-django18,
        {py27,py34,py35}-django{19}
 
 [testenv]
@@ -13,7 +13,6 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
        PYTHONWARNINGS=once
 deps =
-        django17: Django==1.7.11
         django18: Django==1.8.9
         django19: Django==1.9.2
         -rrequirements/requirements-testing.txt


### PR DESCRIPTION
As per discussion on #3915: drops Django 1.7 in a separate pull request.