### PR TITLE
Fix None UUID ForeignKey serialization

### DIFF
--- a/docs/topics/release-notes.md
+++ b/docs/topics/release-notes.md
@@ -45,6 +45,7 @@ You can determine your currently installed version using `pip freeze`:
 **Unreleased**
 
 * Dropped support for EOL Django 1.7 ([#3933][gh3933])
+* Fixed null foreign keys targeting UUIDField primary keys. ([#3936][gh3936])
 
 ### 3.3.2
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -778,6 +778,8 @@ class UUIDField(Field):
         return data
 
     def to_representation(self, value):
+        if value is None:
+            return None
         if self.uuid_format == 'hex_verbose':
             return str(value)
         else:

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -778,8 +778,6 @@ class UUIDField(Field):
         return data
 
     def to_representation(self, value):
-        if value is None:
-            return None
         if self.uuid_format == 'hex_verbose':
             return str(value)
         else:

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -464,9 +464,13 @@ class Serializer(BaseSerializer):
             except SkipField:
                 continue
 
-            if attribute is None:
-                # We skip `to_representation` for `None` values so that
-                # fields do not have to explicitly deal with that case.
+            # We skip `to_representation` for `None` values so that fields do
+            # not have to explicitly deal with that case.
+            #
+            # For related fields with `use_pk_only_optimization` we need to
+            # resolve the pk value.
+            check_for_none = attribute.pk if isinstance(attribute, PKOnlyObject) else attribute
+            if check_for_none is None:
                 ret[field.field_name] = None
             else:
                 ret[field.field_name] = field.to_representation(attribute)

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import uuid
+
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
@@ -46,6 +48,11 @@ class ForeignKeyTarget(RESTFrameworkModel):
     name = models.CharField(max_length=100)
 
 
+class UUIDForeignKeyTarget(RESTFrameworkModel):
+    uuid = models.UUIDField(primary_key=True, default=uuid.uuid4)
+    name = models.CharField(max_length=100)
+
+
 class ForeignKeySource(RESTFrameworkModel):
     name = models.CharField(max_length=100)
     target = models.ForeignKey(ForeignKeyTarget, related_name='sources',
@@ -55,6 +62,14 @@ class ForeignKeySource(RESTFrameworkModel):
 
 # Nullable ForeignKey
 class NullableForeignKeySource(RESTFrameworkModel):
+    name = models.CharField(max_length=100)
+    target = models.ForeignKey(ForeignKeyTarget, null=True, blank=True,
+                               related_name='nullable_sources',
+                               verbose_name='Optional target object',
+                               on_delete=models.CASCADE)
+
+
+class NullableUUIDForeignKeySource(RESTFrameworkModel):
     name = models.CharField(max_length=100)
     target = models.ForeignKey(ForeignKeyTarget, null=True, blank=True,
                                related_name='nullable_sources',

--- a/tests/test_relations_pk.py
+++ b/tests/test_relations_pk.py
@@ -6,7 +6,8 @@ from django.utils import six
 from rest_framework import serializers
 from tests.models import (
     ForeignKeySource, ForeignKeyTarget, ManyToManySource, ManyToManyTarget,
-    NullableForeignKeySource, NullableOneToOneSource, OneToOneTarget
+    NullableForeignKeySource, NullableOneToOneSource,
+    NullableUUIDForeignKeySource, OneToOneTarget, UUIDForeignKeyTarget
 )
 
 
@@ -40,6 +41,18 @@ class ForeignKeySourceSerializer(serializers.ModelSerializer):
 class NullableForeignKeySourceSerializer(serializers.ModelSerializer):
     class Meta:
         model = NullableForeignKeySource
+        fields = ('id', 'name', 'target')
+
+
+# Nullable UUIDForeignKey
+class NullableUUIDForeignKeySourceSerializer(serializers.ModelSerializer):
+    target = serializers.PrimaryKeyRelatedField(
+        pk_field=serializers.UUIDField(),
+        queryset=UUIDForeignKeyTarget.objects.all(),
+        allow_empty=True)
+
+    class Meta:
+        model = NullableUUIDForeignKeySource
         fields = ('id', 'name', 'target')
 
 
@@ -431,6 +444,12 @@ class PKNullableForeignKeyTests(TestCase):
             {'id': 3, 'name': 'source-3', 'target': None}
         ]
         self.assertEqual(serializer.data, expected)
+
+    def test_null_uuid_foreign_key_serializes_as_none(self):
+        source = NullableUUIDForeignKeySource(name='Source')
+        serializer = NullableUUIDForeignKeySourceSerializer(source)
+        data = serializer.data
+        self.assertEqual(data["target"], None)
 
 
 class PKNullableOneToOneTests(TestCase):

--- a/tests/test_relations_pk.py
+++ b/tests/test_relations_pk.py
@@ -49,7 +49,7 @@ class NullableUUIDForeignKeySourceSerializer(serializers.ModelSerializer):
     target = serializers.PrimaryKeyRelatedField(
         pk_field=serializers.UUIDField(),
         queryset=UUIDForeignKeyTarget.objects.all(),
-        allow_empty=True)
+        allow_null=True)
 
     class Meta:
         model = NullableUUIDForeignKeySource
@@ -450,6 +450,11 @@ class PKNullableForeignKeyTests(TestCase):
         serializer = NullableUUIDForeignKeySourceSerializer(source)
         data = serializer.data
         self.assertEqual(data["target"], None)
+
+    def test_nullable_uuid_foreign_key_is_valid_when_none(self):
+        data = {"name": "Source", "target": None}
+        serializer = NullableUUIDForeignKeySourceSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
 
 
 class PKNullableOneToOneTests(TestCase):


### PR DESCRIPTION
Replaces #3915

> A nullable foreign key with a UUID primary key on the other end would result in incorrect serialisation as (the string) 'None'.
> 
> This PR adds a minimal test case and fix.