### PR TITLE
Remove page information in pagination error messages

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -186,7 +186,7 @@ class PageNumberPagination(BasePagination):
 
     template = 'rest_framework/pagination/numbers.html'
 
-    invalid_page_message = _('Invalid page "{page_number}": {message}.')
+    invalid_page_message = _('Invalid page.')
 
     def paginate_queryset(self, queryset, request, view=None):
         """

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -113,7 +113,7 @@ class TestPaginationIntegration:
         response = self.view(request)
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.data == {
-            'detail': 'Invalid page "0": That page number is less than 1.'
+            'detail': 'Invalid page.'
         }
 
     def test_404_not_found_for_invalid_page(self):
@@ -121,7 +121,7 @@ class TestPaginationIntegration:
         response = self.view(request)
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.data == {
-            'detail': 'Invalid page "invalid": That page number is not an integer.'
+            'detail': 'Invalid page.'
         }
 
 


### PR DESCRIPTION
We remove a couple of informations to lower the exposition of our internals.

This is somewhat related to security. We remove those informations to lower the leak of informations.