### PR TITLE
`OrderingFilter` should call `get_serializer_class()` to determine default fields.

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -227,8 +227,9 @@ class OrderingFilter(BaseFilterBackend):
 
         if valid_fields is None:
             # Default to allowing filtering on serializer fields
-            serializer_class = getattr(view, 'serializer_class')
-            if serializer_class is None:
+            try:
+                serializer_class = view.get_serializer_class()
+            except AssertionError:
                 msg = ("Cannot use %s on a view which does not have either a "
                        "'serializer_class' or 'ordering_fields' attribute.")
                 raise ImproperlyConfigured(msg % self.__class__.__name__)


### PR DESCRIPTION
refs #3957 

I made the proposed change

Because the default get_serializer_class method of GenericAPIView throw an Assertion error if there is no serializer_class defined on the view, I made a try except block that catches the exception and return the message as defined previously. I don't know if that is the correct idea.

I also added 3 tests for this fix.