### PR TITLE
Add `/en` to Heroku guidelines link

### DIFF
--- a/docs/api-guide/versioning.md
+++ b/docs/api-guide/versioning.md
@@ -214,7 +214,7 @@ If your versioning scheme is based on the request URL, you will also want to alt
 [cite]: http://www.slideshare.net/evolve_conference/201308-fielding-evolve/31
 [roy-fielding-on-versioning]: http://www.infoq.com/articles/roy-fielding-on-versioning
 [klabnik-guidelines]: http://blog.steveklabnik.com/posts/2011-07-03-nobody-understands-rest-or-http#i_want_my_api_to_be_versioned
-[heroku-guidelines]: https://github.com/interagent/http-api-design/blob/master/foundations/require-versioning-in-the-accepts-header.md
+[heroku-guidelines]: https://github.com/interagent/http-api-design/blob/master/en/foundations/require-versioning-in-the-accepts-header.md
 [json-parameters]: http://tools.ietf.org/html/rfc4627#section-6
 [vendor-media-type]: http://en.wikipedia.org/wiki/Internet_media_type#Vendor_tree
 [lvh]: https://reinteractive.net/posts/199-developing-and-testing-rails-applications-with-subdomains


### PR DESCRIPTION
Their guidelines added localization to the repo structure.