### PR TITLE
add rest-framework-generic-relations link to docs

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -580,9 +580,14 @@ The following third party packages are also available.
 
 The [drf-nested-routers package][drf-nested-routers] provides routers and relationship fields for working with nested resources.
 
+## Rest Framework Generic Relations
+
+The [rest-framework-generic-relations][drf-nested-relations] library provides read/write serialization for generic foreign keys.
+
 [cite]: http://lwn.net/Articles/193245/
 [reverse-relationships]: https://docs.djangoproject.com/en/dev/topics/db/queries/#following-relationships-backward
 [routers]: http://www.django-rest-framework.org/api-guide/routers#defaultrouter
 [generic-relations]: https://docs.djangoproject.com/en/dev/ref/contrib/contenttypes/#id1
 [2.2-announcement]: ../topics/2.2-announcement.md
 [drf-nested-routers]: https://github.com/alanjds/drf-nested-routers
+[drf-nested-relations]: https://github.com/Ian-Foote/rest-framework-generic-relations


### PR DESCRIPTION
Based on the work of [#755](https://github.com/tomchristie/django-rest-framework/pull/755), this library is solving a really typical use case for generic foreign keys. I think it should be more visible.