### PR TITLE
[2.4] Fixes for Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ env:
     - TOX_ENV=py2.6-django1.4
 
 install:
-  - "pip install tox --download-cache $HOME/.pip-cache"
+# Virtualenv < 14 is required to keep the Python 3.2 builds running.
+  - "pip install tox 'virtualenv<14' --download-cache $HOME/.pip-cache"
 
 script:
     - tox -e $TOX_ENV

--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -8,7 +8,7 @@ ______ _____ _____ _____    __
 """
 
 __title__ = 'Django REST framework'
-__version__ = '2.4.8'
+__version__ = '2.4.9'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 2-Clause'
 __copyright__ = 'Copyright 2011-2014 Tom Christie'

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -73,6 +73,12 @@ except ImportError:
     from collections import UserDict
     from collections import MutableMapping as DictMixin
 
+# http responses move in Python 3
+try:
+    from httplib import responses
+except ImportError:
+    from http.client import responses
+
 # Try to import PIL in either of the two ways it can end up installed.
 try:
     from PIL import Image

--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -10,6 +10,7 @@ from django.template.response import SimpleTemplateResponse
 from django.utils import six
 from rest_framework.compat import responses
 
+
 class Response(SimpleTemplateResponse):
     """
     An HttpResponse that allows its data to be rendered into

--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -6,10 +6,9 @@ The appropriate renderer is called during Django's template response rendering.
 """
 from __future__ import unicode_literals
 import django
-from django.core.handlers.wsgi import STATUS_CODE_TEXT
 from django.template.response import SimpleTemplateResponse
 from django.utils import six
-
+import httplib
 
 class Response(SimpleTemplateResponse):
     """
@@ -81,7 +80,7 @@ class Response(SimpleTemplateResponse):
         """
         # TODO: Deprecate and use a template tag instead
         # TODO: Status code text for RFC 6585 status codes
-        return STATUS_CODE_TEXT.get(self.status_code, '')
+        return httplib[self.status_code]
 
     def __getstate__(self):
         """

--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 import django
 from django.template.response import SimpleTemplateResponse
 from django.utils import six
-import httplib
+from rest_framework.compat import responses
 
 class Response(SimpleTemplateResponse):
     """
@@ -80,7 +80,7 @@ class Response(SimpleTemplateResponse):
         """
         # TODO: Deprecate and use a template tag instead
         # TODO: Status code text for RFC 6585 status codes
-        return httplib[self.status_code]
+        return responses.get(self.status_code, '')
 
     def __getstate__(self):
         """

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -15,6 +15,9 @@ import copy
 import datetime
 import inspect
 import types
+
+import django
+
 from decimal import Decimal
 from django.core.paginator import Page
 from django.db import models
@@ -1081,7 +1084,10 @@ class ModelSerializer(Serializer):
                     self.save_object(related)
                 elif isinstance(related, list):
                     # Many to One/Many
-                    getattr(obj, accessor_name).add(*related, bulk=False)
+                    if django.VERSION >= (1, 9):
+                        getattr(obj, accessor_name).add(*related, bulk=False)
+                    else:
+                        getattr(obj, accessor_name).add(*related)
                 else:
                     # Reverse FK or reverse one-one
                     setattr(obj, accessor_name, related)

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1081,7 +1081,10 @@ class ModelSerializer(Serializer):
                     self.save_object(related)
                 else:
                     # Reverse FK or reverse one-one
-                    setattr(obj, accessor_name, related)
+                    try:
+                        setattr(obj, accessor_name, related)
+                    except ValueError:
+                        getattr(obj, accessor_name).add(*related, bulk=False)
             del(obj._related_data)
 
 

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1079,12 +1079,12 @@ class ModelSerializer(Serializer):
                     fk_field = obj._meta.get_field_by_name(accessor_name)[0].field.name
                     setattr(related, fk_field, obj)
                     self.save_object(related)
+                elif isinstance(related, list):
+                    # Many to One/Many
+                    getattr(obj, accessor_name).add(*related, bulk=False)
                 else:
                     # Reverse FK or reverse one-one
-                    try:
-                        setattr(obj, accessor_name, related)
-                    except ValueError:
-                        getattr(obj, accessor_name).add(*related, bulk=False)
+                    setattr(obj, accessor_name, related)
             del(obj._related_data)
 
 


### PR DESCRIPTION
Hey guys,
we are bumping our app to newest Django and I started working a little bit on some changes that are already not supported in Django 1.9.4

However, exception I catch... I am not sure if this is proper way.
Due to change of `m2m.add()` now Django by default picks `bulk=True`, which is something we don't want here.

For now, workaround is to catch exception and try to do `.add(bulk=False)` but it is not perfect solution.
Could you point me in a way how to check if this is M2M or One2One relation? Or foreign key? 