### PR TITLE
OrderingFilter adjustements

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -240,8 +240,7 @@ class OrderingFilter(BaseFilterBackend):
         elif valid_fields == '__all__':
             # View explicitly allows filtering on any model field
             valid_fields = [
-                (field.name, getattr(field, 'label', field.name.title()))
-                for field in queryset.model._meta.fields
+                (field.name, field.verbose_name) for field in queryset.model._meta.fields
             ]
             valid_fields += [
                 (key, key.title().split('__'))

--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -271,8 +271,8 @@ class OrderingFilter(BaseFilterBackend):
         current = None if current is None else current[0]
         options = []
         for key, label in self.get_valid_fields(queryset, view):
-            options.append((key, '%s - ascending' % label))
-            options.append(('-' + key, '%s - descending' % label))
+            options.append((key, '%s - %s' % (label, _('ascending'))))
+            options.append(('-' + key, '%s - %s' % (label, _('descending'))))
         return {
             'request': request,
             'current': current,

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -499,7 +499,7 @@ class SearchFilterM2MTests(TestCase):
 
 
 class OrderingFilterModel(models.Model):
-    title = models.CharField(max_length=20)
+    title = models.CharField(max_length=20, verbose_name='verbose title')
     text = models.CharField(max_length=100)
 
 
@@ -740,6 +740,19 @@ class OrderingFilterTests(TestCase):
             )
 
         reload_module(filters)
+
+    def test_get_template_context(self):
+        class OrderingListView(generics.ListAPIView):
+            ordering_fields = '__all__'
+            serializer_class = OrderingFilterSerializer
+            queryset = OrderingFilterModel.objects.all()
+            filter_backends = (filters.OrderingFilter,)
+
+        request = factory.get('/', {'ordering': 'title'}, HTTP_ACCEPT='text/html')
+        view = OrderingListView.as_view()
+        response = view(request)
+
+        self.assertContains(response, 'verbose title')
 
 
 class SensitiveOrderingFilterModel(models.Model):


### PR DESCRIPTION
## Description

Two small changes to the `OrderingFilter`'s browsable API display.

1. Always use `Field.verbose_name` when `__all__` is specified as `Field.label` doesn't exist;
2. Marked the ordering labels (`'ascending'`, `'descending'`) for translation.
