### PR TITLE
Fixed RelatedField(required=False) bug

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -62,7 +62,7 @@ def is_simple_callable(obj):
     return len_args <= len_defaults
 
 
-def get_attribute(instance, attrs):
+def get_attribute(instance, attrs, required=True):
     """
     Similar to Python's built in `getattr(instance, attr)`,
     but takes a list of nested attributes, instead of a single attribute.
@@ -80,6 +80,12 @@ def get_attribute(instance, attrs):
                 instance = getattr(instance, attr)
         except ObjectDoesNotExist:
             return None
+        # RelatedObjectDoesNotExist inherits from both ObjectDoesNotExist and
+        # AttributeError, so ObjectDoesNotExist has to come first
+        except (AttributeError, KeyError):
+            if not required:
+                raise SkipField
+            raise
         if is_simple_callable(instance):
             try:
                 instance = instance()

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -154,7 +154,7 @@ class RelatedField(Field):
                 pass
 
         # Standard case, return the object instance.
-        return get_attribute(instance, self.source_attrs)
+        return get_attribute(instance, self.source_attrs, self.required)
 
     @property
     def choices(self):

--- a/tests/test_relations_pk.py
+++ b/tests/test_relations_pk.py
@@ -334,12 +334,7 @@ class PKForeignKeyTests(TestCase):
         """
         class ModelSerializer(ForeignKeySourceSerializer):
             class Meta(ForeignKeySourceSerializer.Meta):
-                extra_kwargs = {
-                    'target': {
-                        'required': False,
-                        'allow_empty': True,
-                    }
-                }
+                extra_kwargs = {'target': {'required': False}}
         serializer = ModelSerializer(data={'name': 'test'})
         serializer.is_valid(raise_exception=True)
         self.assertNotIn('target', serializer.data)

--- a/tests/test_relations_pk.py
+++ b/tests/test_relations_pk.py
@@ -327,6 +327,23 @@ class PKForeignKeyTests(TestCase):
         serializer = NullableForeignKeySourceSerializer()
         self.assertEqual(serializer.data['target'], None)
 
+    def test_foreign_key_not_required(self):
+        """
+        Let's say we wanted to fill the non-nullable model field inside
+        Model.save(), we would make it empty and not required.
+        """
+        class ModelSerializer(ForeignKeySourceSerializer):
+            class Meta(ForeignKeySourceSerializer.Meta):
+                extra_kwargs = {
+                    'target': {
+                        'required': False,
+                        'allow_empty': True,
+                    }
+                }
+        serializer = ModelSerializer(data={'name': 'test'})
+        serializer.is_valid(raise_exception=True)
+        self.assertNotIn('target', serializer.data)
+
 
 class PKNullableForeignKeyTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description
I encountered the issue in totally unrelated (and invalid according to docs) case, but also found valid use case where it fails in exactly the same way.

When we want to fill-in the field specifically on `Model` level instead of `ModelSerializer` we would make it `required=False, allow_empty=True` and not pass the field at all in `data`.

Before this fix resolution of `Serializer.data` would yield `KeyError`.