### PR TITLE
Made all content of the base template into blocks

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -2,33 +2,43 @@
 {% load rest_framework %}
 {% load i18n %}
 
+
+{% block prehead %}
 <!DOCTYPE html>
 <html>
 <head>
-  {% block head %}
+{% endblock prehead %}
 
-    {% block meta %}
-      <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-      <meta name="robots" content="NONE,NOARCHIVE" />
-    {% endblock %}
+{% block head %}
 
-    <title>{% block title %}{% if name %}{{ name }} – {% endif %}Django REST framework{% endblock %}</title>
-
-    {% block style %}
-      {% block bootstrap_theme %}
-        <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap.min.css" %}"/>
-        <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap-tweaks.css" %}"/>
-      {% endblock %}
-
-      <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/prettify.css" %}"/>
-      <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/default.css" %}"/>
-    {% endblock %}
-
+  {% block meta %}
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="robots" content="NONE,NOARCHIVE" />
   {% endblock %}
+
+  <title>{% block title %}{% if name %}{{ name }} – {% endif %}Django REST framework{% endblock %}</title>
+
+  {% block style %}
+    {% block bootstrap_theme %}
+      <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap.min.css" %}"/>
+      <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap-tweaks.css" %}"/>
+    {% endblock %}
+
+    <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/prettify.css" %}"/>
+    <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/default.css" %}"/>
+  {% endblock %}
+
+{% endblock %}
+
+{% block posthead %}
 </head>
+{% endblock %}
 
 {% block body %}
+
+{% block bodystart %}
 <body class="{% block bodyclass %}{% endblock %}">
+{% endblock %}
 
   <div class="wrapper">
     {% block navbar %}
@@ -275,6 +285,11 @@
   {{ filter_form }}
   {% endif %}
 
+{% block bodyend %}
 </body>
 {% endblock %}
-</html>
+{% endblock %}
+
+{% block postbody %}
+  </html>
+{% endblock %}


### PR DESCRIPTION
With new overextends template loading [merged into Django](https://code.djangoproject.com/ticket/15053) one can now directly extend `base.html` in a recursive fashion.

I wanted to use my own `base.html` but reuse most of the content from DRF's `base.html`. This was not possible because some content of DRF's `base.html` was not inside of blocks. This pull request moves all of them into blocks so that one can for example extend it and make them empty. Like I am doing [here](https://github.com/wlanslovenija/nodewatcher/blob/api-v2/nodewatcher/modules/frontend/api/templates/rest_framework/base.html).

Then, I can include such `base.html` into my own `base.html`, like an [example here](https://github.com/wlanslovenija/nodewatcher/blob/api-v2/nodewatcher/modules/frontend/api/templates/rest_framework/api.html).

Of course, it would be much better if `base.html` was including subtemplates to begin with, so I could just re-include that in my `api.html`, but because this is not so, and we want backwards compatibility, this approach with blocks works pretty well.

So, there are not backwards incompatible changes here, only moving content into blocks (despite diff showing more changes).