### PR TITLE
Run JavaScript only when DOM is ready

### DIFF
--- a/rest_framework/static/rest_framework/js/default.js
+++ b/rest_framework/static/rest_framework/js/default.js
@@ -19,47 +19,49 @@ function getCookie(c_name)
     return c_value;
 }
 
-// JSON highlighting.
-prettyPrint();
+$(document).ready(function () {
+    // JSON highlighting.
+    prettyPrint();
 
-// Bootstrap tooltips.
-$('.js-tooltip').tooltip({
-    delay: 1000,
-    container: 'body'
-});
+    // Bootstrap tooltips.
+    $('.js-tooltip').tooltip({
+        delay: 1000,
+        container: 'body'
+    });
 
-// Deal with rounded tab styling after tab clicks.
-$('a[data-toggle="tab"]:first').on('shown', function (e) {
-    $(e.target).parents('.tabbable').addClass('first-tab-active');
-});
-$('a[data-toggle="tab"]:not(:first)').on('shown', function (e) {
-    $(e.target).parents('.tabbable').removeClass('first-tab-active');
-});
+    // Deal with rounded tab styling after tab clicks.
+    $('a[data-toggle="tab"]:first').on('shown', function (e) {
+        $(e.target).parents('.tabbable').addClass('first-tab-active');
+    });
+    $('a[data-toggle="tab"]:not(:first)').on('shown', function (e) {
+        $(e.target).parents('.tabbable').removeClass('first-tab-active');
+    });
 
-$('a[data-toggle="tab"]').click(function(){
-    document.cookie="tabstyle=" + this.name + "; path=/";
-});
+    $('a[data-toggle="tab"]').click(function(){
+        document.cookie="tabstyle=" + this.name + "; path=/";
+    });
 
-// Store tab preference in cookies & display appropriate tab on load.
-var selectedTab = null;
-var selectedTabName = getCookie('tabstyle');
+    // Store tab preference in cookies & display appropriate tab on load.
+    var selectedTab = null;
+    var selectedTabName = getCookie('tabstyle');
 
-if (selectedTabName) {
-    selectedTabName = selectedTabName.replace(/[^a-z-]/g, '');
-}
+    if (selectedTabName) {
+        selectedTabName = selectedTabName.replace(/[^a-z-]/g, '');
+    }
 
-if (selectedTabName) {
-    selectedTab = $('.form-switcher a[name=' + selectedTabName + ']');
-}
+    if (selectedTabName) {
+        selectedTab = $('.form-switcher a[name=' + selectedTabName + ']');
+    }
 
-if (selectedTab && selectedTab.length > 0) {
-    // Display whichever tab is selected.
-    selectedTab.tab('show');
-} else {
-    // If no tab selected, display rightmost tab.
-    $('.form-switcher a:first').tab('show');
-}
+    if (selectedTab && selectedTab.length > 0) {
+        // Display whichever tab is selected.
+        selectedTab.tab('show');
+    } else {
+        // If no tab selected, display rightmost tab.
+        $('.form-switcher a:first').tab('show');
+    }
 
-$(window).load(function(){
-    $('#errorModal').modal('show');
+    $(window).load(function(){
+        $('#errorModal').modal('show');
+    });
 });


### PR DESCRIPTION
In custom themes one might want to move all JavaScript to the `<head>`. But currently JavaScript provided by DRF is not written in this way. This pull requests wraps it simply into a `$(document).ready` to assure that.

Diff is ugly because indentation changed.