### PR TITLE
Fixed admin pagination when limit is 0

### DIFF
--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -517,9 +517,9 @@ class TestLimitOffset:
         queryset = self.paginate_queryset(request)
         content = self.get_paginated_content(queryset)
         context = self.get_html_context()
-        assert queryset == self.queryset[20:35]
+        assert queryset == list(self.queryset[20:35])
         assert content == {
-            'results': self.queryset[20:35],
+            'results': list(self.queryset[20:35]),
             'previous': 'http://testserver/?limit=15&offset=5',
             'next': 'http://testserver/?limit=15&offset=35',
             'count': 100


### PR DESCRIPTION
This is an alternative fix #3444.

It is a simpler fix because it simply forces limit to never be 0. By default, if limit is given as 0, then `max_limit` is used as limit. But this can be changed in a subclass if somebody prefers to use `default_limit` in such case as well.

This allows one to request a default limit (by not providing `limit` query parameter) or request a max limit (by providing it with `limit=0` as a query parameter).