### PR TITLE
Remove django1.7 from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ There is a live example API for testing purposes, [available here][sandbox].
 # Requirements
 
 * Python (2.7, 3.2, 3.3, 3.4, 3.5)
-* Django (1.7, 1.8, 1.9)
+* Django (1.8, 1.9)
 
 # Installation
 


### PR DESCRIPTION
Remove django1.7 since #296c56764574b178be2d0ac96b38d7879e0b3947 took django1.7 off the build.