### PR TITLE
Fixed use of deprecated Query.aggregates

### DIFF
--- a/rest_framework/filters.py
+++ b/rest_framework/filters.py
@@ -245,7 +245,7 @@ class OrderingFilter(BaseFilterBackend):
             ]
             valid_fields += [
                 (key, key.title().split('__'))
-                for key in queryset.query.aggregates.keys()
+                for key in queryset.query.annotations.keys()
             ]
         else:
             valid_fields = [


### PR DESCRIPTION
In Django 1.8 [`Query.aggregates` is replaced by `annotations`](https://docs.djangoproject.com/es/1.9/releases/1.8/#aggregate-methods-and-modules).

Using aggregates currently raises a `RemovedInDjango110Warning`. See [Django's source](https://github.com/django/django/blob/1.8.11/django/db/models/sql/query.py#L194). This PR fixes it.