### PR TITLE
Add field's initial value to metadata

### DIFF
--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -124,7 +124,8 @@ class SimpleMetadata(BaseMetadata):
         attrs = [
             'read_only', 'label', 'help_text',
             'min_length', 'max_length',
-            'min_value', 'max_value'
+            'min_value', 'max_value',
+            'initial',
         ]
 
         for attr in attrs:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -135,10 +135,12 @@ class TestMetadata:
                         'required': True,
                         'read_only': False,
                         'label': 'List field',
+                        'initial': '[]',
                         'child': {
                             'type': 'list',
                             'required': True,
                             'read_only': False,
+                            'initial': '[]',
                             'child': {
                                 'type': 'integer',
                                 'required': True,
@@ -322,7 +324,8 @@ class TestModelSerializerMetadata(TestCase):
                         'type': 'field',
                         'required': False,
                         'read_only': True,
-                        'label': 'Children'
+                        'label': 'Children',
+                        'initial': '[]',
                     },
                     'integer_field': {
                         'type': 'integer',


### PR DESCRIPTION
Added field's initial value to metadata so that dynamic frontends can use the value to reduce duplication across front and backends.

@tomchristie I noticed that in the case of a list the initial value is coerced to a string by line 134, although I *think* a list should be translated to a list. There may be other cases I'm not considering and I'm not sure why `force_text` function is used so I have not changed the behavior. Any insights?

Thanks!