### PR TITLE
Reorder initializing the view

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -372,11 +372,6 @@ class APIView(View):
         """
         self.format_kwarg = self.get_format_suffix(**kwargs)
 
-        # Ensure that the incoming request is permitted
-        self.perform_authentication(request)
-        self.check_permissions(request)
-        self.check_throttles(request)
-
         # Perform content negotiation and store the accepted info on the request
         neg = self.perform_content_negotiation(request)
         request.accepted_renderer, request.accepted_media_type = neg
@@ -384,6 +379,11 @@ class APIView(View):
         # Determine the API version, if versioning is in use.
         version, scheme = self.determine_version(request, *args, **kwargs)
         request.version, request.versioning_scheme = version, scheme
+
+        # Ensure that the incoming request is permitted
+        self.perform_authentication(request)
+        self.check_permissions(request)
+        self.check_throttles(request)
 
     def finalize_response(self, request, response, *args, **kwargs):
         """


### PR DESCRIPTION
## Description
Determining the version and performing content negotiation should be done before ensuring the permission of the request. The reason is that these information can be used in handling the exceptions. For example different versions may return different error scheme. Also, the rendering class can be used to determine how to exception handler response should be rendered.