### PR TITLE
Fix typo

### DIFF
--- a/docs/api-guide/pagination.md
+++ b/docs/api-guide/pagination.md
@@ -54,7 +54,7 @@ Or apply the style globally, using the `DEFAULT_PAGINATION_CLASS` settings key. 
 
     REST_FRAMEWORK = {
         'DEFAULT_PAGINATION_CLASS': 'apps.core.pagination.StandardResultsSetPagination'
-        }
+    }
 
 ---
 

--- a/docs/topics/3.1-announcement.md
+++ b/docs/topics/3.1-announcement.md
@@ -110,7 +110,7 @@ When per-request internationalization is enabled, client requests will respect t
         "detail": "No se ha podido satisfacer la solicitud de cabecera de Accept."
     }
 
-Note that the structure of the error responses is still the same. We still have a `details` key in the response. If needed you can modify this behavior too, by using a [custom exception handler][custom-exception-handler].
+Note that the structure of the error responses is still the same. We still have a `detail` key in the response. If needed you can modify this behavior too, by using a [custom exception handler][custom-exception-handler].
 
 We include built-in translations both for standard exception cases, and for serializer validation errors.
 

--- a/docs/topics/3.2-announcement.md
+++ b/docs/topics/3.2-announcement.md
@@ -54,7 +54,7 @@ The following pagination view attributes and settings have been moved into attri
 * `view.max_paginate_by` - Use `paginator.max_page_size` instead.
 * `settings.PAGINATE_BY` - Use `paginator.page_size` instead.
 * `settings.PAGINATE_BY_PARAM` - Use `paginator.page_size_query_param` instead.
-* `settings.MAX_PAGINATE_BY` - Use `max_page_size` instead.
+* `settings.MAX_PAGINATE_BY` - Use `paginator.max_page_size` instead.
 
 ## Modifications to list behaviors
 


### PR DESCRIPTION
* Fix typo in 3.1 release notes. `details` should be `detail` in error responses
* Add missing `paginator` in 3.2 release notes
* Fix `pagination` sample code indention