### PR TITLE
Nested NamespaceVersioning

### DIFF
--- a/rest_framework/versioning.py
+++ b/rest_framework/versioning.py
@@ -112,13 +112,13 @@ class NamespaceVersioning(BaseVersioning):
     Host: example.com
     Accept: application/json
     """
-    invalid_version_message = _('Invalid version in URL path.')
+    invalid_version_message = _('Invalid version in namespace.')
 
     def determine_version(self, request, *args, **kwargs):
         resolver_match = getattr(request, 'resolver_match', None)
         if (resolver_match is None or not resolver_match.namespace):
             return self.default_version
-        version = resolver_match.namespace
+        version = resolver_match.namespace.split(':')[0]
         if not self.is_allowed_version(version):
             raise exceptions.NotFound(self.invalid_version_message)
         return version

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -271,8 +271,12 @@ class TestHyperlinkedRelatedField(UsingURLPatterns, APITestCase):
 
 
 class TestNamespaceVersioningHyperlinkedRelatedFieldScheme(UsingURLPatterns, APITestCase):
+    nested = [
+        url(r'^namespaced/(?P<pk>\d+)/$', dummy_pk_view, name='nested'),
+    ]
     included = [
         url(r'^namespaced/(?P<pk>\d+)/$', dummy_pk_view, name='namespaced'),
+        url(r'^nested/', include(nested, namespace='nested-namespace'))
     ]
 
     urlpatterns = [
@@ -295,6 +299,10 @@ class TestNamespaceVersioningHyperlinkedRelatedFieldScheme(UsingURLPatterns, API
     def test_api_url_is_properly_reversed_with_v1(self):
         field = self._create_field('namespaced', 'v1')
         assert field.to_representation(PKOnlyObject(3)) == 'http://testserver/v1/namespaced/3/'
+
+    def test_api_url_is_properly_reversed_with_nested(self):
+        field = self._create_field('nested', 'v1:nested-namespace')
+        assert field.to_representation(PKOnlyObject(3)) == 'http://testserver/v1/nested/namespaced/3/'
 
     def test_api_url_is_properly_reversed_with_v2(self):
         field = self._create_field('namespaced', 'v2')


### PR DESCRIPTION
## Description

This both fixes the misleading error message for `NamespaceVersioning` and adds proper (at least according to me) nested namespaces handling.

https://github.com/tomchristie/django-rest-framework/issues/4009
