### PR TITLE
links to html-json-forms package

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -1080,6 +1080,9 @@ The [django-rest-framework-hstore][django-rest-framework-hstore] package provide
 
 The [dynamic-rest][dynamic-rest] package extends the ModelSerializer and ModelViewSet interfaces, adding API query parameters for filtering, sorting, and including / excluding all fields and relationships defined by your serializers.
 
+## HTML JSON Forms
+The [html-json-forms][html-json-forms] package provides an algorithm and serializer for processing `<form>` submissions per the (inactive) [HTML JSON Form specification][json-form-spec].  The serializer facilitates processing of arbitrarily nested JSON structures within HTML.  For example, `<input name="items[0][id]" value="5">` will be interpreted as `{"items": [{"id": "5"}]}`.
+
 [cite]: https://groups.google.com/d/topic/django-users/sVFaOfQi4wY/discussion
 [relations]: relations.md
 [model-managers]: https://docs.djangoproject.com/en/dev/topics/db/managers/
@@ -1092,3 +1095,5 @@ The [dynamic-rest][dynamic-rest] package extends the ModelSerializer and ModelVi
 [django-rest-framework-hstore]: https://github.com/djangonauts/django-rest-framework-hstore
 [django-hstore]: https://github.com/djangonauts/django-hstore
 [dynamic-rest]: https://github.com/AltSchool/dynamic-rest
+[html-json-forms]: https://github.com/wq/html-json-forms
+[json-form-spec]: https://www.w3.org/TR/html-json-forms/

--- a/docs/topics/third-party-resources.md
+++ b/docs/topics/third-party-resources.md
@@ -203,6 +203,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 * [djangorestframework-gis][djangorestframework-gis] - Geographic add-ons
 * [djangorestframework-hstore][djangorestframework-hstore] - Serializer class to support django-hstore DictionaryField model field and its schema-mode feature.
 * [djangorestframework-jsonapi][djangorestframework-jsonapi] - Provides a parser, renderer, serializers, and other tools to help build an API that is compliant with the jsonapi.org spec.
+* [html-json-forms][html-json-forms]: Provides an algorithm and serializer to process HTML JSON Form submissions per the (inactive) spec.
 
 ### Serializer fields
 
@@ -355,3 +356,4 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [drf-haystack]: http://drf-haystack.readthedocs.org/en/latest/
 [django-rest-framework-version-transforms]: https://github.com/mrhwick/django-rest-framework-version-transforms
 [djangorestframework-jsonapi]: https://github.com/django-json-api/django-rest-framework-json-api
+[html-json-forms]: https://github.com/wq/html-json-forms


### PR DESCRIPTION
Follow up to #2148 and #2682.  Per the discussion, HTML JSON Forms support will remain a third party package for now.