### PR TITLE
remove trailing slash from cramer cursor link

### DIFF
--- a/docs/topics/3.1-announcement.md
+++ b/docs/topics/3.1-announcement.md
@@ -30,7 +30,7 @@ Note that as a result of this work a number of settings keys and generic view at
 
 Until now, there has only been a single built-in pagination style in REST framework. We now have page, limit/offset and cursor based schemes included by default.
 
-The cursor based pagination scheme is particularly smart, and is a better approach for clients iterating through large or frequently changing result sets. The scheme supports paging against non-unique indexes, by using both cursor and limit/offset information. It also allows for both forward and reverse cursor pagination. Much credit goes to David Cramer for [this blog post](http://cramer.io/2011/03/08/building-cursors-for-the-disqus-api/) on the subject.
+The cursor based pagination scheme is particularly smart, and is a better approach for clients iterating through large or frequently changing result sets. The scheme supports paging against non-unique indexes, by using both cursor and limit/offset information. It also allows for both forward and reverse cursor pagination. Much credit goes to David Cramer for [this blog post](http://cramer.io/2011/03/08/building-cursors-for-the-disqus-api) on the subject.
 
 #### Pagination controls in the browsable API.
 

--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -400,7 +400,7 @@ class CursorPagination(BasePagination):
     """
     The cursor pagination implementation is neccessarily complex.
     For an overview of the position/offset style we use, see this post:
-    http://cramer.io/2011/03/08/building-cursors-for-the-disqus-api/
+    http://cramer.io/2011/03/08/building-cursors-for-the-disqus-api
     """
     cursor_query_param = 'cursor'
     page_size = api_settings.PAGE_SIZE


### PR DESCRIPTION
## Description

http://cramer.io/2011/03/08/building-cursors-for-the-disqus-api/ 404s but 
http://cramer.io/2011/03/08/building-cursors-for-the-disqus-api works.
