### PR TITLE
serializers.ManyRelatedField added to SimpleMetadata.label_lookup

### DIFF
--- a/rest_framework/metadata.py
+++ b/rest_framework/metadata.py
@@ -52,6 +52,7 @@ class SimpleMetadata(BaseMetadata):
         serializers.TimeField: 'time',
         serializers.ChoiceField: 'choice',
         serializers.MultipleChoiceField: 'multiple choice',
+        serializers.ManyRelatedField: 'multiple choice',
         serializers.FileField: 'file upload',
         serializers.ImageField: 'image upload',
         serializers.ListField: 'list',

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -319,7 +319,7 @@ class TestModelSerializerMetadata(TestCase):
                         'label': 'ID'
                     },
                     'children': {
-                        'type': 'field',
+                        'type': 'multiple choice',
                         'required': False,
                         'read_only': True,
                         'label': 'Children'


### PR DESCRIPTION
## Description

I simply added serializers.ManyRelatedField to metadata field mapping. And I updated metadata test_read_only_primary_key_related_field test with "multiple choice", because the model field was `children = models.ManyToManyField('Child')' and serializer field was `children = serializers.PrimaryKeyRelatedField(read_only=True, many=True)` and it must be represented as multiple selectbox field on frontend, (so field type should be "multiple choice", and i guess you missed this because you are rendering data on backend in BrowsableApiRenderer and you didn't notice what we need on frontend)
