### PR TITLE
Fix the string_types / text_types confusion introduced in #4025

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -7,7 +7,7 @@ import base64
 
 from django.contrib.auth import authenticate, get_user_model
 from django.middleware.csrf import CsrfViewMiddleware
-from django.utils.six import string_types
+from django.utils.six import text_types
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import HTTP_HEADER_ENCODING, exceptions
@@ -20,7 +20,7 @@ def get_authorization_header(request):
     Hide some test client ickyness where the header can be unicode.
     """
     auth = request.META.get('HTTP_AUTHORIZATION', b'')
-    if isinstance(auth, string_types):
+    if isinstance(auth, text_types):
         # Work around django test client oddness
         auth = auth.encode(HTTP_HEADER_ENCODING)
     return auth


### PR DESCRIPTION
## Description

#4025 introduced a `string_types` comparison before encoding headers data. However, `string_types` are both binary and unicode in Python 2 and we don't want to encode binary data.
This change fixes that error by using `text_types` instead.