### PR TITLE
No auth view failing permission should raise 403

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -162,7 +162,7 @@ class APIView(View):
         """
         If request is not permitted, determine what kind of exception to raise.
         """
-        if not request.successful_authenticator:
+        if request.authenticators and not request.successful_authenticator:
             raise exceptions.NotAuthenticated()
         raise exceptions.PermissionDenied(detail=message)
 


### PR DESCRIPTION
## Description
A view with no `authentication_classes` set and that fails a
permission check should raise a 403 with the message from the
failing permission.

Fixes #4039