### PR TITLE
Extract exception handler usage to separate method.

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -425,16 +425,17 @@ class APIView(View):
             else:
                 exc.status_code = status.HTTP_403_FORBIDDEN
 
-        exception_handler = self.settings.EXCEPTION_HANDLER
-
         context = self.get_exception_handler_context()
-        response = exception_handler(exc, context)
+        response = self._get_error_response(exc, context)
 
         if response is None:
             raise
 
         response.exception = True
         return response
+
+    def _get_error_response(self, exc, context):
+        return self.settings.EXCEPTION_HANDLER(exc, context)
 
     # Note: Views are made CSRF exempt from within `as_view` as to prevent
     # accidental removal of this exemption in cases where `dispatch` needs to


### PR DESCRIPTION
This makes using custom exception handler on view class level much easier, and thus having differently configured APIs in one project without the need of copy-pasting the whole *handle_exception* method.

Solves multi-configuration problem for django-rest-framework-json-api that has a custom exception handler as it must return jsonapi compatible error responses, like for example (response.data from test): 

```
[{'status': '400', 'detail': 'This field is required.', 'source': {'pointer': '/data/attributes/name'}}]
```
instead of:
````
{'name': ['This field is required.']}
````

I have standard DRF APIs as well as DRF-json-api APIs in one project so I had to copy-paste *handle_exception* and change the exception_handler line for the DRF-json-api views. A bad code duplications, and it can easily break with newer DRF versions.