### PR TITLE
Fix warnings when running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /*.egg-info/
 /env/
 MANIFEST
+coverage.*
 
 !.gitignore
 !.travis.yml

--- a/tests/browsable_api/test_browsable_nested_api.py
+++ b/tests/browsable_api/test_browsable_nested_api.py
@@ -14,13 +14,13 @@ class NestedSerializer(serializers.Serializer):
     two = serializers.IntegerField(max_value=10)
 
 
-class TestNestedSerializerSerializer(serializers.Serializer):
+class NestedSerializerTestSerializer(serializers.Serializer):
     nested = NestedSerializer()
 
 
 class NestedSerializersView(ListCreateAPIView):
     renderer_classes = (BrowsableAPIRenderer, )
-    serializer_class = TestNestedSerializerSerializer
+    serializer_class = NestedSerializerTestSerializer
     queryset = [{'nested': {'one': 1, 'two': 2}}]
 
 

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -784,7 +784,7 @@ class TestBulkCreate(TestCase):
         assert serializer.data == data
 
 
-class TestMetaClassModel(models.Model):
+class MetaClassTestModel(models.Model):
     text = models.CharField(max_length=100)
 
 
@@ -792,7 +792,7 @@ class TestSerializerMetaClass(TestCase):
     def test_meta_class_fields_option(self):
         class ExampleSerializer(serializers.ModelSerializer):
             class Meta:
-                model = TestMetaClassModel
+                model = MetaClassTestModel
                 fields = 'text'
 
         with self.assertRaises(TypeError) as result:
@@ -806,7 +806,7 @@ class TestSerializerMetaClass(TestCase):
     def test_meta_class_exclude_option(self):
         class ExampleSerializer(serializers.ModelSerializer):
             class Meta:
-                model = TestMetaClassModel
+                model = MetaClassTestModel
                 exclude = 'text'
 
         with self.assertRaises(TypeError) as result:
@@ -820,7 +820,7 @@ class TestSerializerMetaClass(TestCase):
     def test_meta_class_fields_and_exclude_options(self):
         class ExampleSerializer(serializers.ModelSerializer):
             class Meta:
-                model = TestMetaClassModel
+                model = MetaClassTestModel
                 fields = ('text',)
                 exclude = ('text',)
 


### PR DESCRIPTION
Classes whose name begins with `Test` but are not test classes were collected by py.test, and giving the following errors at the end of the test run:

```
WC1 test_model_serializer.py cannot collect test class 'TestMetaClassModel' because it has a __init__ constructor
WC1 browsable_api/test_browsable_nested_api.py cannot collect test class 'TestNestedSerializerSerializer' because it has a __init__ constructor
779 passed, **2 pytest-warnings** in 3.57 seconds
```

I changed the name so that the meaning is the same but they are not picked up as tests.

Also running the tests produced a coverage.xml file which was not in .gitignore and I added as `coverage.*` since py.test also supports other report formats like *.html etc.