### PR TITLE
Added support for custom CSRF cookie names

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -12,6 +12,7 @@ import json
 from collections import OrderedDict
 
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.paginator import Page
 from django.http.multipartparser import parse_header
@@ -657,7 +658,8 @@ class BrowsableAPIRenderer(BaseRenderer):
 
             'display_edit_forms': bool(response.status_code != 403),
 
-            'api_settings': api_settings
+            'api_settings': api_settings,
+            'csrf_cookie_name': settings.CSRF_COOKIE_NAME,
         }
         return context
 

--- a/rest_framework/static/rest_framework/js/csrf.js
+++ b/rest_framework/static/rest_framework/js/csrf.js
@@ -33,7 +33,7 @@ function sameOrigin(url) {
         !(/^(\/\/|http:|https:).*/.test(url));
 }
 
-var csrftoken = getCookie('csrftoken');
+var csrftoken = getCookie(window.drf.csrfCookieName);
 
 $.ajaxSetup({
     beforeSend: function(xhr, settings) {

--- a/rest_framework/templates/rest_framework/admin.html
+++ b/rest_framework/templates/rest_framework/admin.html
@@ -230,6 +230,11 @@
 {% if filter_form %}{{ filter_form }}{% endif %}
 
         {% block script %}
+            <script>
+              window.drf = {
+                csrfCookieName: "{{ csrf_cookie_name|default:'csrftoken' }}"
+              };
+            </script>
             <script src="{% static "rest_framework/js/jquery-1.11.3.min.js" %}"></script>
             <script src="{% static "rest_framework/js/ajax-form.js" %}"></script>
             <script src="{% static "rest_framework/js/csrf.js" %}"></script>

--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -258,6 +258,11 @@
   </div><!-- ./wrapper -->
 
   {% block script %}
+    <script>
+      window.drf = {
+        csrfCookieName: "{{ csrf_cookie_name|default:'csrftoken' }}"
+      };
+    </script>
     <script src="{% static "rest_framework/js/jquery-1.11.3.min.js" %}"></script>
     <script src="{% static "rest_framework/js/ajax-form.js" %}"></script>
     <script src="{% static "rest_framework/js/csrf.js" %}"></script>


### PR DESCRIPTION
Instead of hardcoding the CSRF cookie name, the value is passed to the template as a context variable, rendered as a JavaScript variable, and read by csrf.js.

refs #4048