### PR TITLE
fix deprecated warning of inspect

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -30,7 +30,9 @@ from django.utils.ipv6 import clean_ipv6_address
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import ISO_8601
-from rest_framework.compat import unicode_repr, unicode_to_repr
+from rest_framework.compat import (
+    is_simple_callable, unicode_repr, unicode_to_repr
+)
 from rest_framework.exceptions import ValidationError
 from rest_framework.settings import api_settings
 from rest_framework.utils import html, humanize_datetime, representation
@@ -44,22 +46,6 @@ class empty:
     It is required because `None` may be a valid input or output value.
     """
     pass
-
-
-def is_simple_callable(obj):
-    """
-    True if the object is a callable that takes no arguments.
-    """
-    function = inspect.isfunction(obj)
-    method = inspect.ismethod(obj)
-
-    if not (function or method):
-        return False
-
-    args, _, _, defaults = inspect.getargspec(obj)
-    len_args = len(args) if function else len(args) - 1
-    len_defaults = len(defaults) if defaults else 0
-    return len_args <= len_defaults
 
 
 def get_attribute(instance, attrs):

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -14,9 +14,8 @@ from django.utils.encoding import smart_text
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.translation import ugettext_lazy as _
 
-from rest_framework.fields import (
-    Field, empty, get_attribute, is_simple_callable, iter_options
-)
+from rest_framework.compat import is_simple_callable
+from rest_framework.fields import Field, empty, get_attribute, iter_options
 from rest_framework.reverse import reverse
 from rest_framework.utils import html
 


### PR DESCRIPTION
* `inspect.signature` is introduced in Python 3.3
* `inspect.getfullargspec` is introduced in Python 3.0 and deprecated since Python 3.5
* `inspect.getargspec` is deprecated since Python 3.0
