### PR TITLE
Remove redundant parentheses in return statement

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -300,7 +300,7 @@ The following example will authenticate any incoming request as the user given b
             except User.DoesNotExist:
                 raise exceptions.AuthenticationFailed('No such user')
 
-            return (user, None)
+            return user, None
 
 ---
 


### PR DESCRIPTION
Remove redundant parentheses in the return statement.

