### PR TITLE
Fixed DecimalField arbitrary precision support

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -992,6 +992,9 @@ class DecimalField(Field):
         """
         Quantize the decimal value to the configured precision.
         """
+        if self.decimal_places is None:
+            return value
+
         context = decimal.getcontext().copy()
         context.prec = self.max_digits
         return value.quantize(

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -894,6 +894,21 @@ class TestNoStringCoercionDecimalField(FieldValues):
     )
 
 
+class TestNoDecimalPlaces(FieldValues):
+    valid_inputs = {
+        '0.12345': Decimal('0.12345'),
+    }
+    invalid_inputs = {
+        '0.1234567': ['Ensure that there are no more than 6 digits in total.']
+    }
+    outputs = {
+        '1.2345': '1.2345',
+        '0': '0',
+        '1.1': '1.1',
+    }
+    field = serializers.DecimalField(max_digits=6, decimal_places=None)
+
+
 # Date & time serializers...
 
 class TestDateField(FieldValues):


### PR DESCRIPTION
`DecimalField` has some support for non strict number of decimal places (checking here and there that `decimal_places` is not None but it fails in `quantize()` with "unsupported operand type(s) for ** or pow(): 'Decimal' and 'NoneType'".

This changeset fixes the problem and allows `DecimalField` to handle `decimal_places=None`. Tests added too.