### PR TITLE
Handle incorrectly padded HTTP basic auth header

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -4,6 +4,7 @@ Provides various authentication policies.
 from __future__ import unicode_literals
 
 import base64
+import binascii
 
 from django.contrib.auth import authenticate, get_user_model
 from django.middleware.csrf import CsrfViewMiddleware
@@ -77,7 +78,7 @@ class BasicAuthentication(BaseAuthentication):
 
         try:
             auth_parts = base64.b64decode(auth[1]).decode(HTTP_HEADER_ENCODING).partition(':')
-        except (TypeError, UnicodeDecodeError):
+        except (TypeError, UnicodeDecodeError, binascii.Error):
             msg = _('Invalid basic header. Credentials not correctly base64 encoded.')
             raise exceptions.AuthenticationFailed(msg)
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -85,6 +85,14 @@ class BasicAuthTests(TestCase):
         response = self.csrf_client.post('/basic/', {'example': 'example'}, format='json', HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_regression_handle_bad_base64_basic_auth_header(self):
+        """Ensure POSTing JSON over basic auth with incorrectly padded Base64 string is handled correctly"""
+        # regression test for issue in 'rest_framework.authentication.BasicAuthentication.authenticate'
+        # https://github.com/tomchristie/django-rest-framework/issues/4089
+        auth = 'Basic =a='
+        response = self.csrf_client.post('/basic/', {'example': 'example'}, format='json', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
     def test_post_form_failing_basic_auth(self):
         """Ensure POSTing form over basic auth without correct credentials fails"""
         response = self.csrf_client.post('/basic/', {'example': 'example'})


### PR DESCRIPTION
Fixes #4089

Includes regression test.