### PR TITLE
added python 3.5 checks for django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - TOX_ENV=py35-django19
     - TOX_ENV=py34-django19
     - TOX_ENV=py27-django19
+    - TOX_ENV=py35-django18
     - TOX_ENV=py34-django18
     - TOX_ENV=py33-django18
     - TOX_ENV=py32-django18

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
        PYTHONWARNINGS=once
 deps =
-        django18: Django==1.8.12
-        django19: Django==1.9.5
+        django18: Django==1.8.13
+        django19: Django==1.9.6
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ addopts=--tb=short
 [tox]
 envlist =
        py27-{lint,docs},
-       {py27,py32,py33,py34}-django18,
+       {py27,py32,py33,py34,py35}-django18,
        {py27,py34,py35}-django{19}
 
 [testenv]


### PR DESCRIPTION
should the python 3.2 checks dropped?
