### PR TITLE
Fields: Fix representation of IntegerField, FloatField with None argument

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -845,7 +845,7 @@ class IntegerField(Field):
         return data
 
     def to_representation(self, value):
-        return int(value)
+        return int(value) if value is not None else None
 
 
 class FloatField(Field):

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -878,7 +878,7 @@ class FloatField(Field):
             self.fail('invalid')
 
     def to_representation(self, value):
-        return float(value)
+        return float(value) if value is not None else None
 
 
 class DecimalField(Field):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -748,6 +748,15 @@ class TestIntegerField(FieldValues):
     }
     field = serializers.IntegerField()
 
+    def test_allow_null(self):
+        """
+        If `allow_null=True` then `None` is a valid input.
+        """
+        field = serializers.IntegerField(allow_null=True)
+        output = field.run_validation(None)
+        assert output is None
+        assert field.to_representation(None) is None
+
 
 class TestMinMaxIntegerField(FieldValues):
     """
@@ -793,6 +802,15 @@ class TestFloatField(FieldValues):
         0.0: 0.0,
     }
     field = serializers.FloatField()
+
+    def test_allow_null(self):
+        """
+        If `allow_null=True` then `None` is a valid input.
+        """
+        field = serializers.FloatField(allow_null=True)
+        output = field.run_validation(None)
+        assert output is None
+        assert field.to_representation(None) is None
 
 
 class TestMinMaxFloatField(FieldValues):


### PR DESCRIPTION
While IntegerField allow_null=True in DB may be NULL value and it crash field with TypeError, while in `to_representation` method calculating int(None).