### PR TITLE
Improve HTML form rendering

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -319,9 +319,6 @@ class HTMLFormRenderer(BaseRenderer):
             style['template_pack'] = parent_style.get('template_pack', self.template_pack)
         style['renderer'] = self
 
-        # Get a clone of the field with text-only value representation.
-        field = field.as_form_field()
-
         if style.get('input_type') == 'datetime-local' and isinstance(field.value, six.text_type):
             field.value = field.value.rstrip('Z')
 

--- a/rest_framework/templates/rest_framework/horizontal/input.html
+++ b/rest_framework/templates/rest_framework/horizontal/input.html
@@ -6,7 +6,7 @@
   {% endif %}
 
   <div class="col-sm-10">
-    <input name="{{ field.name }}" {% if style.input_type != "file" %}class="form-control"{% endif %} type="{{ style.input_type }}" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.value %}value="{{ field.value }}"{% endif %}>
+    <input name="{{ field.name }}" {% if style.input_type != "file" %}class="form-control"{% endif %} type="{{ style.input_type }}" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.string_value %}value="{{ field.string_value }}"{% endif %}>
 
     {% if field.errors %}
       {% for error in field.errors %}

--- a/rest_framework/templates/rest_framework/horizontal/select.html
+++ b/rest_framework/templates/rest_framework/horizontal/select.html
@@ -8,7 +8,7 @@
   <div class="col-sm-10">
     <select class="form-control" name="{{ field.name }}">
       {% if field.allow_null or field.allow_blank %}
-        <option value="" {% if not field.value %}selected{% endif %}>--------</option>
+        <option value="" {% if not field.string_value %}selected{% endif %}>--------</option>
       {% endif %}
       {% for select in field.iter_options %}
           {% if select.start_option_group %}

--- a/rest_framework/templates/rest_framework/horizontal/textarea.html
+++ b/rest_framework/templates/rest_framework/horizontal/textarea.html
@@ -6,7 +6,7 @@
   {% endif %}
 
   <div class="col-sm-10">
-    <textarea name="{{ field.name }}" class="form-control" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if style.rows %}rows="{{ style.rows }}"{% endif %}>{% if field.value %}{{ field.value }}{% endif %}</textarea>
+    <textarea name="{{ field.name }}" class="form-control" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if style.rows %}rows="{{ style.rows }}"{% endif %}>{% if field.string_value %}{{ field.string_value }}{% endif %}</textarea>
 
     {% if field.errors %}
       {% for error in field.errors %}

--- a/rest_framework/templates/rest_framework/inline/input.html
+++ b/rest_framework/templates/rest_framework/inline/input.html
@@ -5,5 +5,5 @@
     </label>
   {% endif %}
 
-  <input name="{{ field.name }}" {% if style.input_type != "file" %}class="form-control"{% endif %} type="{{ style.input_type }}" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.value %}value="{{ field.value }}"{% endif %}>
+  <input name="{{ field.name }}" {% if style.input_type != "file" %}class="form-control"{% endif %} type="{{ style.input_type }}" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.string_value %}value="{{ field.string_value }}"{% endif %}>
 </div>

--- a/rest_framework/templates/rest_framework/inline/select.html
+++ b/rest_framework/templates/rest_framework/inline/select.html
@@ -7,7 +7,7 @@
 
   <select class="form-control" name="{{ field.name }}">
     {% if field.allow_null or field.allow_blank %}
-      <option value="" {% if not field.value %}selected{% endif %}>--------</option>
+      <option value="" {% if not field.string_value %}selected{% endif %}>--------</option>
     {% endif %}
     {% for select in field.iter_options %}
         {% if select.start_option_group %}

--- a/rest_framework/templates/rest_framework/inline/textarea.html
+++ b/rest_framework/templates/rest_framework/inline/textarea.html
@@ -5,5 +5,5 @@
     </label>
   {% endif %}
 
-  <input name="{{ field.name }}" type="text" class="form-control" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.value %}value="{{ field.value }}"{% endif %}>
+  <input name="{{ field.name }}" type="text" class="form-control" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.string_value %}value="{{ field.string_value }}"{% endif %}>
 </div>

--- a/rest_framework/templates/rest_framework/vertical/input.html
+++ b/rest_framework/templates/rest_framework/vertical/input.html
@@ -3,7 +3,7 @@
     <label {% if style.hide_label %}class="sr-only"{% endif %}>{{ field.label }}</label>
   {% endif %}
 
-  <input name="{{ field.name }}" {% if style.input_type != "file" %}class="form-control"{% endif %} type="{{ style.input_type }}" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.value %}value="{{ field.value }}"{% endif %}>
+  <input name="{{ field.name }}" {% if style.input_type != "file" %}class="form-control"{% endif %} type="{{ style.input_type }}" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if field.string_value %}value="{{ field.string_value }}"{% endif %}>
 
   {% if field.errors %}
     {% for error in field.errors %}

--- a/rest_framework/templates/rest_framework/vertical/select.html
+++ b/rest_framework/templates/rest_framework/vertical/select.html
@@ -7,7 +7,7 @@
 
   <select class="form-control" name="{{ field.name }}">
     {% if field.allow_null or field.allow_blank %}
-      <option value="" {% if not field.value %}selected{% endif %}>--------</option>
+      <option value="" {% if not field.string_value %}selected{% endif %}>--------</option>
     {% endif %}
     {% for select in field.iter_options %}
         {% if select.start_option_group %}

--- a/rest_framework/templates/rest_framework/vertical/textarea.html
+++ b/rest_framework/templates/rest_framework/vertical/textarea.html
@@ -5,7 +5,7 @@
     </label>
   {% endif %}
 
-  <textarea name="{{ field.name }}" class="form-control" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if style.rows %}rows="{{ style.rows }}"{% endif %}>{% if field.value %}{{ field.value }}{% endif %}</textarea>
+  <textarea name="{{ field.name }}" class="form-control" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if style.rows %}rows="{{ style.rows }}"{% endif %}>{% if field.string_value %}{{ field.string_value }}{% endif %}</textarea>
 
   {% if field.errors %}
     {% for error in field.errors %}<span class="help-block">{{ error }}</span>{% endfor %}

--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -72,14 +72,16 @@ class BoundField(object):
     def _proxy_class(self):
         return self._field.__class__
 
+    @property
+    def string_value(self):
+        if self.value is None or self.value is False:
+            return ''
+        return force_text(self.value)
+
     def __repr__(self):
         return unicode_to_repr('<%s value=%s errors=%s>' % (
             self.__class__.__name__, self.value, self.errors
         ))
-
-    def as_form_field(self):
-        value = '' if (self.value is None or self.value is False) else force_text(self.value)
-        return self.__class__(self._field, value, self.errors, self._prefix)
 
 
 class NestedBoundField(BoundField):
@@ -105,15 +107,6 @@ class NestedBoundField(BoundField):
         if hasattr(field, 'fields'):
             return NestedBoundField(field, value, error, prefix=self.name + '.')
         return BoundField(field, value, error, prefix=self.name + '.')
-
-    def as_form_field(self):
-        values = {}
-        for key, value in self.value.items():
-            if isinstance(value, (list, dict)):
-                values[key] = value
-            else:
-                values[key] = '' if (value is None or value is False) else force_text(value)
-        return self.__class__(self._field, values, self.errors, self._prefix)
 
 
 class BindingDict(collections.MutableMapping):

--- a/tests/test_bound_fields.py
+++ b/tests/test_bound_fields.py
@@ -45,15 +45,15 @@ class TestSimpleBoundField:
         assert serializer['amount'].errors is None
         assert serializer['amount'].name == 'amount'
 
-    def test_as_form_fields(self):
+    def test_string_value(self):
         class ExampleSerializer(serializers.Serializer):
             bool_field = serializers.BooleanField()
             null_field = serializers.IntegerField(allow_null=True)
 
         serializer = ExampleSerializer(data={'bool_field': False, 'null_field': None})
         assert serializer.is_valid()
-        assert serializer['bool_field'].as_form_field().value == ''
-        assert serializer['null_field'].as_form_field().value == ''
+        assert serializer['bool_field'].string_value == ''
+        assert serializer['null_field'].string_value == ''
 
 
 class TestNestedBoundField:
@@ -78,7 +78,7 @@ class TestNestedBoundField:
         assert serializer['nested']['amount'].errors is None
         assert serializer['nested']['amount'].name == 'nested.amount'
 
-    def test_as_form_fields(self):
+    def test_string_value(self):
         class Nested(serializers.Serializer):
             bool_field = serializers.BooleanField()
             null_field = serializers.IntegerField(allow_null=True)
@@ -88,8 +88,8 @@ class TestNestedBoundField:
 
         serializer = ExampleSerializer(data={'nested': {'bool_field': False, 'null_field': None}})
         assert serializer.is_valid()
-        assert serializer['nested']['bool_field'].as_form_field().value == ''
-        assert serializer['nested']['null_field'].as_form_field().value == ''
+        assert serializer['nested']['bool_field'].string_value == ''
+        assert serializer['nested']['null_field'].string_value == ''
 
     def test_rendering_nested_fields_with_none_value(self):
         from rest_framework.renderers import HTMLFormRenderer

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -485,3 +485,90 @@ class TestHTMLFormRenderer(TestCase):
         result = renderer.render(self.serializer.data, None, {})
 
         self.assertIsInstance(result, SafeText)
+
+
+class TestChoiceFieldHTMLFormRenderer(TestCase):
+    """
+    Test rendering ChoiceField with HTMLFormRenderer.
+    """
+
+    def setUp(self):
+        choices = ((1, 'Option1'), (2, 'Option2'), (12, 'Option12'))
+
+        class TestSerializer(serializers.Serializer):
+            test_field = serializers.ChoiceField(choices=choices,
+                                                 initial=2)
+
+        self.TestSerializer = TestSerializer
+        self.renderer = HTMLFormRenderer()
+
+    def test_render_initial_option(self):
+        serializer = self.TestSerializer()
+        result = self.renderer.render(serializer.data)
+
+        self.assertIsInstance(result, SafeText)
+
+        self.assertInHTML('<option value="2" selected>Option2</option>',
+                          result)
+        self.assertInHTML('<option value="1">Option1</option>', result)
+        self.assertInHTML('<option value="12">Option12</option>', result)
+
+    def test_render_selected_option(self):
+        serializer = self.TestSerializer(data={'test_field': '12'})
+
+        serializer.is_valid()
+        result = self.renderer.render(serializer.data)
+
+        self.assertIsInstance(result, SafeText)
+
+        self.assertInHTML('<option value="12" selected>Option12</option>',
+                          result)
+        self.assertInHTML('<option value="1">Option1</option>', result)
+        self.assertInHTML('<option value="2">Option2</option>', result)
+
+
+class TestMultipleChoiceFieldHTMLFormRenderer(TestCase):
+    """
+    Test rendering MultipleChoiceField with HTMLFormRenderer.
+    """
+
+    def setUp(self):
+        self.renderer = HTMLFormRenderer()
+
+    def test_render_selected_option_with_string_option_ids(self):
+        choices = (('1', 'Option1'), ('2', 'Option2'), ('12', 'Option12'),
+                   ('}', 'OptionBrace'))
+
+        class TestSerializer(serializers.Serializer):
+            test_field = serializers.MultipleChoiceField(choices=choices)
+
+        serializer = TestSerializer(data={'test_field': ['12']})
+        serializer.is_valid()
+
+        result = self.renderer.render(serializer.data)
+
+        self.assertIsInstance(result, SafeText)
+
+        self.assertInHTML('<option value="12" selected>Option12</option>',
+                          result)
+        self.assertInHTML('<option value="1">Option1</option>', result)
+        self.assertInHTML('<option value="2">Option2</option>', result)
+        self.assertInHTML('<option value="}">OptionBrace</option>', result)
+
+    def test_render_selected_option_with_integer_option_ids(self):
+        choices = ((1, 'Option1'), (2, 'Option2'), (12, 'Option12'))
+
+        class TestSerializer(serializers.Serializer):
+            test_field = serializers.MultipleChoiceField(choices=choices)
+
+        serializer = TestSerializer(data={'test_field': ['12']})
+        serializer.is_valid()
+
+        result = self.renderer.render(serializer.data)
+
+        self.assertIsInstance(result, SafeText)
+
+        self.assertInHTML('<option value="12" selected>Option12</option>',
+                          result)
+        self.assertInHTML('<option value="1">Option1</option>', result)
+        self.assertInHTML('<option value="2">Option2</option>', result)


### PR DESCRIPTION
## Description

This is an alternative approach to handling bound field values during HTML form rendering. Instead of forcing field values to string representations early through `.as_form_field()` (done in 6b08e97) it makes both native and string representations available to form renderer / templates.

As mentioned in the commit log, it should fix at least #4120 and #4121; effectively it reverts 6b08e97 but should also handle the cases covered in that commit, at least to a degree provable with the test suite.

I also tried adding some tests for issues I could quickly identify as related (e.g. #3139), as otherwise just plain getting rid of `.as_form_field()`, surprisingly, didn't make any test to start failing. But I'm sure there are more that I have missed.