### PR TITLE
Fix typos in ReturnDict and ReturnList docstrings

### DIFF
--- a/rest_framework/utils/serializer_helpers.py
+++ b/rest_framework/utils/serializer_helpers.py
@@ -10,7 +10,7 @@ from rest_framework.compat import unicode_to_repr
 
 class ReturnDict(OrderedDict):
     """
-    Return object from `serialier.data` for the `Serializer` class.
+    Return object from `serializer.data` for the `Serializer` class.
     Includes a backlink to the serializer instance for renderers
     to use if they need richer field information.
     """
@@ -33,7 +33,7 @@ class ReturnDict(OrderedDict):
 
 class ReturnList(list):
     """
-    Return object from `serialier.data` for the `SerializerList` class.
+    Return object from `serializer.data` for the `SerializerList` class.
     Includes a backlink to the serializer instance for renderers
     to use if they need richer field information.
     """


### PR DESCRIPTION
## Description

Fixes typos in the <code>ReturnDict</code> and <code>ReturnList</code> docstrings.
