### PR TITLE
JSONField JSON Object serialization for webform-input

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1541,6 +1541,16 @@ class JSONField(Field):
         self.binary = kwargs.pop('binary', False)
         super(JSONField, self).__init__(*args, **kwargs)
 
+    def get_value(self, dictionary):
+        """
+            If the incoming data is an html-input then it always comes in stringified via. the
+            multipart/form-input so we should call json.loads on it.
+        """
+        ret = super(JSONField, self).get_value(dictionary)
+        if html.is_html_input(dictionary):
+            return json.loads(ret)
+        return ret
+
     def to_internal_value(self, data):
         try:
             if self.binary:

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -30,6 +30,7 @@ from rest_framework.settings import api_settings
 from rest_framework.utils import encoders
 from rest_framework.utils.breadcrumbs import get_breadcrumbs
 from rest_framework.utils.field_mapping import ClassLookupDict
+from rest_framework.fields import JSONField
 
 
 def zero_as_none(value):
@@ -319,8 +320,13 @@ class HTMLFormRenderer(BaseRenderer):
             style['template_pack'] = parent_style.get('template_pack', self.template_pack)
         style['renderer'] = self
 
+        # If we are rendering a JSON Field we want to convert Python literals to Javascript literals
+        if issubclass(field._proxy_class, JSONField):
+            field.value = json.dumps(field.value)
+
         # Get a clone of the field with text-only value representation.
         field = field.as_form_field()
+
 
         if style.get('input_type') == 'datetime-local' and isinstance(field.value, six.text_type):
             field.value = field.value.rstrip('Z')


### PR DESCRIPTION
Discussion in #4135 

I added a failing spec, not sure if `test_serializer.py` is the right place for it - since it failing is tied also to the way multipart/form-data is parsed in the Django request. It may also be worthwhile to consider adding `Content-Type: text/json` in the form submission for JSONField (even if Django won't treat it as such, at least to make clear that rest-framework aren't just trying to turn random form-inputs into JSON objects). 

