### PR TITLE
Create HyperlinkedPrimaryKeyRelatedField combination between HyperlinkedRelatedField and PrimaryKeyRelatedField

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -392,6 +392,15 @@ class HyperlinkedIdentityField(HyperlinkedRelatedField):
         return False
 
 
+class HyperlinkedPrimaryKeyRelatedField(HyperlinkedRelatedField):
+    """
+    A read-write field which act like HyperlinkedRelatedField in output and
+    act like PrimaryKeyRelatedField in input
+    """
+    def to_internal_value(self, data):
+        return self.get_queryset().get(pk=data)
+
+
 class SlugRelatedField(RelatedField):
     """
     A read-write field that represents the target of the relationship


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/tomchristie/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Create `HyperlinkedPrimaryKeyRelatedField` class which is relation field acts like `HyperlinkedRelatedField` in output and act like `PrimaryKeyRelatedField` in input

## Example

```python
class OrderNestedSerializer(serializers.HyperlinkedModelSerializer):
    status = HyperlinkedPrimaryKeyRelatedField(queryset=OrderStatus.objects.all(), 
                                               view_name='orderstatus-detail')

    class Meta:
        model = CustomerOrder
        fields = ('url',  'status', 'discount_percentage', 'notes')
```

### Output:
```javascript
{
...
status: 'http://localhost:8000/order-statuses/1',
...
}
```
### Input:
```javascript
{
...
status: 1,
...
}
```
