### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ If you want to draw attention to a note or warning, use a pair of enclosing line
 [issues]: https://github.com/tomchristie/django-rest-framework/issues?state=open
 [pep-8]: http://www.python.org/dev/peps/pep-0008/
 [pull-requests]: https://help.github.com/articles/using-pull-requests
-[tox]: http://tox.readthedocs.org/en/latest/
+[tox]: https://tox.readthedocs.io/en/latest/
 [markdown]: http://daringfireball.net/projects/markdown/basics
 [docs]: https://github.com/tomchristie/django-rest-framework/tree/master/docs
 [mou]: http://mouapp.com/

--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -361,7 +361,7 @@ HTTP Signature (currently a [IETF draft][http-signature-ietf-draft]) provides a 
 [throttling]: throttling.md
 [csrf-ajax]: https://docs.djangoproject.com/en/dev/ref/csrf/#ajax
 [mod_wsgi_official]: http://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGIPassAuthorization
-[django-oauth-toolkit-getting-started]: https://django-oauth-toolkit.readthedocs.org/en/latest/rest-framework/getting_started.html
+[django-oauth-toolkit-getting-started]: https://django-oauth-toolkit.readthedocs.io/en/latest/rest-framework/getting_started.html
 [django-rest-framework-oauth]: http://jpadilla.github.io/django-rest-framework-oauth/
 [django-rest-framework-oauth-authentication]: http://jpadilla.github.io/django-rest-framework-oauth/authentication/
 [django-rest-framework-oauth-permissions]: http://jpadilla.github.io/django-rest-framework-oauth/permissions/
@@ -370,7 +370,7 @@ HTTP Signature (currently a [IETF draft][http-signature-ietf-draft]) provides a 
 [oauth-1.0a]: http://oauth.net/core/1.0a
 [django-oauth-plus]: http://code.larlet.fr/django-oauth-plus
 [django-oauth2-provider]: https://github.com/caffeinehit/django-oauth2-provider
-[django-oauth2-provider-docs]: https://django-oauth2-provider.readthedocs.org/en/latest/
+[django-oauth2-provider-docs]: https://django-oauth2-provider.readthedocs.io/en/latest/
 [rfc6749]: http://tools.ietf.org/html/rfc6749
 [django-oauth-toolkit]: https://github.com/evonove/django-oauth-toolkit
 [evonove]: https://github.com/evonove/
@@ -384,9 +384,9 @@ HTTP Signature (currently a [IETF draft][http-signature-ietf-draft]) provides a 
 [djangorestframework-httpsignature]: https://github.com/etoccalino/django-rest-framework-httpsignature
 [amazon-http-signature]: http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
 [http-signature-ietf-draft]: https://datatracker.ietf.org/doc/draft-cavage-http-signatures/
-[hawkrest]: http://hawkrest.readthedocs.org/en/latest/
+[hawkrest]: https://hawkrest.readthedocs.io/en/latest/
 [hawk]: https://github.com/hueniverse/hawk
-[mohawk]: http://mohawk.readthedocs.org/en/latest/
+[mohawk]: https://mohawk.readthedocs.io/en/latest/
 [mac]: http://tools.ietf.org/html/draft-hammer-oauth-v2-mac-token-05
 [djoser]: https://github.com/sunscrapers/djoser
 [django-rest-auth]: https://github.com/Tivix/django-rest-auth

--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -670,7 +670,7 @@ The [django-rest-framework-hstore][django-rest-framework-hstore] package provide
 [strftime]: http://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
 [django-widgets]: https://docs.djangoproject.com/en/dev/ref/forms/widgets/
 [iso8601]: http://www.w3.org/TR/NOTE-datetime
-[drf-compound-fields]: http://drf-compound-fields.readthedocs.org
+[drf-compound-fields]: https://drf-compound-fields.readthedocs.io
 [drf-extra-fields]: https://github.com/Hipo/drf-extra-fields
 [djangorestframework-recursive]: https://github.com/heywbj/django-rest-framework-recursive
 [django-rest-framework-gis]: https://github.com/djangonauts/django-rest-framework-gis

--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -435,9 +435,9 @@ The [djangorestframework-word-filter][django-rest-framework-word-search-filter] 
 
 [cite]: https://docs.djangoproject.com/en/dev/topics/db/queries/#retrieving-specific-objects-with-filters
 [django-filter]: https://github.com/alex/django-filter
-[django-filter-docs]: https://django-filter.readthedocs.org/en/latest/index.html
-[guardian]: https://django-guardian.readthedocs.org/
-[view-permissions]: https://django-guardian.readthedocs.org/en/latest/userguide/assign.html
+[django-filter-docs]: https://django-filter.readthedocs.io/en/latest/index.html
+[guardian]: https://django-guardian.readthedocs.io/
+[view-permissions]: https://django-guardian.readthedocs.io/en/latest/userguide/assign.html
 [view-permissions-blogpost]: http://blog.nyaruka.com/adding-a-view-permission-to-django-models
 [nullbooleanselect]: https://github.com/django/django/blob/master/django/forms/widgets.py
 [search-django-admin]: https://docs.djangoproject.com/en/dev/ref/contrib/admin/#django.contrib.admin.ModelAdmin.search_fields

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -1096,7 +1096,7 @@ The [html-json-forms][html-json-forms] package provides an algorithm and seriali
 [model-managers]: https://docs.djangoproject.com/en/dev/topics/db/managers/
 [encapsulation-blogpost]: http://www.dabapps.com/blog/django-models-and-encapsulation/
 [django-rest-marshmallow]: http://tomchristie.github.io/django-rest-marshmallow/
-[marshmallow]: https://marshmallow.readthedocs.org/en/latest/
+[marshmallow]: https://marshmallow.readthedocs.io/en/latest/
 [serpy]: https://github.com/clarkduvall/serpy
 [mongoengine]: https://github.com/umutbozkurt/django-rest-framework-mongoengine
 [django-rest-framework-gis]: https://github.com/djangonauts/django-rest-framework-gis

--- a/docs/topics/2.4-announcement.md
+++ b/docs/topics/2.4-announcement.md
@@ -39,7 +39,7 @@ Then run the `runtests.py` script.
 
     ./runtests.py
 
-The new test runner also includes [flake8](https://flake8.readthedocs.org) code linting, which should help keep our coding style consistent.
+The new test runner also includes [flake8](https://flake8.readthedocs.io) code linting, which should help keep our coding style consistent.
 
 #### Test runner flags
 

--- a/docs/topics/browsable-api.md
+++ b/docs/topics/browsable-api.md
@@ -163,4 +163,4 @@ Better support for autocomplete inputs is planned in future versions.
 [bcomponentsnav]: http://getbootstrap.com/2.3.2/components.html#navbar
 [autocomplete-packages]: https://www.djangopackages.com/grids/g/auto-complete/
 [django-autocomplete-light]: https://github.com/yourlabs/django-autocomplete-light
-[django-autocomplete-light-install]: http://django-autocomplete-light.readthedocs.org/en/latest/#install
+[django-autocomplete-light-install]: https://django-autocomplete-light.readthedocs.io/en/master/install.html

--- a/docs/topics/contributing.md
+++ b/docs/topics/contributing.md
@@ -205,7 +205,7 @@ If you want to draw attention to a note or warning, use a pair of enclosing line
 [pep-8]: http://www.python.org/dev/peps/pep-0008/
 [travis-status]: ../img/travis-status.png
 [pull-requests]: https://help.github.com/articles/using-pull-requests
-[tox]: http://tox.readthedocs.org/en/latest/
+[tox]: https://tox.readthedocs.io/en/latest/
 [markdown]: http://daringfireball.net/projects/markdown/basics
 [docs]: https://github.com/tomchristie/django-rest-framework/tree/master/docs
 [mou]: http://mouapp.com/

--- a/docs/topics/third-party-resources.md
+++ b/docs/topics/third-party-resources.md
@@ -250,7 +250,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 * [ember-django-adapter][ember-django-adapter] - An adapter for working with Ember.js
 * [django-versatileimagefield][django-versatileimagefield] - Provides a drop-in replacement for Django's stock `ImageField` that makes it easy to serve images in multiple sizes/renditions from a single field. For DRF-specific implementation docs, [click here][django-versatileimagefield-drf-docs].
 * [drf-tracking][drf-tracking] - Utilities to track requests to DRF API views.
-* [django-rest-framework-braces][django-rest-framework-braces] - Collection of utilities for working with Django Rest Framework. The most notable ones are [FormSerializer](https://django-rest-framework-braces.readthedocs.org/en/latest/overview.html#formserializer) and [SerializerForm](https://django-rest-framework-braces.readthedocs.org/en/latest/overview.html#serializerform), which are adapters between DRF serializers and Django forms.
+* [django-rest-framework-braces][django-rest-framework-braces] - Collection of utilities for working with Django Rest Framework. The most notable ones are [FormSerializer](https://django-rest-framework-braces.readthedocs.io/en/latest/overview.html#formserializer) and [SerializerForm](https://django-rest-framework-braces.readthedocs.io/en/latest/overview.html#serializerform), which are adapters between DRF serializers and Django forms.
 * [drf-haystack][drf-haystack] - Haystack search for Django Rest Framework
 * [django-rest-framework-version-transforms][django-rest-framework-version-transforms] - Enables the use of delta transformations for versioning of DRF resource representations.
 * [django-rest-messaging][django-rest-messaging], [django-rest-messaging-centrifugo][django-rest-messaging-centrifugo] and [django-rest-messaging-js][django-rest-messaging-js] - A real-time pluggable messaging service using DRM.
@@ -292,7 +292,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [travis-profile]: https://travis-ci.org/profile
 [pypi-register]: https://pypi.python.org/pypi?%3Aaction=register_form
 [semver]: http://semver.org/
-[tox-docs]: https://tox.readthedocs.org/en/latest/
+[tox-docs]: https://tox.readthedocs.io/en/latest/
 [drf-compat]: https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/compat.py
 [rest-framework-grid]: https://www.djangopackages.com/grids/g/django-rest-framework/
 [drf-create-pr]: https://github.com/tomchristie/django-rest-framework/compare
@@ -348,14 +348,14 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [api-development-with-django-and-django-rest-framework]: https://bnotions.com/api-development-with-django-and-django-rest-framework/
 [django-rest-auth]: https://github.com/Tivix/django-rest-auth/
 [django-versatileimagefield]: https://github.com/WGBH/django-versatileimagefield
-[django-versatileimagefield-drf-docs]:http://django-versatileimagefield.readthedocs.org/en/latest/drf_integration.html
+[django-versatileimagefield-drf-docs]:https://django-versatileimagefield.readthedocs.io/en/latest/drf_integration.html
 [cdrf.co]:http://www.cdrf.co
 [drf-tracking]: https://github.com/aschn/drf-tracking
 [django-rest-framework-braces]: https://github.com/dealertrack/django-rest-framework-braces
 [dry-rest-permissions]: https://github.com/Helioscene/dry-rest-permissions
 [django-url-filter]: https://github.com/miki725/django-url-filter
 [cookiecutter-django-rest]:  https://github.com/agconti/cookiecutter-django-rest
-[drf-haystack]: http://drf-haystack.readthedocs.org/en/latest/
+[drf-haystack]: https://drf-haystack.readthedocs.io/en/latest/
 [django-rest-framework-version-transforms]: https://github.com/mrhwick/django-rest-framework-version-transforms
 [djangorestframework-jsonapi]: https://github.com/django-json-api/django-rest-framework-json-api
 [html-json-forms]: https://github.com/wq/html-json-forms


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified. I also fixed some which weren't quite pointing at the wrong thing.