### PR TITLE
Updated Guardians and Filter Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ env:
     - TOX_ENV=py34-django110
 
 matrix:
-    allow_failures:
-        - env: TOX_ENV=py27-django110
-        - env: TOX_ENV=py34-django110
-        - env: TOX_ENV=py35-django110
     fast_finish: true
 
 install:

--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,4 +1,4 @@
 # Optional packages which may be used with REST framework.
-markdown==2.6.6
-django-guardian==1.4.4
-django-filter==0.10.0
+markdown==2.6.4
+django-guardian==1.4.3
+django-filter==0.13.0


### PR DESCRIPTION
Replaces #4028. Just pulls in @avuipy's work from there. 

Django Filter is already 1.10 compatible. It just needed updating. 

Opening PR to see what Travis says.... — And it's good. 

Removing Django 1.10 from allowed_failures. 

@tomchristie fixed the underling issue (identified in #4028) in 994e1ba927cb93b674330c885375b0409ea725cf. 

He removed the `abstract = True` from `BaseFilterableItem` in the the test suite. 

This was introduced in 4d45865b. The test there was to check that subclasses of the FilterSet's model class are correctly allowed by `get_filter_class`. There's nothing about this that requires allowing abstract superclasses. 

**If** this is needed, **if** it's an issue, it's an issue with Django-Filter. I'm happy to look at issues there, but it's out of scope for DRF.


