### PR TITLE
Include Django as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     author_email='tom@tomchristie.com',  # SEE NOTE BELOW (*)
     packages=get_packages('rest_framework'),
     package_data=get_package_data('rest_framework'),
-    install_requires=[],
+    install_requires=['django'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This includes Django as an explicit dependency of this library. This will reduce some confusion for users who might install this library but forget to install Django. It will also allow static analysis tools like Sourcegraph (e.g., https://sourcegraph.com/github.com/tomchristie/django-rest-framework@d404597e0b63942ebba6378026081f1ef8dbb72b/-/blob/rest_framework/authtoken/models.py#L4) to link references from Django REST Framework to Django, making the code easier to explore and understand.