### PR TITLE
Extend AuthTokenSerializer to allow login with custom username fields

### DIFF
--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -11,7 +11,7 @@ class AuthTokenSerializer(serializers.Serializer):
 
     def __init__(self, data=empty, **kwargs):
         self.fields[get_user_model().USERNAME_FIELD] = serializers.CharField(label=_(get_user_model().USERNAME_FIELD))
-        super().__init__(self, data, **kwargs)
+        super(self.__class__, self).__init__(self, data, **kwargs)
 
     def validate(self, attrs):
         username = attrs.get('%s' % get_user_model().USERNAME_FIELD)

--- a/rest_framework/authtoken/serializers.py
+++ b/rest_framework/authtoken/serializers.py
@@ -1,9 +1,8 @@
-from django.contrib.auth import authenticate
+from django.contrib.auth import authenticate, get_user_model
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import serializers
 from rest_framework.fields import empty
-from django.contrib.auth import get_user_model
 
 
 class AuthTokenSerializer(serializers.Serializer):


### PR DESCRIPTION
Login with token fails (obtain_auth_token in authtoken/serializers.py) if you're using a custom field as your USERNAME_FIELD, as it calls authenticate() with username and password and it also requires "username" to be present in the post request.
