### PR TITLE
In LimitOffsetPagination `limit=0` should revert to default limit.

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -319,6 +319,7 @@ class LimitOffsetPagination(BasePagination):
             try:
                 return _positive_int(
                     request.query_params[self.limit_query_param],
+                    strict=True,
                     cutoff=self.max_limit
                 )
             except (KeyError, ValueError):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -486,6 +486,19 @@ class TestLimitOffset:
         assert queryset == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         assert content.get('next') == next_url
 
+    def test_zero_limit(self):
+        """
+        An zero limit query param should be ignored in favor of the default.
+        """
+        request = Request(factory.get('/', {'limit': 0, 'offset': 0}))
+        queryset = self.paginate_queryset(request)
+        content = self.get_paginated_content(queryset)
+        next_limit = self.pagination.default_limit
+        next_offset = self.pagination.default_limit
+        next_url = 'http://testserver/?limit={0}&offset={1}'.format(next_limit, next_offset)
+        assert queryset == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        assert content.get('next') == next_url
+
     def test_max_limit(self):
         """
         The limit defaults to the max_limit when there is a max_limit and the
@@ -504,31 +517,6 @@ class TestLimitOffset:
         assert queryset == list(range(51, 66))
         assert content.get('next') == next_url
         assert content.get('previous') == prev_url
-
-    def test_limit_zero(self):
-        """
-        A limit of 0 should return empty results.
-        """
-        request = Request(factory.get('/', {'limit': 0, 'offset': 10}))
-        queryset = self.paginate_queryset(request)
-        context = self.get_html_context()
-        content = self.get_paginated_content(queryset)
-
-        assert context == {
-            'previous_url': 'http://testserver/?limit=0&offset=10',
-            'page_links': [
-                PageLink(
-                    url='http://testserver/?limit=0',
-                    number=1,
-                    is_active=True,
-                    is_break=False
-                )
-            ],
-            'next_url': 'http://testserver/?limit=0&offset=10'
-        }
-
-        assert queryset == []
-        assert content.get('results') == []
 
 
 class TestCursorPagination:


### PR DESCRIPTION
Treat `limit=0 in the same way as an other invalid amount in the `limit` parameter.