### PR TITLE
Pass through strings as-in with date/time fields.

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1073,7 +1073,7 @@ class DateTimeField(Field):
 
         output_format = getattr(self, 'format', api_settings.DATETIME_FORMAT)
 
-        if output_format is None:
+        if output_format is None or isinstance(value, six.string_types):
             return value
 
         if output_format.lower() == ISO_8601:
@@ -1133,7 +1133,7 @@ class DateField(Field):
 
         output_format = getattr(self, 'format', api_settings.DATE_FORMAT)
 
-        if output_format is None:
+        if output_format is None or isinstance(value, six.string_types):
             return value
 
         # Applying a `DateField` to a datetime value is almost always
@@ -1146,8 +1146,6 @@ class DateField(Field):
         )
 
         if output_format.lower() == ISO_8601:
-            if isinstance(value, six.string_types):
-                value = datetime.datetime.strptime(value, '%Y-%m-%d').date()
             return value.isoformat()
 
         return value.strftime(output_format)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -993,6 +993,8 @@ class TestDateTimeField(FieldValues):
     outputs = {
         datetime.datetime(2001, 1, 1, 13, 00): '2001-01-01T13:00:00',
         datetime.datetime(2001, 1, 1, 13, 00, tzinfo=timezone.UTC()): '2001-01-01T13:00:00Z',
+        '2001-01-01T00:00:00': '2001-01-01T00:00:00',
+        six.text_type('2016-01-10T00:00:00'): '2016-01-10T00:00:00',
         None: None,
         '': None,
     }


### PR DESCRIPTION
Closes #4013.
Closes #4019.

Ignore strings and pass through as-is from date/time fields.
Note that the existing implementation in TimeField/DateField was unnecessarily convoluted.
We can't know that the strings are necessarily in the correct format, but since they're already a valid type we'll just pass them through as-is.
