### PR TITLE
Fix #4198

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -532,7 +532,7 @@ This option should be a list or tuple of field names, and is declared as follows
             fields = ('id', 'account_name', 'users', 'created')
             read_only_fields = ('account_name',)
 
-Model fields which have `editable=False` set, and `AutoField` fields will be set to read-only by default, and do not need to be added to the `read_only_fields` option.
+Model fields which have `editable=False` set, and `AutoField` fields will be set to read-only by default, and do not need to be added to the `read_only_fields` option. Having a field listed in `read_only_fields` and declared on the class will raise an exception.
 
 ---
 
@@ -569,6 +569,8 @@ This option is a dictionary, mapping field names to a dictionary of keyword argu
             user.set_password(validated_data['password'])
             user.save()
             return user
+
+Having arguments for a field in `extra_kwargs` for a field declared on the class will raise an exception.
 
 ## Relational fields
 

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -947,6 +947,11 @@ class ModelSerializer(Serializer):
         # Determine any extra field arguments and hidden fields that
         # should be included
         extra_kwargs = self.get_extra_kwargs()
+        for field in extra_kwargs:
+            assert field not in declared_fields, (
+                "Field {} is declared on the class and also present in "
+                "extra_kwargs or read_only_fields".format(field)
+            )
         extra_kwargs, hidden_fields = self.get_uniqueness_extra_kwargs(
             field_names, declared_fields, extra_kwargs
         )
@@ -1321,12 +1326,11 @@ class ModelSerializer(Serializer):
                 # add in a hidden field that populates it.
                 hidden_fields[unique_constraint_name] = HiddenField(default=default)
 
-        # Update `extra_kwargs` with any new options.
+        # Update `extra_kwargs` with any new options but don't overwrite old values.
         for key, value in uniqueness_extra_kwargs.items():
             if key in extra_kwargs:
-                extra_kwargs[key].update(value)
-            else:
-                extra_kwargs[key] = value
+                value.update(extra_kwargs[key])
+            extra_kwargs[key] = value
 
         return extra_kwargs, hidden_fields
 


### PR DESCRIPTION
Fixed #4198 by changing the following

- Raise exception if field is defined on the class and present in extra_kwargs or read_only_fields
- Do not overwrite options specified in extra_kwargs in get_uniqueness_extra_kwargs