### PR TITLE
Optionally sort JSON output

### DIFF
--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -340,6 +340,16 @@ The default style is to return minified responses, in line with [Heroku's API de
 
 Default: `True`
 
+#### SORTED_JSON
+
+When set to `True`, keys in JSON responses will be sorted. For example:
+
+    {"email": "jane@example", "is_admin": false, "username": "jane"}
+
+When set to `False`, the JSON responses are arbitrarily ordered.
+
+Default: `False`
+
 #### COERCE_DECIMAL_TO_STRING
 
 When returning decimal objects in API representations that do not support a native decimal type, it is normally best to return the value as a string. This avoids the loss of precision that occurs with binary floating point implementations.

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -97,9 +97,12 @@ class JSONRenderer(BaseRenderer):
             separators = INDENT_SEPARATORS
 
         ret = json.dumps(
-            data, cls=self.encoder_class,
-            indent=indent, ensure_ascii=self.ensure_ascii,
-            separators=separators
+            data,
+            cls=self.encoder_class,
+            indent=indent,
+            ensure_ascii=self.ensure_ascii,
+            separators=separators,
+            sort_keys=api_settings.SORTED_JSON,
         )
 
         # On python 2.x json.dumps() returns bytestrings if ensure_ascii=True,

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -111,6 +111,7 @@ DEFAULTS = {
     # Encoding
     'UNICODE_JSON': True,
     'COMPACT_JSON': True,
+    'SORTED_JSON': False,
     'COERCE_DECIMAL_TO_STRING': True,
     'UPLOADED_FILES_USE_URL': True,
 }


### PR DESCRIPTION
This pull request adds a setting for sorting the keys of JSON responses by setting the `sort_keys` option on `json.dumps` (see [Python docs](https://docs.python.org/3.5/library/json.html#json.dump)). By default, this is set to `False` preserving existing functionality for those who don't want this.

The [Heroku API design docs](https://github.com/interagent/http-api-design) make no mention of sorting output but if you look at their examples, many them are sorted. Sorting output can make finding keys in large JSON blocks much easier especially in development.