### PR TITLE
Lazily get the name of hyperlinked models

### DIFF
--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -98,6 +98,11 @@ class TestHyperlinkedRelatedField(APISimpleTestCase):
         representation = self.field.to_representation(MockObject(pk=''))
         assert representation is None
 
+    def test_representation_does_not_call_get_name(self):
+        self.field.get_name = lambda _: pytest.fail(
+            "HyperlinkedRelatedField.get_name() called eagerly")
+        self.field.to_representation(MockObject(pk=1))
+
 
 class TestHyperlinkedIdentityField(APISimpleTestCase):
     def setUp(self):
@@ -233,9 +238,16 @@ class TestManyRelatedField(APISimpleTestCase):
 class TestHyperlink:
     def setup(self):
         self.default_hyperlink = serializers.Hyperlink('http://example.com', 'test')
+        self.callable_hyperlink = serializers.Hyperlink('http://example.com', lambda: 'called')
 
     def test_can_be_pickled(self):
         import pickle
         upkled = pickle.loads(pickle.dumps(self.default_hyperlink))
         assert upkled == self.default_hyperlink
         assert upkled.name == self.default_hyperlink.name
+
+    def test_simple_name_property(self):
+        assert 'test' == self.default_hyperlink.name
+
+    def test_callable_name_property(self):
+        assert 'called' == self.callable_hyperlink.name


### PR DESCRIPTION
## Description

Add support for `Hyperlink` `name`s to be callable.  This allows the call to `get_name()` in `HyperlinkedRelatedField` to be deferred until the property is accessed.

## Rationale

The default behavior of `HyperlinkedRelatedField.to_representation()` was surprising. Even though it only needs the pk of an instance, it was calling `__str__()`, resulting in a database query to fetch additional properties for stringification.

When serializing a list of _n_ links, this resulted in _n_ additional unnecessary database queries.  By passing in a function to get the name by default, we only call `__str__()` if it's needed.