### PR TITLE
Robust uniqueness checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,16 @@ env:
     - TOX_ENV=py27-django110
     - TOX_ENV=py35-django110
     - TOX_ENV=py34-django110
+    - TOX_ENV=py27-djangomaster
+    - TOX_ENV=py34-djangomaster
+    - TOX_ENV=py35-djangomaster
 
 matrix:
     fast_finish: true
     allow_failures:
-      - TOX_ENV=py27-djangomaster
-      - TOX_ENV=py34-djangomaster
-      - TOX_ENV=py35-djangomaster
+      - env: TOX_ENV=py27-djangomaster
+      - env: TOX_ENV=py34-djangomaster
+      - env: TOX_ENV=py35-djangomaster
 
 install:
     # Virtualenv < 14 is required to keep the Python 3.2 builds running.


### PR DESCRIPTION
Uniqueness checks for an invalid value should quietly pass, as the value does not exist.
This allows other validators to correctly catch the invalid input and return an appropriate error message, rather than resulting in a hard 500 failure.

Closes #3381
Closes #3493