### PR TITLE
Added missing colon in extra_kwargs documentation

### DIFF
--- a/docs/api-guide/validators.md
+++ b/docs/api-guide/validators.md
@@ -216,7 +216,7 @@ For example:
 
         class Meta:
             fields = ('client', 'date', 'amount')
-            extra_kwargs = {'client' {'required': 'False'}}
+            extra_kwargs = {'client': {'required': 'False'}}
             validators = []  # Remove a default "unique together" constraint.
 
 ## Updating nested serializers


### PR DESCRIPTION
This fixes a bug in the documentation of the "optional fields" extra_kwargs.