### PR TITLE
dict attr fix

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -123,6 +123,8 @@ def get_related_model(field):
 
 
 def value_from_object(field, obj):
+    if isinstance(obj, dict):
+        return obj[field.attname]
     if django.VERSION < (1, 9):
         return field._get_val_from_obj(obj)
     field.value_from_object(obj)

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1227,6 +1227,8 @@ class DurationField(Field):
         self.fail('invalid', format='[DD] [HH:[MM:]]ss[.uuuuuu]')
 
     def to_representation(self, value):
+        if isinstance(value, six.string_types):
+            return value
         return duration_string(value)
 
 
@@ -1686,4 +1688,6 @@ class ModelField(Field):
         value = value_from_object(self.model_field, obj)
         if is_protected_type(value):
             return value
+        if isinstance(obj, dict):
+            return obj[self.model_field.attname]
         return self.model_field.value_to_string(obj)


### PR DESCRIPTION
when using YAMLrenderer/Parser getting error with deserialization.

```python
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/uwsgidecorators.py", line 36, in manage_spool_request
    ret = f(vars)
  File "./kiosk/utils.py", line 87, in sync_outputs
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/serializers.py", line 700, in data
    ret = super(ListSerializer, self).data
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/serializers.py", line 239, in data
    self._data = self.to_representation(self.instance)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/serializers.py", line 618, in to_representation
    self.child.to_representation(item) for item in iterable
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/serializers.py", line 476, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/serializers.py", line 618, in to_representation
    self.child.to_representation(item) for item in iterable
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/serializers.py", line 476, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/serializers.py", line 618, in to_representation
    self.child.to_representation(item) for item in iterable
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/serializers.py", line 476, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/fields.py", line 1691, in to_representation
    return self.model_field.value_to_string(obj)
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/fields/__init__.py", line 851, in value_to_string
    return smart_text(self.value_from_object(obj))
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/fields/__init__.py", line 909, in value_from_object
    return getattr(obj, self.attname)
AttributeError: 'dict' object has no attribute 'password'
```
this workaround fixes it