### PR TITLE
Fix issues with routers for custom list-route and detail-routes

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -144,7 +144,9 @@ class SimpleRouter(BaseRouter):
 
         Returns a list of the Route namedtuple.
         """
-        known_actions = flatten([route.mapping.values() for route in self.routes if isinstance(route, Route)])
+        # converting to list as iterables are good for one pass, known host needs to be checked again and again for
+        # different functions.
+        known_actions = list(flatten([route.mapping.values() for route in self.routes if isinstance(route, Route)]))
 
         # Determine any `@detail_route` or `@list_route` decorated methods on the viewset
         detail_routes = []
@@ -154,6 +156,7 @@ class SimpleRouter(BaseRouter):
             httpmethods = getattr(attr, 'bind_to_methods', None)
             detail = getattr(attr, 'detail', True)
             if httpmethods:
+                # checking method names against the known actions list
                 if methodname in known_actions:
                     raise ImproperlyConfigured('Cannot use @detail_route or @list_route '
                                                'decorators on method "%s" '


### PR DESCRIPTION
I have a serializer:
```python
class TestViewSet(viewsets.ViewSet):
    @list_route(['PUT'])
    def update(self, *args, **kwargs):
        return Response({})

    @list_route(['PUT'])
    def hello_rest(self, *args, **kwargs):
        return Response({})
```
and a router config
```python
router = routers.DefaultRouter(trailing_slash=False)
router.register('test', TestViewSet, base_name='test')
```
Ideally the above configuration should fail as per https://github.com/tomchristie/django-rest-framework/blob/d41ddc9e5f3346892e46659245522d4be8abdc1a/rest_framework/routers.py#L157.  But this passess.

And when I remove the the method hello_rest it fails as expected.