### PR TITLE
Change template context generation in TemplateHTMLRenderer

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -165,13 +165,14 @@ class TemplateHTMLRenderer(BaseRenderer):
             template_names = self.get_template_names(response, view)
             template = self.resolve_template(template_names)
 
-        context = self.resolve_context(data, request, response)
+        context = self.get_template_context(data, renderer_context)
         return template_render(template, context, request=request)
 
     def resolve_template(self, template_names):
         return loader.select_template(template_names)
 
-    def resolve_context(self, data, request, response):
+    def get_template_context(self, data, renderer_context):
+        response = renderer_context['response']
         if response.exception:
             data['status_code'] = response.status_code
         return data


### PR DESCRIPTION
Make ``TemplateHTMLRenderer`` more subclass-friendly. Refs #4230.

- Change the name of ``resolve_context()`` to ``get_template_context()``.

- Pass the renderer context to this method, to give subclasses more flexibility
  when overriding.

This allows users to write code like this:
```
class ViewInContextHTMLRenderer(TemplateHTMLRenderer):

    def get_template_context(self, data, renderer_context):
        context = super().get_template_context(data, renderer_context)
        context['view'] = renderer_context['view']
        return context
```
Or maybe even:
```
class ExtraContextHTMLRenderer(TemplateHTMLRenderer):

    def get_template_context(self, data, renderer_context):
        context = super().get_template_context(data, renderer_context)
        context.update(renderer_context['extra_template_context'])
        return context
```
Currently, you have to override and reimplement the whole ``render()`` method instead.

This change does break compatibility with existing code that touches this interface. As far as I see, the interface was not documented. If desirable, we could add a compatibility shim.