### PR TITLE
Browsable api renderer. `get_filter_form` method. Return if don't have filter_backends in view. 

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -578,14 +578,14 @@ class BrowsableAPIRenderer(BaseRenderer):
         return get_breadcrumbs(request.path, request)
 
     def get_filter_form(self, data, view, request):
-        if not hasattr(view, 'get_queryset') or not hasattr(view, 'filter_backends'):
+        if not hasattr(view, 'get_queryset') or not getattr(view, 'filter_backends', None):
             return
 
         # Infer if this is a list view or not.
         paginator = getattr(view, 'paginator', None)
         if isinstance(data, list):
             pass
-        elif (paginator is not None and data is not None):
+        elif paginator is not None and data is not None:
             try:
                 paginator.get_results(data)
             except (TypeError, KeyError):


### PR DESCRIPTION
get_filter_form should return if don't have filter_backends in view.