### PR TITLE
Fix the error without specified encoding when compiling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     print("warning: pypandoc module not found, could not convert Markdown to RST")
 
     def read_md(f):
-        return open(f, 'r').read()
+        return open(f, 'r', encoding='utf-8').read()
 
 
 def get_version(package):

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import sys
+from io import open
 
 from setuptools import setup
 


### PR DESCRIPTION
## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.

When compile djang REST framework with pypandoc using OpenWRT toolchain,
it raises the error:

```
warning: pypandoc module not found, could not convert Markdown to RST
Traceback (most recent call last):
  File "./setup.py", line 86, in <module>
    long_description=read_md('README.md'),
  File "./setup.py", line 19, in read_md
    return open(f, 'r').read()
  File "/GIT_POOL/OpenWRT/OpenWrt-SDK-mvebu_gcc-4.8-linaro_uClibc-0.9.33.2_eabi.Linux-x86_64/staging_dir/target-arm_cortex-a9+vfpv3_uClibc-0.9.33.2_eabi/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 4874: ordinal not in range(128)
```

I specify encoding='utf-8' to resolve the building failure.

	modified:   setup.py