### PR TITLE
Added Limit/Offset pagination without counts.

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -17,8 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import status
 from rest_framework.compat import template_render
-from rest_framework.exceptions import APIException
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import APIException, NotFound
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.utils.urls import remove_query_param, replace_query_param


### PR DESCRIPTION
## Description

I've added an improved version of LimitOffsetPaginator - NoCountsLimitOffsetPaginator.

The rationale for it: counts are slow on large datasets, and it best to avoid them, on the other hand, cursor pagination is not as easy to use as the limit/offset one (and it does not support sorting). Additionally, angular ui-scroll library uses negative offsets which were not supported properly by LimitOffsetPaginator.

I haven't create tests for it (it's just a copy of what I made in our code), if you are willing to include this paginator into DRF I can add the coverage to it.