### PR TITLE
lookup_type is deprecated in favor of lookup_expr

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -178,8 +178,8 @@ For more advanced filtering requirements you can specify a `FilterSet` class tha
     from rest_framework import generics
 
     class ProductFilter(filters.FilterSet):
-        min_price = django_filters.NumberFilter(name="price", lookup_type='gte')
-        max_price = django_filters.NumberFilter(name="price", lookup_type='lte')
+        min_price = django_filters.NumberFilter(name="price", lookup_expr='gte')
+        max_price = django_filters.NumberFilter(name="price", lookup_expr='lte')
         class Meta:
             model = Product
             fields = ['category', 'in_stock', 'min_price', 'max_price']

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -37,9 +37,9 @@ if django_filters:
 
     # These class are used to test a filter class.
     class SeveralFieldsFilter(django_filters.FilterSet):
-        text = django_filters.CharFilter(lookup_type='icontains')
-        decimal = django_filters.NumberFilter(lookup_type='lt')
-        date = django_filters.DateFilter(lookup_type='gt')
+        text = django_filters.CharFilter(lookup_expr='icontains')
+        decimal = django_filters.NumberFilter(lookup_expr='lt')
+        date = django_filters.DateFilter(lookup_expr='gt')
 
         class Meta:
             model = FilterableItem
@@ -53,7 +53,7 @@ if django_filters:
 
     # These classes are used to test a misconfigured filter class.
     class MisconfiguredFilter(django_filters.FilterSet):
-        text = django_filters.CharFilter(lookup_type='icontains')
+        text = django_filters.CharFilter(lookup_expr='icontains')
 
         class Meta:
             model = BasicModel

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -377,9 +377,9 @@ class TestGenericIPAddressFieldValidation(TestCase):
 
         s = TestSerializer(data={'address': 'not an ip address'})
         self.assertFalse(s.is_valid())
-        self.assertEquals(1, len(s.errors['address']),
-                          'Unexpected number of validation errors: '
-                          '{0}'.format(s.errors))
+        self.assertEqual(1, len(s.errors['address']),
+                         'Unexpected number of validation errors: '
+                         '{0}'.format(s.errors))
 
 
 # Tests for relational field mappings.

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -286,14 +286,14 @@ class JSONRendererTests(TestCase):
         qs = DummyTestModel.objects.values('id', 'name')
         ret = JSONRenderer().render(qs)
         data = json.loads(ret.decode('utf-8'))
-        self.assertEquals(data, [{'id': o.id, 'name': o.name}])
+        self.assertEqual(data, [{'id': o.id, 'name': o.name}])
 
     def test_render_queryset_values_list(self):
         o = DummyTestModel.objects.create(name='dummy')
         qs = DummyTestModel.objects.values_list('id', 'name')
         ret = JSONRenderer().render(qs)
         data = json.loads(ret.decode('utf-8'))
-        self.assertEquals(data, [[o.id, o.name]])
+        self.assertEqual(data, [[o.id, o.name]])
 
     def test_render_dict_abc_obj(self):
         class Dict(MutableMapping):
@@ -323,7 +323,7 @@ class JSONRendererTests(TestCase):
         x[2] = 3
         ret = JSONRenderer().render(x)
         data = json.loads(ret.decode('utf-8'))
-        self.assertEquals(data, {'key': 'string value', '2': 3})
+        self.assertEqual(data, {'key': 'string value', '2': 3})
 
     def test_render_obj_with_getitem(self):
         class DictLike(object):

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -298,8 +298,8 @@ class TestNamespaceVersioningHyperlinkedRelatedFieldScheme(URLPatternsTestCase):
     ]
 
     urlpatterns = [
-        url(r'^v1/', include(included, namespace='v1')),
-        url(r'^v2/', include(included, namespace='v2')),
+        url(r'^v1/', include(included, namespace='v1', app_name='restframeworkv1')),
+        url(r'^v2/', include(included, namespace='v2', app_name='restframeworkv2')),
         url(r'^non-api/(?P<pk>\d+)/$', dummy_pk_view, name='non-api-view')
     ]
 

--- a/tests/test_write_only_fields.py
+++ b/tests/test_write_only_fields.py
@@ -21,7 +21,7 @@ class WriteOnlyFieldTests(TestCase):
         }
         serializer = self.Serializer(data=data)
         self.assertTrue(serializer.is_valid())
-        self.assertEquals(serializer.validated_data, data)
+        self.assertEqual(serializer.validated_data, data)
 
     def write_only_fields_are_not_present_on_output(self):
         instance = {
@@ -29,4 +29,4 @@ class WriteOnlyFieldTests(TestCase):
             'password': '123'
         }
         serializer = self.Serializer(instance)
-        self.assertEquals(serializer.data, {'email': 'foo@example.com'})
+        self.assertEqual(serializer.data, {'email': 'foo@example.com'})


### PR DESCRIPTION
assertEquals is deprecated in favor of assertEqual

app_name is a required keyword as of Django 1.10