### PR TITLE
Don't strip empty query params when paginating

### DIFF
--- a/rest_framework/utils/urls.py
+++ b/rest_framework/utils/urls.py
@@ -7,7 +7,7 @@ def replace_query_param(url, key, val):
     parameters of the URL, and return the new URL.
     """
     (scheme, netloc, path, query, fragment) = urlparse.urlsplit(url)
-    query_dict = urlparse.parse_qs(query)
+    query_dict = urlparse.parse_qs(query, keep_blank_values=True)
     query_dict[key] = [val]
     query = urlparse.urlencode(sorted(list(query_dict.items())), doseq=True)
     return urlparse.urlunsplit((scheme, netloc, path, query, fragment))
@@ -19,7 +19,7 @@ def remove_query_param(url, key):
     parameters of the URL, and return the new URL.
     """
     (scheme, netloc, path, query, fragment) = urlparse.urlsplit(url)
-    query_dict = urlparse.parse_qs(query)
+    query_dict = urlparse.parse_qs(query, keep_blank_values=True)
     query_dict.pop(key, None)
     query = urlparse.urlencode(sorted(list(query_dict.items())), doseq=True)
     return urlparse.urlunsplit((scheme, netloc, path, query, fragment))

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -108,6 +108,17 @@ class TestPaginationIntegration:
             'count': 50
         }
 
+    def test_empty_query_params_are_preserved(self):
+        request = factory.get('/', {'page': 2, 'filter': ''})
+        response = self.view(request)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            'results': [12, 14, 16, 18, 20],
+            'previous': 'http://testserver/?filter=',
+            'next': 'http://testserver/?filter=&page=3',
+            'count': 50
+        }
+
     def test_404_not_found_for_zero_page(self):
         request = factory.get('/', {'page': '0'})
         response = self.view(request)


### PR DESCRIPTION
## Description

Fixes issue with pagination when the url contains empty query params. The previous implementation would strip out any empty query params from the `next` and `previous` urls. This PR fixes the query parsing and ensures that empty query params are preserved.

This possibly fixes #3328.