### PR TITLE
Fix Typo in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -346,7 +346,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 [versioning]: api-guide/versioning.md
 [contentnegotiation]: api-guide/content-negotiation.md
 [metadata]: api-guide/metadata.md
-[schemas]: 'api-guide/schemas.md'
+[schemas]: api-guide/schemas.md
 [formatsuffixes]: api-guide/format-suffixes.md
 [reverse]: api-guide/reverse.md
 [exceptions]: api-guide/exceptions.md


### PR DESCRIPTION
Currently generating invalid URL at index page.
http://www.django-rest-framework.org/'api-guide/schemas.md'

Though it is correct in navigation.