### PR TITLE
Add logical or permission operator

### DIFF
--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -470,3 +470,25 @@ class CustomPermissionsTests(TestCase):
             detail = response.data.get('detail')
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertEqual(detail, self.custom_message)
+
+
+class AllowPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return True
+
+
+class DenyPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return False
+
+
+class PermissionOperatorTests(TestCase):
+    def test_permission_logical_or(self):
+        # We evaluate all possible combinations.
+
+        # We pass None to the has_permission function, request and view aren't
+        # relevant to these classes.
+        self.assertFalse((DenyPermission | DenyPermission)().has_permission(None, None))
+        self.assertTrue((AllowPermission | DenyPermission)().has_permission(None, None))
+        self.assertTrue((DenyPermission | AllowPermission)().has_permission(None, None))
+        self.assertTrue((AllowPermission | AllowPermission)().has_permission(None, None))


### PR DESCRIPTION
## Description

A common problem with permission classes is that implementing logical operators requires creating a new permission class just to have this effect. This makes the permission classes less atomic and harder to read and manage (For example: https://github.com/evonove/django-oauth-toolkit/pull/396).

## In Practice

In that particular example we wrote an `IsAuthenticatedOrTokenHasScope` permission class, while instead we could implement a class like so:

```python
class WebAuthenticated(ExtPermission):
    def has_permission(self, request, view):
        is_authenticated = IsAuthenticated().has_permission(request, view)
        oauth2authenticated = False
        if is_authenticated:
            oauth2authenticated = isinstance(request.successful_authenticator, OAuth2Authentication)

        return is_authenticated and not oauth2authenticated
```

and in the `permission_classes` we could set `(WebAuthenticated | TokenHasScope,)`

## Further Development

We could implement more logical operators `~`, `&`, `^`, and so forth, which would make permission class definition more expressive.