### PR TITLE
Add LICENSE.md to the built wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = 1
+
+[metadata]
+license_file = LICENSE.md


### PR DESCRIPTION
The wheel released on Pypi does not include the license file . The way to do this is by updating the setup.cfg accordingly. This fix will ensure that the LICENSE.md file is available in the `dist-info` dir of the built wheels as `LICENSE.txt`.
This way folks redistribution an official DRF wheel are complying with the BSD license... otherwise they would not by virtue of not including the license text!