### PR TITLE
Add failing test case for #3788

### DIFF
--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -978,4 +978,4 @@ class TestSerializerDefaultTrueBoolean(TestCase):
         data.update({'required_data': 'foo'})
         serializer = self.default_true_boolean_serializer(data=data)
         serializer.is_valid()
-        self.assertTrue(serializer.data['visible'])
+        self.assertNotIn('visible', serializer.validated_data)

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -16,6 +16,7 @@ from django.core.validators import (
 )
 from django.db import models
 from django.db.models import DurationField as ModelDurationField
+from django.http import QueryDict
 from django.test import TestCase
 from django.utils import six
 
@@ -955,3 +956,26 @@ class TestMetaInheritance(TestCase):
         self.assertEqual(unicode_repr(ChildSerializer()), child_expected)
         self.assertEqual(unicode_repr(TestSerializer()), test_expected)
         self.assertEqual(unicode_repr(ChildSerializer()), child_expected)
+
+
+class DefaultTrueBooleanModel(models.Model):
+    required_data = models.CharField(max_length=255)
+    visible = models.BooleanField(default=True)
+
+
+class TestSerializerDefaultTrueBoolean(TestCase):
+
+    def setUp(self):
+        class DefaultTrueBooleanSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = DefaultTrueBooleanModel
+                fields = ('required_data', 'visible')
+
+        self.default_true_boolean_serializer = DefaultTrueBooleanSerializer
+
+    def test_default_value(self):
+        data = QueryDict('', mutable=True)
+        data.update({'required_data': 'foo'})
+        serializer = self.default_true_boolean_serializer(data=data)
+        serializer.is_valid()
+        self.assertTrue(serializer.data['visible'])

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 import pickle
 
 import pytest
-from django.db import models
-from django.http import QueryDict
 
 from rest_framework import serializers
 from rest_framework.compat import unicode_repr
@@ -311,26 +309,3 @@ class TestCacheSerializerData:
         pickled = pickle.dumps(serializer.data)
         data = pickle.loads(pickled)
         assert data == {'field1': 'a', 'field2': 'b'}
-
-
-class DefaultTrueBooleanModel(models.Model):
-    required_data = models.CharField(max_length=255)
-    visible = models.BooleanField(default=True)
-
-
-class TestSerializerDefaultTrueBoolean:
-
-    def setup(self):
-        class DefaultTrueBooleanSerializer(serializers.ModelSerializer):
-            class Meta:
-                model = DefaultTrueBooleanModel
-                fields = ('required_data', 'visible')
-
-        self.default_true_boolean_serializer = DefaultTrueBooleanSerializer
-
-    def test_default_value(self):
-        data = QueryDict('', mutable=True)
-        data.update({'required_data': 'foo'})
-        serializer = self.default_true_boolean_serializer(data=data)
-        serializer.is_valid()
-        assert serializer.data['visible']

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import pickle
 
 import pytest
+from django.db import models
+from django.http import QueryDict
 
 from rest_framework import serializers
 from rest_framework.compat import unicode_repr
@@ -309,3 +311,26 @@ class TestCacheSerializerData:
         pickled = pickle.dumps(serializer.data)
         data = pickle.loads(pickled)
         assert data == {'field1': 'a', 'field2': 'b'}
+
+
+class DefaultTrueBooleanModel(models.Model):
+    required_data = models.CharField(max_length=255)
+    visible = models.BooleanField(default=True)
+
+
+class TestSerializerDefaultTrueBoolean:
+
+    def setup(self):
+        class DefaultTrueBooleanSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = DefaultTrueBooleanModel
+                fields = ('required_data', 'visible')
+
+        self.default_true_boolean_serializer = DefaultTrueBooleanSerializer
+
+    def test_default_value(self):
+        data = QueryDict('', mutable=True)
+        data.update({'required_data': 'foo'})
+        serializer = self.default_true_boolean_serializer(data=data)
+        serializer.is_valid()
+        assert serializer.data['visible']


### PR DESCRIPTION
Added failing test case for issue #3788. It tests that model's BooleanField default value (when True) is ignored on serializer.