### PR TITLE
Fix SwaggerRenderer implementation example

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -246,7 +246,7 @@ to the Open API ("Swagger") format:
 
         def render(self, data, media_type=None, renderer_context=None):
             codec = OpenAPICodec()
-            return OpenAPICodec.dump(data)
+            return codec.dump(data)
 
 ---
 


### PR DESCRIPTION
## Description

A small fix in implementation of SwaggerRenderer. The `.dump()` method must be called as an instance method.
