### PR TITLE
Problems when Serializing instance of a derived class that is also the target of a OneToOneField

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1164,24 +1164,19 @@ class ModelSerializer(Serializer):
                 from django.core.exceptions import FieldDoesNotExist
                 try:
                     return related_model._meta.get_field(to_field)
-                except FieldDoesNotExist as e:
+                except FieldDoesNotExist:
                     for field in related_model._meta.fields:
                         if field.related_model:
                             try:
                                 new_field = get_related_field(
                                     field.related_model, to_field)
                                 return new_field
-                            except FieldDoesNotExist as e:
+                            except FieldDoesNotExist:
                                 continue
                 raise FieldDoesNotExist(
                     '%s has not field named %r' % (related_model, to_field))
-            #try:
-            #    related_pk = (relation_info.related_model._meta
-            #        .get_field(to_field).primary_key)
-            #except FieldDoesNotExist as e:
-            #   import ipdb; ipdb.set_trace()
             pk = (get_related_field(relation_info.related_model, to_field)
-                .primary_key)
+                  .primary_key)
             if not pk:
                 field_kwargs['slug_field'] = to_field
                 field_class = self.serializer_related_to_field

--- a/tests/test_onetoone_with_inheritance.py
+++ b/tests/test_onetoone_with_inheritance.py
@@ -8,7 +8,7 @@ from tests.models import RESTFrameworkModel
 
 
 # Models
-from tests.test_multitable_inheritance import ChildModel, DerivedModelSerializer
+from tests.test_multitable_inheritance import ChildModel
 
 
 class ChildAssociatedModel(RESTFrameworkModel):


### PR DESCRIPTION
I have found that when attempting to serialize an instance of a model that: 

1. was derived (subclassed) from a model
2. was itself referenced via a one-to-one relationship by a third model
3. had a serializer that listed the referring model in its Meta.fields

A FieldDoesNotExist exception would be thrown indicating that the model with the OneToOne field has no field named <parent>_ptr where parent is the lower-cased name of the model at the top of the inheritance chain.

The attached pull request searches the inheritance chain recursively to find the correct field.

A unit test has also been included. My fork includes a branch called "foreign-key-to-derived-model-tests' which includes only the unit test. It may be used to verify the problem this pull request resolves.
