### PR TITLE
Test large files

### DIFF
--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -3,7 +3,9 @@
 from __future__ import unicode_literals
 
 from django import forms
-from django.core.files.uploadhandler import MemoryFileUploadHandler
+from django.core.files.uploadhandler import (
+    MemoryFileUploadHandler, TemporaryFileUploadHandler
+)
 from django.test import TestCase
 from django.utils.six.moves import StringIO
 
@@ -39,7 +41,7 @@ class TestFileUploadParser(TestCase):
             "Test text file".encode('utf-8')
         )
         request = MockRequest()
-        request.upload_handlers = (MemoryFileUploadHandler(),)
+        request.upload_handlers = (MemoryFileUploadHandler(), TemporaryFileUploadHandler(),)
         request.META = {
             'HTTP_CONTENT_DISPOSITION': 'Content-Disposition: inline; filename=file.txt',
             'HTTP_CONTENT_LENGTH': 14,
@@ -60,6 +62,18 @@ class TestFileUploadParser(TestCase):
         """
         Parse raw file upload when filename is missing.
         """
+        parser = FileUploadParser()
+        self.stream.seek(0)
+        self.parser_context['request'].META['HTTP_CONTENT_DISPOSITION'] = ''
+        with self.assertRaises(ParseError):
+            parser.parse(self.stream, None, self.parser_context)
+
+    def test_parse_missing_filename_large_file(self):
+        """
+        Parse large raw file upload when filename is missing.
+        """
+        from django.conf import settings
+        self.parser_context['request'].META['HTTP_CONTENT_LENGTH'] = settings.FILE_UPLOAD_MAX_MEMORY_SIZE + 1
         parser = FileUploadParser()
         self.stream.seek(0)
         self.parser_context['request'].META['HTTP_CONTENT_DISPOSITION'] = ''


### PR DESCRIPTION
I filled #3374 time ago and it was closed. Probably it wasn't very well explained, but it showed a non consistent behaviour.

Today I wrote this test that shows that large files and small files don't have the same behaviour. I couldn't fix it. My knowledge of DRF is limitated. This test, probably, will help to fix the error.

I think that fixing this test would fix #3374 and probably it would help with #3610.