### PR TITLE
use verbose_name instead of object_name in field_mapping

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -59,7 +59,7 @@ def get_detail_view_name(model):
     """
     return '%(model_name)s-detail' % {
         'app_label': model._meta.app_label,
-        'model_name': model._meta.verbose_name.lower()
+        'model_name': model._meta.object_name.lower()
     }
 
 

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -59,7 +59,7 @@ def get_detail_view_name(model):
     """
     return '%(model_name)s-detail' % {
         'app_label': model._meta.app_label,
-        'model_name': model._meta.object_name.lower()
+        'model_name': model._meta.verbose_name.lower()
     }
 
 
@@ -220,7 +220,7 @@ def get_field_kwargs(field_name, model_field):
         unique_error_message = model_field.error_messages.get('unique', None)
         if unique_error_message:
             unique_error_message = unique_error_message % {
-                'model_name': model_field.model._meta.object_name,
+                'model_name': model_field.model._meta.verbose_name,
                 'field_label': model_field.verbose_name
             }
         validator = UniqueValidator(

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -77,7 +77,7 @@ class TestUniquenessValidation(TestCase):
         data = {'username': 'existing'}
         serializer = UniquenessSerializer(data=data)
         assert not serializer.is_valid()
-        assert serializer.errors == {'username': ['UniquenessModel with this username already exists.']}
+        assert serializer.errors == {'username': ['uniqueness model with this username already exists.']}
 
     def test_is_unique(self):
         data = {'username': 'other'}


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/tomchristie/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

It should use `verbose_name`, not `object_name`, took me 2 hours to find out why parts of error were not translated as I didn't expect it to happen in drf.