### PR TITLE
Add url prefix to DefaultRouter and SchemaGenerator init

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -278,6 +278,7 @@ class DefaultRouter(SimpleRouter):
     def __init__(self, *args, **kwargs):
         self.schema_title = kwargs.pop('schema_title', None)
         self.schema_renderers = kwargs.pop('schema_renderers', self.default_schema_renderers)
+        self.schema_prefix = kwargs.pop('schema_prefix', '')
         super(DefaultRouter, self).__init__(*args, **kwargs)
 
     def get_api_root_view(self, schema_urls=None):
@@ -296,7 +297,8 @@ class DefaultRouter(SimpleRouter):
             view_renderers += list(self.schema_renderers)
             schema_generator = SchemaGenerator(
                 title=self.schema_title,
-                patterns=schema_urls
+                patterns=schema_urls,
+                prefix=self.schema_prefix
             )
             schema_media_types = [
                 renderer.media_type

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -57,7 +57,7 @@ class SchemaGenerator(object):
         'delete': 'destroy',
     }
 
-    def __init__(self, title=None, patterns=None, urlconf=None):
+    def __init__(self, title=None, patterns=None, urlconf=None, prefix=''):
         assert coreapi, '`coreapi` must be installed for schema support.'
 
         if patterns is None and urlconf is not None:
@@ -71,7 +71,7 @@ class SchemaGenerator(object):
             patterns = urls.urlpatterns
 
         self.title = title
-        self.endpoints = self.get_api_endpoints(patterns)
+        self.endpoints = self.get_api_endpoints(patterns, prefix)
 
     def get_schema(self, request=None):
         if request is None:


### PR DESCRIPTION
When using a DefaultRouter as a path, the schema generated by SchemaGenerator is wrong;

```
router = DefaultRouter(schema_title="foobar")
url(r"^api/", include(router.urls))
```

The schema generated will contains path like /foobar/ and not /api/foobar/, causing wrong url being used by coreapi-cli and djando-rest-swagger.

I didn't find a proper way to retrieve the prefixed path included at the time when the schema urls are generated, so i explicitly added optional arguments.

This patch add 2 arguments, the first one to DefaultRouter: schema_prefix; the second to SchemaGenerator init: prefix.