### PR TITLE
fixes bug in APIView with object level permissions

### DIFF
--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -151,6 +151,9 @@ class DjangoObjectPermissions(DjangoModelPermissions):
     This permission can only be applied against view classes that
     provide a `.queryset` attribute.
     """
+
+    requires_object_permission = True
+
     perms_map = {
         'GET': [],
         'OPTIONS': [],

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -7,6 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.db import models
 from django.http import Http404
 from django.http.response import HttpResponseBase
+from django.shortcuts import get_object_or_404 as _get_object_or_404
 from django.utils import six
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _
@@ -382,7 +383,11 @@ class APIView(View):
 
         # Ensure that the incoming request is permitted
         self.perform_authentication(request)
-        self.check_permissions(request)
+        if getattr(self, 'requires_object_permission', None) and 'pk' in kwargs:
+            obj = _get_object_or_404(self.get_queryset(), pk=kwargs['pk'])
+            self.check_object_permissions(request, obj)
+        else:
+            self.check_permissions(request)
         self.check_throttles(request)
 
     def finalize_response(self, request, response, *args, **kwargs):


### PR DESCRIPTION
Currently, object level permissions cannot be used with any classes that inherit from APIView. The issue is that `APIView.initial()` trys to call `check_permissions()` even when `DjangoObjectPermissions` is present, when it should call `check_object_permissions()`.

My solution is to add a class variable to `DjangoObjectPermissions` called `has_object_permission `. This is checked before  `APIView.initial()` calls `check_permissions()`, and calls `check_object_permissions()` instead if `has_object_permission` is True, and a primary key is present in the `kwargs` for `initial()`

I did have to add an import and a database call to get the object for checking it's permissions, so there may be a more efficient way around that.