### PR TITLE
Schema autogeneration

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.admindocs.views import simplify_regex
 from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
 from django.utils import six
+from django.utils.encoding import force_text
 
 from rest_framework import exceptions, serializers
 from rest_framework.compat import coreapi, uritemplate, urlparse
@@ -258,8 +259,6 @@ class SchemaGenerator(object):
         if not hasattr(view, 'get_serializer_class'):
             return []
 
-        fields = []
-
         serializer_class = view.get_serializer_class()
         serializer = serializer_class()
 
@@ -269,11 +268,17 @@ class SchemaGenerator(object):
         if not isinstance(serializer, serializers.Serializer):
             return []
 
+        fields = []
         for field in serializer.fields.values():
             if field.read_only:
                 continue
             required = field.required and method != 'PATCH'
-            field = coreapi.Field(name=field.source, location='form', required=required)
+            field = coreapi.Field(
+                name=field.source,
+                location='form',
+                required=required,
+                description=force_text(field.help_text),
+            )
             fields.append(field)
 
         return fields

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -176,18 +176,16 @@ class SchemaGenerator(object):
         Return a tuple of strings, indicating the identity to use for a
         given endpoint. eg. ('users', 'list').
         """
-        category = None
+        category = []
         for item in path.strip('/').split('/'):
             if '{' in item:
-                break
-            category = item
+                continue
+            category.append(item)
 
         actions = getattr(callback, 'actions', self.default_mapping)
         action = actions[method.lower()]
 
-        if category:
-            return (category, action)
-        return (action,)
+        return (' '.join(category), action)
 
     # Methods for generating each individual `Link` instance...
 

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -246,10 +246,16 @@ class SchemaGenerator(object):
         Return a list of `coreapi.Field` instances corresponding to any
         templated path variables.
         """
+        path_descriptions = getattr(view, 'path_fields_descriptions', {})
+
         fields = []
 
         for variable in uritemplate.variables(path):
-            field = coreapi.Field(name=variable, location='path', required=True)
+            field = coreapi.Field(name=variable,
+                                  location='path',
+                                  required=True,
+                                  description=path_descriptions.get(variable, ''),
+                                  )
             fields.append(field)
 
         return fields

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -180,7 +180,7 @@ class SchemaGenerator(object):
         for item in path.strip('/').split('/'):
             if '{' in item:
                 continue
-            category.append(item)
+            category.append(item.capitalize())
 
         actions = getattr(callback, 'actions', self.default_mapping)
         action = actions[method.lower()]

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
 from django.utils import six
 from django.utils.encoding import force_text
 
-from rest_framework import exceptions, serializers
+from rest_framework import exceptions, serializers, viewsets
 from rest_framework.compat import coreapi, uritemplate, urlparse
 from rest_framework.request import clone_request
 from rest_framework.views import APIView
@@ -207,10 +207,18 @@ class SchemaGenerator(object):
         else:
             encoding = None
 
+        if isinstance(view, viewsets.GenericViewSet):
+            actions = getattr(callback, 'actions', self.default_mapping)
+            action = actions[method.lower()]
+            view_fn = getattr(callback.cls, action, None)
+        else:
+            view_fn = getattr(callback.cls, method.lower(), None)
+
         return coreapi.Link(
             url=urlparse.urljoin(self.url, path),
             action=method.lower(),
             encoding=encoding,
+            description=view_fn.__doc__ if view_fn else '',
             fields=fields
         )
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -74,7 +74,7 @@ class TestRouterGeneratedSchema(TestCase):
             url='',
             title='Example API',
             content={
-                'example': {
+                'Example': {
                     'list': coreapi.Link(
                         url='/example/',
                         action='get',
@@ -104,7 +104,7 @@ class TestRouterGeneratedSchema(TestCase):
             url='',
             title='Example API',
             content={
-                'example': {
+                'Example': {
                     'list': coreapi.Link(
                         url='/example/',
                         action='get',
@@ -171,7 +171,7 @@ class TestSchemaGenerator(TestCase):
             url='',
             title='Test View',
             content={
-                'example-view': {
+                'Example-view': {
                     'create': coreapi.Link(
                         url='/example-view/',
                         action='post',
@@ -198,7 +198,7 @@ class TestSchemaAndSubSchemaGenerator(TestCase):
             url='',
             title='Test View',
             content={
-                'example': {
+                'Example': {
                     'list': coreapi.Link(
                         url='/example/',
                         action='get',
@@ -251,7 +251,7 @@ class TestSchemaAndSubSchemaGenerator(TestCase):
                         ]
                     )
                 },
-                'example-view': {
+                'Example-view': {
                     'create': coreapi.Link(
                         url='/{example_id}/example-view/',
                         action='post',

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -23,8 +23,8 @@ class ExamplePagination(pagination.PageNumberPagination):
 
 
 class ExampleSerializer(serializers.Serializer):
-    a = serializers.CharField(required=True)
-    b = serializers.CharField(required=False)
+    a = serializers.CharField(required=True, help_text='About a')
+    b = serializers.CharField(required=False, help_text='About b')
 
 
 class ExampleViewSet(ModelViewSet):
@@ -109,8 +109,8 @@ class TestRouterGeneratedSchema(TestCase):
                         action='post',
                         encoding='application/json',
                         fields=[
-                            coreapi.Field('a', required=True, location='form'),
-                            coreapi.Field('b', required=False, location='form')
+                            coreapi.Field('a', required=True, location='form', description='About a'),
+                            coreapi.Field('b', required=False, location='form', description='About b')
                         ]
                     ),
                     'retrieve': coreapi.Link(
@@ -126,8 +126,8 @@ class TestRouterGeneratedSchema(TestCase):
                         encoding='application/json',
                         fields=[
                             coreapi.Field('pk', required=True, location='path'),
-                            coreapi.Field('a', required=True, location='form'),
-                            coreapi.Field('b', required=False, location='form')
+                            coreapi.Field('a', required=True, location='form', description='About a'),
+                            coreapi.Field('b', required=False, location='form', description='About b')
                         ]
                     ),
                     'partial_update': coreapi.Link(
@@ -136,8 +136,8 @@ class TestRouterGeneratedSchema(TestCase):
                         encoding='application/json',
                         fields=[
                             coreapi.Field('pk', required=True, location='path'),
-                            coreapi.Field('a', required=False, location='form'),
-                            coreapi.Field('b', required=False, location='form')
+                            coreapi.Field('a', required=False, location='form', description='About a'),
+                            coreapi.Field('b', required=False, location='form', description='About b')
                         ]
                     ),
                     'destroy': coreapi.Link(

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -38,6 +38,7 @@ class ExampleView(APIView):
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
     def get(self, request, *args, **kwargs):
+        """get documentation"""
         return Response()
 
     def post(self, request, *args, **kwargs):
@@ -171,6 +172,7 @@ class TestSchemaGenerator(TestCase):
                     'read': coreapi.Link(
                         url='/example-view/',
                         action='get',
+                        description='get documentation',
                         fields=[]
                     )
                 }

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -36,6 +36,9 @@ class ExampleViewSet(ModelViewSet):
 
 class ExampleView(APIView):
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    path_fields_descriptions = {
+        'example_id': 'Description of example_id path parameter',
+    }
 
     def get(self, request, *args, **kwargs):
         """get documentation"""
@@ -256,7 +259,7 @@ class TestSchemaAndSubSchemaGenerator(TestCase):
                         url='/{example_id}/example-view/',
                         action='post',
                         fields=[
-                            coreapi.Field('example_id', required=True, location='path')
+                            coreapi.Field('example_id', required=True, location='path', description='Description of example_id path parameter')
                         ]
                     ),
                     'read': coreapi.Link(
@@ -264,7 +267,7 @@ class TestSchemaAndSubSchemaGenerator(TestCase):
                         action='get',
                         description='get documentation',
                         fields=[
-                            coreapi.Field('example_id', required=True, location='path')
+                            coreapi.Field('example_id', required=True, location='path', description='Description of example_id path parameter')
                         ]
                     )
                 },

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -6,7 +6,7 @@ from django.test import TestCase, override_settings
 from rest_framework import filters, pagination, permissions, serializers
 from rest_framework.compat import coreapi
 from rest_framework.response import Response
-from rest_framework.routers import DefaultRouter
+from rest_framework.routers import DefaultRouter, SimpleRouter
 from rest_framework.schemas import SchemaGenerator
 from rest_framework.test import APIClient
 from rest_framework.views import APIView
@@ -52,6 +52,14 @@ urlpatterns = [
 ]
 urlpatterns2 = [
     url(r'^example-view/$', ExampleView.as_view(), name='example-view')
+]
+
+
+router = SimpleRouter()
+router.register('example', ExampleViewSet, base_name='example')
+urlpatterns3 = [
+    url(r'^', include(router.urls)),
+    url(r'^(?P<example_id>\w+)/example-view/$', ExampleView.as_view(), name='example-view')
 ]
 
 
@@ -176,6 +184,90 @@ class TestSchemaGenerator(TestCase):
                         fields=[]
                     )
                 }
+            }
+        )
+        self.assertEquals(schema, expected)
+
+
+@unittest.skipUnless(coreapi, 'coreapi is not installed')
+class TestSchemaAndSubSchemaGenerator(TestCase):
+    def test_view(self):
+        schema_generator = SchemaGenerator(title='Test View', patterns=urlpatterns3)
+        schema = schema_generator.get_schema()
+        expected = coreapi.Document(
+            url='',
+            title='Test View',
+            content={
+                'example': {
+                    'list': coreapi.Link(
+                        url='/example/',
+                        action='get',
+                        fields=[
+                            coreapi.Field('page', required=False, location='query'),
+                            coreapi.Field('ordering', required=False, location='query')
+                        ]
+                    ),
+                    'create': coreapi.Link(
+                        url='/example/',
+                        action='post',
+                        encoding='application/json',
+                        fields=[
+                            coreapi.Field('a', required=True, location='form', description='About a'),
+                            coreapi.Field('b', required=False, location='form', description='About b')
+                        ]
+                    ),
+                    'retrieve': coreapi.Link(
+                        url='/example/{pk}/',
+                        action='get',
+                        fields=[
+                            coreapi.Field('pk', required=True, location='path')
+                        ]
+                    ),
+                    'update': coreapi.Link(
+                        url='/example/{pk}/',
+                        action='put',
+                        encoding='application/json',
+                        fields=[
+                            coreapi.Field('pk', required=True, location='path'),
+                            coreapi.Field('a', required=True, location='form', description='About a'),
+                            coreapi.Field('b', required=False, location='form', description='About b')
+                        ]
+                    ),
+                    'partial_update': coreapi.Link(
+                        url='/example/{pk}/',
+                        action='patch',
+                        encoding='application/json',
+                        fields=[
+                            coreapi.Field('pk', required=True, location='path'),
+                            coreapi.Field('a', required=False, location='form', description='About a'),
+                            coreapi.Field('b', required=False, location='form', description='About b')
+                        ]
+                    ),
+                    'destroy': coreapi.Link(
+                        url='/example/{pk}/',
+                        action='delete',
+                        fields=[
+                            coreapi.Field('pk', required=True, location='path')
+                        ]
+                    )
+                },
+                'example-view': {
+                    'create': coreapi.Link(
+                        url='/{example_id}/example-view/',
+                        action='post',
+                        fields=[
+                            coreapi.Field('example_id', required=True, location='path')
+                        ]
+                    ),
+                    'read': coreapi.Link(
+                        url='/{example_id}/example-view/',
+                        action='get',
+                        description='get documentation',
+                        fields=[
+                            coreapi.Field('example_id', required=True, location='path')
+                        ]
+                    )
+                },
             }
         )
         self.assertEquals(schema, expected)


### PR DESCRIPTION
Schema Autogeneration
===================

This pull request addresses Schema autogeneration from the API views.

1. it resolves a bug where the higher namespace urls (/account/{account_id}/books/{pk}/) are hidden by lower namespace (/account/{pk}/).
2. It uses the docstring of the method that will handle the request (either get, post, put, etc for the APIView or list, retrieve, update for the viewset) as the description of the coreapi.Link.
3. It uses the help_text of the serializers fields as the description of the coreapi.Field.
4. It capitalize the names of the Link.