### PR TITLE
urljoin with leading slash remove part of path

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -206,6 +206,9 @@ class SchemaGenerator(object):
         else:
             encoding = None
 
+        if self.url and path.startswith('/'):
+            path = path[1:]
+
         return coreapi.Link(
             url=urlparse.urljoin(self.url, path),
             action=method.lower(),


### PR DESCRIPTION
simplify_regex return an url with a leading slash which is interpreted as a root path by urlparse;
```
>>> urlparse.urljoin("http://localhost:8000/api/", "/foo/")
'http://localhost:8000/foo/'
```

leads to SchemaGenerator returning a wrong link.