### PR TITLE
Quantize incoming digitals

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -955,7 +955,7 @@ class DecimalField(Field):
         if value in (decimal.Decimal('Inf'), decimal.Decimal('-Inf')):
             self.fail('invalid')
 
-        return self.validate_precision(value)
+        return self.quantize(self.validate_precision(value))
 
     def validate_precision(self, value):
         """
@@ -1018,7 +1018,8 @@ class DecimalField(Field):
         context.prec = self.max_digits
         return value.quantize(
             decimal.Decimal('.1') ** self.decimal_places,
-            context=context)
+            context=context
+        )
 
 
 # Date & time fields...

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -912,6 +912,26 @@ class TestLocalizedDecimalField(TestCase):
         self.assertTrue(isinstance(field.to_representation(Decimal('1.1')), six.string_types))
 
 
+class TestQuantizedValueForDecimal(TestCase):
+    def test_int_quantized_value_for_decimal(self):
+        field = serializers.DecimalField(max_digits=4, decimal_places=2)
+        value = field.to_internal_value(12).as_tuple()
+        expected_digit_tuple = (0, (1, 2, 0, 0), -2)
+        self.assertEqual(value, expected_digit_tuple)
+
+    def test_string_quantized_value_for_decimal(self):
+        field = serializers.DecimalField(max_digits=4, decimal_places=2)
+        value = field.to_internal_value('12').as_tuple()
+        expected_digit_tuple = (0, (1, 2, 0, 0), -2)
+        self.assertEqual(value, expected_digit_tuple)
+
+    def test_part_precision_string_quantized_value_for_decimal(self):
+        field = serializers.DecimalField(max_digits=4, decimal_places=2)
+        value = field.to_internal_value('12.0').as_tuple()
+        expected_digit_tuple = (0, (1, 2, 0, 0), -2)
+        self.assertEqual(value, expected_digit_tuple)
+
+
 class TestNoDecimalPlaces(FieldValues):
     valid_inputs = {
         '0.12345': Decimal('0.12345'),


### PR DESCRIPTION
`DecimalField` now quantizes incoming values, ensuring that the resulting value includes the correct representation.

Previous the value would be correct, but would not be associated with the precision used by the field, so eg...

    >>> class ExampleSerializer(serializers.Serializer):
    >>>     total_price = serializers.DecimalField(max_digits=5, decimal_places=2)
    >>> serializer = ExampleSerializer(data={'total_price': '12'})
    >>> assert serializers.is_valid()
    >>> print serializer.validated_data['total_price']
    12.00  # Now correctly represented. Previously would print 12.

Closes #4318.