### PR TITLE
Serializer defaults should not be included in partial updates.

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -51,7 +51,7 @@ Defaults to `False`
 
 If set, this gives the default value that will be used for the field if no input value is supplied. If not set the default behaviour is to not populate the attribute at all.
 
-The `default` is not applied during partial update operations, in which case, only fields that are provided will have a validated value returned.
+The `default` is not applied during partial update operations. In the partial update case only fields that are provided in the incoming data will have a validated value returned.
 
 May be set to a function or other callable, in which case the value will be evaluated each time it is used. When called, it will receive no arguments. If the callable has a `set_context` method, that will be called each time before getting the value with the field instance as only argument. This works the same way as for [validators](validators.md#using-set_context).
 

--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -49,7 +49,9 @@ Defaults to `False`
 
 ### `default`
 
-If set, this gives the default value that will be used for the field if no input value is supplied.  If not set the default behavior is to not populate the attribute at all.
+If set, this gives the default value that will be used for the field if no input value is supplied. If not set the default behaviour is to not populate the attribute at all.
+
+The `default` is not applied during partial update operations, in which case, only fields that are provided will have a validated value returned.
 
 May be set to a function or other callable, in which case the value will be evaluated each time it is used. When called, it will receive no arguments. If the callable has a `set_context` method, that will be called each time before getting the value with the field instance as only argument. This works the same way as for [validators](validators.md#using-set_context).
 

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -435,7 +435,8 @@ class Field(object):
         return `empty`, indicating that no value should be set in the
         validated data for this field.
         """
-        if self.default is empty:
+        if self.default is empty or getattr(self.root, 'partial', False):
+            # No default, or this is a partial update.
             raise SkipField()
         if callable(self.default):
             if hasattr(self.default, 'set_context'):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -309,3 +309,31 @@ class TestCacheSerializerData:
         pickled = pickle.dumps(serializer.data)
         data = pickle.loads(pickled)
         assert data == {'field1': 'a', 'field2': 'b'}
+
+
+class TestDefaultInclusions:
+    def setup(self):
+        class ExampleSerializer(serializers.Serializer):
+            char = serializers.CharField(read_only=True, default='abc')
+            integer = serializers.IntegerField()
+        self.Serializer = ExampleSerializer
+
+    def test_default_should_included_on_create(self):
+        serializer = self.Serializer(data={'integer': 456})
+        assert serializer.is_valid()
+        assert serializer.validated_data == {'char': 'abc', 'integer': 456}
+        assert serializer.errors == {}
+
+    def test_default_should_not_be_included_on_update(self):
+        instance = MockObject(char='def', integer=123)
+        serializer = self.Serializer(instance, data={'integer': 456})
+        assert serializer.is_valid()
+        assert serializer.validated_data == {'integer': 456}
+        assert serializer.errors == {}
+
+    def test_default_should_not_be_included_on_partial_update(self):
+        instance = MockObject(char='def', integer=123)
+        serializer = self.Serializer(instance, data={'integer': 456}, partial=True)
+        assert serializer.is_valid()
+        assert serializer.validated_data == {'integer': 456}
+        assert serializer.errors == {}

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -324,11 +324,11 @@ class TestDefaultInclusions:
         assert serializer.validated_data == {'char': 'abc', 'integer': 456}
         assert serializer.errors == {}
 
-    def test_default_should_not_be_included_on_update(self):
+    def test_default_should_be_included_on_update(self):
         instance = MockObject(char='def', integer=123)
         serializer = self.Serializer(instance, data={'integer': 456})
         assert serializer.is_valid()
-        assert serializer.validated_data == {'integer': 456}
+        assert serializer.validated_data == {'char': 'abc', 'integer': 456}
         assert serializer.errors == {}
 
     def test_default_should_not_be_included_on_partial_update(self):


### PR DESCRIPTION
When a partial update is applied, defaults should never be populated.
The only fields which get values should be those that are explicitly included.

Closes #3565.