### PR TITLE
extra_kwargs takes precedence over uniqueness kwargs

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1324,9 +1324,8 @@ class ModelSerializer(Serializer):
         # Update `extra_kwargs` with any new options.
         for key, value in uniqueness_extra_kwargs.items():
             if key in extra_kwargs:
-                extra_kwargs[key].update(value)
-            else:
-                extra_kwargs[key] = value
+                value.update(extra_kwargs[key])
+            extra_kwargs[key] = value
 
         return extra_kwargs, hidden_fields
 

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -976,3 +976,22 @@ class TestModelFieldValues(TestCase):
         source = OneToOneSourceTestModel(target=target)
         serializer = ExampleSerializer(source)
         self.assertEqual(serializer.data, {'target': 1})
+
+
+class TestUniquenessOverride(TestCase):
+    def test_required_not_overwritten(self):
+        class TestModel(models.Model):
+            field_1 = models.IntegerField(null=True)
+            field_2 = models.IntegerField()
+
+            class Meta:
+                unique_together = (('field_1', 'field_2'),)
+
+        class TestSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = TestModel
+                extra_kwargs = {'field_1': {'required': False}}
+
+        fields = TestSerializer().fields
+        self.assertFalse(fields['field_1'].required)
+        self.assertTrue(fields['field_2'].required)


### PR DESCRIPTION
When an option is specified in extra_kwargs it should always override any implict extra_kwargs that are generated by uniqueness constraints.

Closes #4199.
Closes #4198.