### PR TITLE
Filter HEAD out from schemas

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -167,7 +167,7 @@ class SchemaGenerator(object):
 
         return [
             method for method in
-            callback.cls().allowed_methods if method != 'OPTIONS'
+            callback.cls().allowed_methods if method not in ('OPTIONS', 'HEAD')
         ]
 
     def get_key(self, path, method, callback):


### PR DESCRIPTION
Refs #4356

`HEAD` shouldn't be included in `allowed_methods`, as it's not required, but let's not error if it is.
