### PR TITLE
Include kwargs passed to 'as_view' when generating schemas.

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -195,6 +195,8 @@ class SchemaGenerator(object):
         Return a `coreapi.Link` instance for the given endpoint.
         """
         view = callback.cls()
+        for attr, val in getattr(callback, 'initkwargs', {}).items():
+            setattr(view, attr, val)
 
         fields = self.get_path_fields(path, method, callback, view)
         fields += self.get_serializer_fields(path, method, callback, view)

--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -97,6 +97,7 @@ class ViewSetMixin(object):
         # generation can pick out these bits of information from a
         # resolved URL.
         view.cls = cls
+        view.initkwargs = initkwargs
         view.suffix = initkwargs.get('suffix', None)
         view.actions = actions
         return csrf_exempt(view)


### PR DESCRIPTION
When a view is instantiated using `as_view()` any additional keyword arguments that have been passing in `as_view()` should also be respected when performing schema generation.

Closes #4331.
Closes #4330.