### PR TITLE
exclude OPTIONS requests from throttling

### DIFF
--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -118,6 +118,9 @@ class SimpleRateThrottle(BaseThrottle):
         """
         if self.rate is None:
             return True
+            
+        if request.method == 'OPTIONS':
+            return True
 
         self.key = self.get_cache_key(request, view)
         if self.key is None:

--- a/rest_framework/throttling.py
+++ b/rest_framework/throttling.py
@@ -118,7 +118,7 @@ class SimpleRateThrottle(BaseThrottle):
         """
         if self.rate is None:
             return True
-            
+
         if request.method == 'OPTIONS':
             return True
 


### PR DESCRIPTION
Web browsers send OPTIONS requests an API server prior to every request to check if CORS allowed, so rates are reached half time. We could just double the rate, but other clients (mobile apps) don't send extra requests, so we need to exclude OPTIONS from rating to apply throttle rates evenly