### PR TITLE
Add test for raising non-ValidationError in serializer, and it 'escape'

### DIFF
--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -61,6 +61,19 @@ class TestSerializer:
         with pytest.raises(AssertionError):
             serializer.save()
 
+    def test_non_validation_error_escapes(self):
+        from rest_framework.exceptions import APIException
+
+        class CustomException(APIException):
+            @classmethod
+            def throw(self, *a, **kw):
+                raise self
+
+        serializer = self.Serializer(data={'char': 'abc', 'integer': 123})
+        serializer.validate_char = CustomException.throw
+        with pytest.raises(CustomException):
+            serializer.is_valid()
+
 
 class TestValidateMethod:
     def test_non_field_error_validate_method(self):


### PR DESCRIPTION
Serializers should certainly except `ValidationError`s and respond
with the appropriate `400 Bad Request`.

This commit adds a test to check that it remains possible to raise
another exception - e.g. deriving `APIException` - that escapes
the serializer and is handled elsewhere - or not, as the case may
be.

It turns out that this behaviour is already supported, but it
wasn't clear that it was (or was by-design) from reading the
existing tests; while it _seemed_ to be the case from the source,
it's not as obvious as it would be if there's an explicit test.