### PR TITLE
Router Improvements

### DIFF
--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -21,3 +21,5 @@ HTTP_HEADER_ENCODING = 'iso-8859-1'
 
 # Default datetime input and output formats
 ISO_8601 = 'iso-8601'
+
+default_app_config = 'rest_framework.apps.RestFrameworkConfig'

--- a/rest_framework/apps.py
+++ b/rest_framework/apps.py
@@ -2,8 +2,6 @@ from django.apps import AppConfig
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
-from rest_framework.compat import importlib
-
 
 class RestFrameworkConfig(AppConfig):
     name = 'rest_framework'
@@ -15,6 +13,7 @@ class RestFrameworkConfig(AppConfig):
 
         This lets us evaluate all of the @router.route('...') calls.
         """
+        from rest_framework.compat import importlib
         for app in settings.INSTALLED_APPS:
             for mod_name in ['api']:
                 try:

--- a/rest_framework/apps.py
+++ b/rest_framework/apps.py
@@ -1,0 +1,23 @@
+from importlib import import_module
+
+from django.apps import AppConfig
+from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
+
+
+class RestFrameworkConfig(AppConfig):
+    name = 'rest_framework'
+    verbose_name = _("REST Framework")
+
+    def ready(self):
+        """
+        Try to auto-import any modules in INSTALLED_APPS.
+
+        This lets us evaluate all of the @router.route('...') calls.
+        """
+        for app in settings.INSTALLED_APPS:
+            for mod_name in ['api']:
+                try:
+                    import_module('%s.%s' % (app, mod_name))
+                except ImportError:
+                    pass

--- a/rest_framework/apps.py
+++ b/rest_framework/apps.py
@@ -1,8 +1,8 @@
-from importlib import import_module
-
 from django.apps import AppConfig
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
+
+from rest_framework.compat import importlib
 
 
 class RestFrameworkConfig(AppConfig):
@@ -18,6 +18,6 @@ class RestFrameworkConfig(AppConfig):
         for app in settings.INSTALLED_APPS:
             for mod_name in ['api']:
                 try:
-                    import_module('%s.%s' % (app, mod_name))
+                    importlib.import_module('%s.%s' % (app, mod_name))
                 except ImportError:
                     pass

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -173,6 +173,32 @@ class SimpleRouter(BaseRouter):
         self.trailing_slash = trailing_slash and '/' or ''
         super(SimpleRouter, self).__init__()
 
+    def route(self, *full_path, **kwargs):
+        """
+        ViewSet class decorator for automatically registering a route:
+
+            router = SimpleRouter()
+
+            @router.route('parent')
+            class ParentViewSet(ViewSet):
+                pass
+
+            @router.route('parent', 'child', base_name='children)
+            class ChildViewSet(ViewSet):
+                pass
+        """
+        full_path = list(full_path)
+        assert len(full_path) > 0, 'Must provide a route prefix'
+        base_name = kwargs.pop('base_name', '-'.join(full_path))
+
+        def wrapper(viewset_cls):
+            self.register(wrapper._full_path, viewset_cls, wrapper._base_name)
+            return viewset_cls
+
+        wrapper._full_path = full_path
+        wrapper._base_name = base_name
+        return wrapper
+
     def get_default_base_name(self, viewset):
         """
         If `base_name` is not specified, attempt to automatically determine

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -68,16 +68,18 @@ class RouteTree:
         been set or if the path doesn't exist.
         """
         routes = self.routes
+        parent_path = []
 
         for part in path:
             if part not in routes:
-                # TODO: invalid path error message
-                raise KeyError('')
-            routes = routes[path].routes
+                on_path = (' on path %s' % parent_path) if len(parent_path) > 0 else ''
+                raise KeyError('Parent route "%s"%s was not registred' % (part, on_path))
+            parent_path.append(part)
+            routes = routes[part].routes
 
         if name in routes:
-            # TODO: route name already exists error message
-            raise KeyError('')
+            on_path = (' on path %s' % path) if len(path) > 0 else ''
+            raise KeyError('Route "%s" already set%s' % (name, on_path))
 
         routes[name] = self.Node({}, value)
 

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -23,6 +23,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
 
 from rest_framework import exceptions, renderers, views
+from rest_framework.compat import six
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.schemas import SchemaGenerator
@@ -347,7 +348,7 @@ class SimpleRouter(BaseRouter):
         """
         def normalize(entry):
             prefix, viewset, base_name = entry
-            if isinstance(prefix, str):
+            if isinstance(prefix, six.string_types):
                 prefix = [prefix]
             return prefix, viewset, base_name
 

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -159,6 +159,26 @@ class TestSimpleRouter(TestCase):
             for method in methods_map:
                 self.assertEqual(route.mapping[method], endpoint)
 
+    def test_route_nodes_path(self):
+        """
+        Should return a full prefix for the given route_nodes. Duplicate parent
+        lookups should have a count appended.
+        """
+        tree = RouteTree()
+        tree.set(NoteViewSet, [], 'first')
+        tree.set(NoteViewSet, ['first'], 'first')
+        tree.set(NoteViewSet, ['first', 'first'], 'last')
+
+        self.assertEqual(
+            self.router.get_route_nodes_path(tree.get([], 'first')),
+            r'first')
+        self.assertEqual(
+            self.router.get_route_nodes_path(tree.get(['first'], 'first')),
+            r'first/(?P<first_uuid>[^/.]+)/first')
+        self.assertEqual(
+            self.router.get_route_nodes_path(tree.get(['first', 'first'], 'last')),
+            r'first/(?P<first_uuid>[^/.]+)/first/(?P<first_2_uuid>[^/.]+)/last')
+
 
 @override_settings(ROOT_URLCONF='tests.test_routers')
 class TestRootView(TestCase):

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -179,6 +179,23 @@ class TestSimpleRouter(TestCase):
             self.router.get_route_nodes_path(tree.get(['first', 'first'], 'last')),
             r'first/(?P<first_uuid>[^/.]+)/first/(?P<first_2_uuid>[^/.]+)/last')
 
+    def test_route(self):
+        """
+        Should allow registering ViewSets via a class decorator.
+        """
+        @self.router.route('parent', 'child')
+        class ChildViewSet(NoteViewSet):
+            pass
+
+        @self.router.route('parent')
+        class ParentViewSet(NoteViewSet):
+            pass
+
+        self.assertEqual(self.router._process_registry(), [
+            (['parent'], ParentViewSet, 'parent'),
+            (['parent', 'child'], ChildViewSet, 'parent-child')
+        ])
+
 
 @override_settings(ROOT_URLCONF='tests.test_routers')
 class TestRootView(TestCase):


### PR DESCRIPTION
This PR includes some improvements to the `routers.SimpleRouter` class. The additions don't break or change any existing features and all tests pass (including new tests). I felt these changes were small enough that they should be included directly with DRF instead of as a third-party app. But, I'm open to going down that route if it makes more sense.

## Nested Routes
I've used `drf-nested-routers` but I think my solution is a little cleaner. It's also less boilerplate. Here's an example use:
```python
router = SimpleRouter()

# old-style register still supported:
router.register('users', UserViewSet)

# new-style register with nested routes:
router.register(['users', 'orgs', 'repos'], UserOrgReportViewSet)
router.register(['users', 'orgs'], UserOrgViewSet)

assert router.urls == [
    url(r'users/', name='users-list'),
    url(r'users/(?P<pk>[^/.]+)/', name='users-detail'),
    url(r'users/(?P<users_pk>[^/.]+)/orgs/', name='users-orgs-list'),
    url(r'users/(?P<users_pk>[^/.]+)/orgs/(?P<pk>[^/.]+)/', name='users-orgs-detail'),
    url(r'users/(?P<users_pk>[^/.]+)/orgs/(?P<orgs_pk>[^/.]+)/repos/', name='users-orgs-repos-list'),
    url(r'users/(?P<users_pk>[^/.]+)/orgs/(?P<orgs_pk>[^/.]+)/repos/?P<pk>[^/.]+)/', name='users-orgs-repos-detail'),
]
```

The order in which `register()` is called doesn't matter. In my experience this can be useful when you have nested routes defined in several apps outside of the app containing the parent route. The route hierarchy is sorted and validated when `router.urls` is referenced.

## Declarative Routing
The second addition is the `@router.route('...')` class decorator. I'm not sure how other people manage api routes spread across many apps on a large project but I've found this to be a useful pattern. It works similarly to `models.py`. Instead of something like:
```python
# file in project root called api.py
from rest_framework.routers import DefaultRouter

from project.app_1 import views as views_1
# ...
from project.app_n import views as views_n

router = DefaultRouter()
router.register('view1', views_1.ViewSet1)
router.register('view2', views_1.ViewSet2)
# ...
router.register('view4', views_n.ViewSet1)
router.register('view5', views_n.ViewSet2)

url_patterns = router.urls
```

You just use the class decorator on your api views. By convention I use `api.py` but that could be changed. In the `app_config.ready()` method all the `api` modules are loaded for each app in `INSTALLED_APPS` so that any `router.route()` decorator is evaluated and all of the routes are ready when Django has loaded up and your url conf is loaded.
```python
# in project/__init__.py
from rest_framework.routers import DefaultRouter

project_api = DefaultRouter()


# in project/urls.py
from django.conf.urls import include
from project import project_api

url_patterns = [
    include(r'api/', project_api.urls, namespace='api')
]


# in project/my_app/api.py
from rest_framework.viewsets import ViewSet
from project import project_router 

@project_router.router('users', 'orgs')
class UserOrgsViewSet(ViewSet):
     def get_queryset(self):
        user = self.kwargs['users_pk']
        return Orgs.objects.filter(owner=user)


# in project/core/api.py
from rest_framework.viewsets import ViewSet
from project import project_router

@project_router('users')
class UsersViewSet(ViewSet):
    pass
```
