### PR TITLE
Stricter type validation for CharField.

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -10,7 +10,7 @@ from django.core.urlresolvers import (
 from django.db.models import Manager
 from django.db.models.query import QuerySet
 from django.utils import six
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text, smart_text
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.translation import ugettext_lazy as _
 
@@ -168,7 +168,7 @@ class RelatedField(Field):
 
         return OrderedDict([
             (
-                six.text_type(self.to_representation(item)),
+                force_text(self.to_representation(item), strings_only=True),
                 self.display_value(item)
             )
             for item in queryset

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -10,7 +10,7 @@ from django.core.urlresolvers import (
 from django.db.models import Manager
 from django.db.models.query import QuerySet
 from django.utils import six
-from django.utils.encoding import force_text, smart_text
+from django.utils.encoding import smart_text
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.translation import ugettext_lazy as _
 
@@ -168,7 +168,7 @@ class RelatedField(Field):
 
         return OrderedDict([
             (
-                force_text(self.to_representation(item), strings_only=True),
+                self.to_representation(item),
                 self.display_value(item)
             )
             for item in queryset

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -535,6 +535,8 @@ class TestCharField(FieldValues):
         'abc': 'abc'
     }
     invalid_inputs = {
+        (): ['Not a valid string.'],
+        True: ['Not a valid string.'],
         '': ['This field may not be blank.']
     }
     outputs = {

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -614,7 +614,7 @@ class TestRelationalFieldDisplayValue(TestCase):
                 fields = '__all__'
 
         serializer = TestSerializer()
-        expected = OrderedDict([('1', 'Red Color'), ('2', 'Yellow Color'), ('3', 'Green Color')])
+        expected = OrderedDict([(1, 'Red Color'), (2, 'Yellow Color'), (3, 'Green Color')])
         self.assertEqual(serializer.fields['color'].choices, expected)
 
     def test_custom_display_value(self):
@@ -630,7 +630,7 @@ class TestRelationalFieldDisplayValue(TestCase):
                 fields = '__all__'
 
         serializer = TestSerializer()
-        expected = OrderedDict([('1', 'My Red Color'), ('2', 'My Yellow Color'), ('3', 'My Green Color')])
+        expected = OrderedDict([(1, 'My Red Color'), (2, 'My Yellow Color'), (3, 'My Green Color')])
         self.assertEqual(serializer.fields['color'].choices, expected)
 
 


### PR DESCRIPTION
CharField now only accepts string and numeric types, and will raise a validation error on other inputs.

Closes #3394.