### PR TITLE
Add test to ensure blank parameters are preserved in next link

### DIFF
--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -108,6 +108,17 @@ class TestPaginationIntegration:
             'count': 50
         }
 
+    def test_additional_blank_query_params_are_preserved(self):
+        request = factory.get('/?foobar&page=2')
+        response = self.view(request)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            'results': [12, 14, 16, 18, 20],
+            'previous': 'http://testserver/?foobar',
+            'next': 'http://testserver/?foobar&page=3',
+            'count': 50
+        }
+
     def test_404_not_found_for_zero_page(self):
         request = factory.get('/', {'page': '0'})
         response = self.view(request)


### PR DESCRIPTION
This pull requests adds a test that checks to ensure blank parameters are preserved in the `next` link in paged results. This is related to issue #4393.
