### PR TITLE
fix a b0rked code example in the permissions section of api guide

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -92,7 +92,7 @@ Or, if you're using the `@api_view` decorator with function based views.
     from rest_framework.permissions import IsAuthenticated
     from rest_framework.response import Response
 
-    @api_view('GET')
+    @api_view(['GET'])
     @permission_classes((IsAuthenticated, ))
     def example_view(request, format=None):
         content = {


### PR DESCRIPTION
I think the [permissions section of the docs](http://www.django-rest-framework.org/api-guide/permissions/#setting-the-permission-policy) has an error in the code example concerning using the `@api_view` decorator with function based views.  