### PR TITLE
Fix template syntax error for `as_list_of_strings`

### DIFF
--- a/rest_framework/templates/rest_framework/vertical/checkbox_multiple.html
+++ b/rest_framework/templates/rest_framework/vertical/checkbox_multiple.html
@@ -9,7 +9,7 @@
     <div>
       {% for key, text in field.choices.items %}
         <label class="checkbox-inline">
-          <input type="checkbox" name="{{ field.name }}" value="{{ key }}" {% if key|as_string in field.value|as_list_of_stringsg %}checked{% endif %}>
+          <input type="checkbox" name="{{ field.name }}" value="{{ key }}" {% if key|as_string in field.value|as_list_of_strings %}checked{% endif %}>
             {{ text }}
         </label>
       {% endfor %}
@@ -18,7 +18,7 @@
     {% for key, text in field.choices.items %}
       <div class="checkbox">
         <label>
-          <input type="checkbox" name="{{ field.name }}" value="{{ key }}" {% if key|as_string in field.value|as_list_of_stringsg %}checked{% endif %}>
+          <input type="checkbox" name="{{ field.name }}" value="{{ key }}" {% if key|as_string in field.value|as_list_of_strings %}checked{% endif %}>
           {{ text }}
         </label>
       </div>


### PR DESCRIPTION
## Description

Fixes template syntax error for `as_list_of_strings` introduced in v3.4.4 from PR https://github.com/tomchristie/django-rest-framework/pull/4374
