### PR TITLE
Improve debug error handling

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -143,6 +143,7 @@ class Request(object):
         self._full_data = Empty
         self._content_type = Empty
         self._stream = Empty
+        self.debug_plaintext_traceback = None
 
         if self.parser_context is None:
             self.parser_context = {}
@@ -391,3 +392,8 @@ class Request(object):
             '`request.QUERY_PARAMS` has been deprecated in favor of `request.query_params` '
             'since version 3.0, and has been fully removed as of version 3.2.'
         )
+
+    def force_plaintext_errors(self, value):
+        # Hack to allow our exception handler to force choice of
+        # plaintext or html error responses.
+        self._request.is_ajax = lambda: value

--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -143,7 +143,6 @@ class Request(object):
         self._full_data = Empty
         self._content_type = Empty
         self._stream = Empty
-        self.debug_plaintext_traceback = None
 
         if self.parser_context is None:
             self.parser_context = {}

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -3,17 +3,14 @@ Provides an APIView class that is the base of all views in REST framework.
 """
 from __future__ import unicode_literals
 
-import sys
-
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.db import models
 from django.http import Http404
-from django.http.response import HttpResponse, HttpResponseBase
+from django.http.response import HttpResponseBase
 from django.utils import six
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _
-from django.views import debug
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
@@ -94,11 +91,6 @@ def exception_handler(exc, context):
 
         set_rollback()
         return Response(data, status=status.HTTP_403_FORBIDDEN)
-
-    # throw django's error page if debug is True
-    if settings.DEBUG:
-        exception_reporter = debug.ExceptionReporter(context.get('request'), *sys.exc_info())
-        return HttpResponse(exception_reporter.get_traceback_html(), status=500)
 
     return None
 
@@ -439,10 +431,17 @@ class APIView(View):
         response = exception_handler(exc, context)
 
         if response is None:
-            raise
+            self.raise_uncaught_exception(exc)
 
         response.exception = True
         return response
+
+    def raise_uncaught_exception(self, exc):
+        if settings.DEBUG:
+            renderer = self.request.accepted_renderer
+            use_plaintext_traceback = getattr(renderer, 'format') not in ('html', 'api')
+            self.request.force_plaintext_errors(use_plaintext_traceback)
+        raise
 
     # Note: Views are made CSRF exempt from within `as_view` as to prevent
     # accidental removal of this exemption in cases where `dispatch` needs to

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -438,9 +438,10 @@ class APIView(View):
 
     def raise_uncaught_exception(self, exc):
         if settings.DEBUG:
-            renderer = self.request.accepted_renderer
-            use_plaintext_traceback = getattr(renderer, 'format') not in ('html', 'api')
-            self.request.force_plaintext_errors(use_plaintext_traceback)
+            request = self.request
+            renderer_format = getattr(request.accepted_renderer, 'format')
+            use_plaintext_traceback = renderer_format not in ('html', 'api', 'admin')
+            request.force_plaintext_errors(use_plaintext_traceback)
         raise
 
     # Note: Views are made CSRF exempt from within `as_view` as to prevent


### PR DESCRIPTION
Closes #4409 

Ensures that Django's standard exception handling still runs in all uncaught cases, but forces the debug.technical_500_response to render in either plaintext or html, depending on the content negotiation that's taken place.

We have to implement a hack to achieving this, overriding the underlying `HTTPRequest.is_ajax()` method, however this is probably better than the alternative of reimplementing and keeping up to date with Django's exception handling inside REST framework.