### PR TITLE
Add django-rest-framework-roles to third party packages in permissions docs

### DIFF
--- a/docs/api-guide/permissions.md
+++ b/docs/api-guide/permissions.md
@@ -261,6 +261,10 @@ The [REST Condition][rest-condition] package is another extension for building c
 
 The [DRY Rest Permissions][dry-rest-permissions] package provides the ability to define different permissions for individual default and custom actions. This package is made for apps with permissions that are derived from relationships defined in the app's data model. It also supports permission checks being returned to a client app through the API's serializer. Additionally it supports adding permissions to the default and custom list actions to restrict the data they retrive per user.
 
+## Django Rest Framework Roles
+
+The [Django Rest Framework Roles][django-rest-framework-roles] package makes it easier to parameterize your API over multiple types of users.
+
 [cite]: https://developer.apple.com/library/mac/#documentation/security/Conceptual/AuthenticationAndAuthorizationGuide/Authorization/Authorization.html
 [authentication]: authentication.md
 [throttling]: throttling.md
@@ -275,3 +279,4 @@ The [DRY Rest Permissions][dry-rest-permissions] package provides the ability to
 [composed-permissions]: https://github.com/niwibe/djangorestframework-composed-permissions
 [rest-condition]: https://github.com/caxap/rest_condition
 [dry-rest-permissions]: https://github.com/Helioscene/dry-rest-permissions
+[django-rest-framework-roles]: https://github.com/computer-lab/django-rest-framework-roles


### PR DESCRIPTION
## Description

Adds a section linking to [django-rest-framework-roles](https://github.com/computer-lab/django-rest-framework-roles) in the _permissions_ docs.

## Testing

* Verified that `mkdocs build` runs.
* Verified that the rendered markdown looks pleasing with `mkdocs serve`