### PR TITLE
Error finding manage.py

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -22,7 +22,6 @@ Create a new Django project named `tutorial`, then start a new app called `quick
     django-admin.py startproject tutorial .  # Note the trailing '.' character
     cd tutorial
     django-admin.py startapp quickstart
-    cd ..
 
 Now sync your database for the first time:
 


### PR DESCRIPTION
When these commands are executed the way they're explained you get an error when you try to sync the database the first time:

(env) replaceafill@laptop:~/tutorial$ python manage.py migrate
python: can't open file 'manage.py': [Errno 2] No such file or directory

The reason is that after the quickstart app is created you have to stay in the tutorial project directory for this (and the rest of the commands below) to work.