### PR TITLE
Skip HiddenField from Schema fields

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -296,8 +296,9 @@ class SchemaGenerator(object):
 
         fields = []
         for field in serializer.fields.values():
-            if field.read_only:
+            if field.read_only or isinstance(field, serializers.HiddenField):
                 continue
+
             required = field.required and method != 'PATCH'
             description = force_text(field.help_text) if field.help_text else ''
             field = coreapi.Field(

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -26,6 +26,8 @@ class ExamplePagination(pagination.PageNumberPagination):
 class ExampleSerializer(serializers.Serializer):
     a = serializers.CharField(required=True, help_text='A field description')
     b = serializers.CharField(required=False)
+    read_only = serializers.CharField(read_only=True)
+    hidden = serializers.HiddenField(default='hello')
 
 
 class AnotherSerializer(serializers.Serializer):


### PR DESCRIPTION
## Description

Fixes #4425 by skipping HiddenField in SchemaGenerator.get_serializer_fields. Tests for HiddenField as well as serializer fields with `read_only=True`.