### PR TITLE
Throttling random request code example fix

### DIFF
--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -188,7 +188,7 @@ The following is an example of a rate throttle, that will randomly throttle 1 in
 
     class RandomRateThrottle(throttling.BaseThrottle):
         def allow_request(self, request, view):
-            return random.randint(1, 10) == 1
+            return random.randint(1, 10) != 1
 
 [cite]: https://dev.twitter.com/docs/error-codes-responses
 [permissions]: permissions.md


### PR DESCRIPTION
There was a mistake in this code example in article about throttling:

```python
import random

class RandomRateThrottle(throttling.BaseThrottle):
    def allow_request(self, request, view):
        return random.randint(1, 10) == 1
```

The description says it throttles one random request in each 10, while in reality it throttles 9 out of 10. Fixed this.