### PR TITLE
Russian localization typo fix

### DIFF
--- a/rest_framework/locale/ru/LC_MESSAGES/django.po
+++ b/rest_framework/locale/ru/LC_MESSAGES/django.po
@@ -338,7 +338,7 @@ msgstr "Недопустимый первичный ключ \"{pk_value}\" - о
 
 #: relations.py:208
 msgid "Incorrect type. Expected pk value, received {data_type}."
-msgstr "Некорректный тип. Ожилалось значение первичного ключа, получен {data_type}."
+msgstr "Некорректный тип. Ожидалось значение первичного ключа, получен {data_type}."
 
 #: relations.py:240
 msgid "Invalid hyperlink - No URL match."


### PR DESCRIPTION
Fixed little typo `ОжиЛалось` in Russian localization file.
