### PR TITLE
Fix APIClient.get() when path contains unicode arguments

### DIFF
--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -79,10 +79,13 @@ class APIRequestFactory(DjangoRequestFactory):
         r = {
             'QUERY_STRING': urlencode(data or {}, doseq=True),
         }
-        # Fix to support old behavior where you have the arguments in the url
-        # See #1461
         if not data and '?' in path:
-            r['QUERY_STRING'] = path.split('?')[1]
+            # Fix to support old behavior where you have the arguments in the
+            # url. See #1461.
+            query_string = force_bytes(path.split('?')[1])
+            if six.PY3:
+                query_string = query_string.decode('iso-8859-1')
+            r['QUERY_STRING'] = query_string
         r.update(extra)
         return self.generic('GET', path, **r)
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -245,3 +245,10 @@ class TestAPIRequestFactory(TestCase):
         self.assertEqual(dict(request.GET), {'demo': ['test']})
         request = factory.get('/view/', {'demo': 'test'})
         self.assertEqual(dict(request.GET), {'demo': ['test']})
+
+    def test_request_factory_url_arguments_with_unicode(self):
+        factory = APIRequestFactory()
+        request = factory.get('/view/?demo=testé')
+        self.assertEqual(dict(request.GET), {'demo': ['testé']})
+        request = factory.get('/view/', {'demo': 'testé'})
+        self.assertEqual(dict(request.GET), {'demo': ['testé']})


### PR DESCRIPTION
If the URL contains unicode arguments, `APIClient` and `APIRequestFactory` `.get()` cause an exception to be raised when the request query dict is accessed, because we end up with an unicode `QUERY_STRING` and that's not what django expects. 

Without this patch (which is [adapted from django](https://github.com/django/django/blob/5bd967e1c52bfe811daffaccd3ef8964f8a3cb35/django/test/client.py#L402-L408)), the test I've added fails with:

```
tests/test_testing.py:252: in test_request_factory_url_arguments_with_unicode
    self.assertEqual(dict(request.GET), {'demo': [u'testé']})
../../.virtualenvs/drf-testing/local/lib/python2.7/site-packages/django/utils/functional.py:35: in __get__
    res = instance.__dict__[self.name] = self.func(instance)
../../.virtualenvs/drf-testing/local/lib/python2.7/site-packages/django/core/handlers/wsgi.py:124: in GET
    return http.QueryDict(raw_query_string, encoding=self._encoding)
../../.virtualenvs/drf-testing/local/lib/python2.7/site-packages/django/http/request.py:398: in __init__
    value = value.decode(encoding)
../../.virtualenvs/drf-testing/lib/python2.7/encodings/utf_8.py:16: in decode
    return codecs.utf_8_decode(input, errors, True)
E   UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 4: ordinal not in range(128)
```