### PR TITLE
Add ability to disable permissions check in schema generation

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -9,6 +9,7 @@ from django.utils.encoding import force_text
 from rest_framework import exceptions, serializers
 from rest_framework.compat import coreapi, uritemplate, urlparse
 from rest_framework.request import clone_request
+from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 
@@ -88,10 +89,11 @@ class SchemaGenerator(object):
 
             if request is not None:
                 view.request = clone_request(request, method)
-                try:
-                    view.check_permissions(view.request)
-                except exceptions.APIException:
-                    continue
+                if api_settings.SCHEMA_CHECK_PERMISSIONS:
+                    try:
+                        view.check_permissions(view.request)
+                    except exceptions.APIException:
+                        continue
             else:
                 view.request = None
 

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -9,7 +9,6 @@ from django.utils.encoding import force_text
 from rest_framework import exceptions, serializers
 from rest_framework.compat import coreapi, uritemplate, urlparse
 from rest_framework.request import clone_request
-from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 
@@ -89,11 +88,8 @@ class SchemaGenerator(object):
 
             if request is not None:
                 view.request = clone_request(request, method)
-                if api_settings.SCHEMA_CHECK_PERMISSIONS:
-                    try:
-                        view.check_permissions(view.request)
-                    except exceptions.APIException:
-                        continue
+                if not self.check_view_permission(view):
+                    continue
             else:
                 view.request = None
 
@@ -165,6 +161,13 @@ class SchemaGenerator(object):
         if path == '/':
             return False  # Ignore the root endpoint.
 
+        return True
+
+    def check_view_permission(self, view):
+        try:
+            view.check_permissions(view.request)
+        except exceptions.APIException:
+            return False
         return True
 
     def get_allowed_methods(self, callback):

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -84,9 +84,6 @@ DEFAULTS = {
     'EXCEPTION_HANDLER': 'rest_framework.views.exception_handler',
     'NON_FIELD_ERRORS_KEY': 'non_field_errors',
 
-    # Schema generation
-    'SCHEMA_CHECK_PERMISSIONS': True,
-
     # Testing
     'TEST_REQUEST_RENDERER_CLASSES': (
         'rest_framework.renderers.MultiPartRenderer',

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -84,6 +84,9 @@ DEFAULTS = {
     'EXCEPTION_HANDLER': 'rest_framework.views.exception_handler',
     'NON_FIELD_ERRORS_KEY': 'non_field_errors',
 
+    # Schema generation
+    'SCHEMA_CHECK_PERMISSIONS': True,
+
     # Testing
     'TEST_REQUEST_RENDERER_CLASSES': (
         'rest_framework.renderers.MultiPartRenderer',


### PR DESCRIPTION
## Description

Sometimes permission check in schema generation is hard, useless or both. For example if permission rely on some http request data. Or if one's want to provide full schema to everyone. Or schema will be provided only for develop, not for production.

I propose to add option to completely disable permission check during schema generation. Checks are on by default.

There is possible security concern (potentially will expose more info about site's inner parts than client could get otherwise), but I don't know what is DRF security policy about schema generation.