### PR TITLE
Fixed an issue where the incorrect value is set to ResolverMatch.func_name of api_view decorated view  #4462

### DIFF
--- a/rest_framework/decorators.py
+++ b/rest_framework/decorators.py
@@ -55,6 +55,7 @@ def api_view(http_method_names=None):
             setattr(WrappedAPIView, method.lower(), handler)
 
         WrappedAPIView.__name__ = func.__name__
+        WrappedAPIView.__module__ = func.__module__
 
         WrappedAPIView.renderer_classes = getattr(func, 'renderer_classes',
                                                   APIView.renderer_classes)


### PR DESCRIPTION
When run the `django.core.urlresolvers.resolve ( '/')` to the @api_view decorated function, ResolverMatch.func_name has been set a invalid dotted name

https://github.com/tomchristie/django-rest-framework/issues/4462