### PR TITLE
Store initkwargs as view class attribute for schema discovery.

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -130,6 +130,7 @@ class APIView(View):
 
         view = super(APIView, cls).as_view(**initkwargs)
         view.cls = cls
+        view.initkwagrs = initkwargs
 
         # Note: session based authentication is explicitly CSRF validated,
         # all other authentication is CSRF exempt.


### PR DESCRIPTION
I have a problem with schema discovery. Mine `get_queryset` implementation of generic views requires some attributes pre-set for the view, that happens in `.as_view` method. But `as_view` attributes is lost, if the APIView used. Currently, rest_framework keeps `initkwargs` only for views created from a Viewset.

This change makes API Views consistent with views from [Viewsets](https://github.com/kmmbvnr/django-rest-framework/blob/master/rest_framework/viewsets.py#L100) during API schema [discovery](https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/schemas.py#L76)

