### PR TITLE
Update to correct location of reverse relation doc

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -442,7 +442,7 @@ Declaring a `ModelSerializer` looks like this:
 
 By default, all the model fields on the class will be mapped to a corresponding serializer fields.
 
-Any relationships such as foreign keys on the model will be mapped to `PrimaryKeyRelatedField`. Reverse relationships are not included by default unless explicitly included as specified in [serializer relations][relations].
+Any relationships such as foreign keys on the model will be mapped to `PrimaryKeyRelatedField`. Reverse relationships are not included by default unless explicitly included as specified in the [serializer relations][relations] documentation.
 
 #### Inspecting a `ModelSerializer`
 

--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -442,7 +442,7 @@ Declaring a `ModelSerializer` looks like this:
 
 By default, all the model fields on the class will be mapped to a corresponding serializer fields.
 
-Any relationships such as foreign keys on the model will be mapped to `PrimaryKeyRelatedField`. Reverse relationships are not included by default unless explicitly included as described below.
+Any relationships such as foreign keys on the model will be mapped to `PrimaryKeyRelatedField`. Reverse relationships are not included by default unless explicitly included as specified in [serializer relations][relations].
 
 #### Inspecting a `ModelSerializer`
 


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/tomchristie/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

There was a part in the docs that said reverse relations were explained "below" but they were actually referenced in the serializer relations file. Fixed to include the link to the proper file

