### PR TITLE
Fix indentation regression in API listing

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -150,10 +150,10 @@
               </div>
 
               <div class="response-info">
-                <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}
-  {% for key, val in response_headers.items %}<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>
-  {% endfor %}
-  </span>{{ content|urlize_quoted_links }}</pre>{% endautoescape %}
+                <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}{% for key, val in response_headers.items %}
+<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>{% endfor %}
+
+</span>{{ content|urlize_quoted_links }}</pre>{% endautoescape %}
               </div>
             </div>
 


### PR DESCRIPTION
## Description

In commit 5392be4ddba37da3e50c3feabc8b3b1c944481a8, there was a [change made](https://github.com/tomchristie/django-rest-framework/commit/5392be4ddba37da3e50c3feabc8b3b1c944481a8#diff-261afecdd8ae47666b7560a36e554180R153) when cleaning up the template for the API listing that caused 2 spaces to appear before every header item (except the first) and before the first line of the body of the response. This meant that the API listing often looked like:

```
HTTP 200 OK
  Allow: GET, OPTIONS
  Content-Type: application/json
  Vary: Accept

  {
    "key": "value",
    "key2": "value2"
}
```

This change removes those leading spaces, so that it will now look like:

```
HTTP 200 OK
Allow: GET, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "key": "value",
    "key2": "value2"
}
```
