### PR TITLE
Fix response rendering with empty context

### DIFF
--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -56,7 +56,7 @@ class Response(SimpleTemplateResponse):
 
         assert renderer, ".accepted_renderer not set on Response"
         assert accepted_media_type, ".accepted_media_type not set on Response"
-        assert context, ".renderer_context not set on Response"
+        assert context is not None, ".renderer_context not set on Response"
         context['response'] = self
 
         media_type = renderer.media_type


### PR DESCRIPTION
This PR allows `response.render` to be called when `response.rendered_context == {}`.

I believe this should be allowed, since if [the JSONRenderer, for example](https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/renderers.py#L85-L92) receives a `None` context, it sets it to an empty dictionary itself.