### PR TITLE
Fix 1.10 deprecation warnings

### DIFF
--- a/docs/api-guide/reverse.md
+++ b/docs/api-guide/reverse.md
@@ -23,7 +23,7 @@ There's no requirement for you to use them, but if you do then the self-describi
 
 **Signature:** `reverse(viewname, *args, **kwargs)`
 
-Has the same behavior as [`django.core.urlresolvers.reverse`][reverse], except that it returns a fully qualified URL, using the request to determine the host and port.
+Has the same behavior as [`django.urls.reverse`][reverse], except that it returns a fully qualified URL, using the request to determine the host and port.
 
 You should **include the request as a keyword argument** to the function, for example:
 
@@ -44,7 +44,7 @@ You should **include the request as a keyword argument** to the function, for ex
 
 **Signature:** `reverse_lazy(viewname, *args, **kwargs)`
 
-Has the same behavior as [`django.core.urlresolvers.reverse_lazy`][reverse-lazy], except that it returns a fully qualified URL, using the request to determine the host and port.
+Has the same behavior as [`django.urls.reverse_lazy`][reverse-lazy], except that it returns a fully qualified URL, using the request to determine the host and port.
 
 As with the `reverse` function, you should **include the request as a keyword argument** to the function, for example:
 

--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -197,7 +197,7 @@ REST framework includes the following test case classes, that mirror the existin
 
 You can use any of REST framework's test case classes as you would for the regular Django test case classes.  The `self.client` attribute will be an `APIClient` instance.
 
-    from django.core.urlresolvers import reverse
+    from django.urls import reverse
     from rest_framework import status
     from rest_framework.test import APITestCase
     from myproject.apps.core.models import Account

--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,5 +1,5 @@
 # Optional packages which may be used with REST framework.
 markdown==2.6.4
-django-guardian==1.4.3
-django-filter==0.13.0
+django-guardian==1.4.6
+django-filter==0.14.0
 coreapi==1.32.0

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -216,8 +216,13 @@ try:
 
     if markdown.version <= '2.2':
         HEADERID_EXT_PATH = 'headerid'
-    else:
+        LEVEL_PARAM = 'level'
+    elif markdown.version < '2.6':
         HEADERID_EXT_PATH = 'markdown.extensions.headerid'
+        LEVEL_PARAM = 'level'
+    else:
+        HEADERID_EXT_PATH = 'markdown.extensions.toc'
+        LEVEL_PARAM = 'baselevel'
 
     def apply_markdown(text):
         """
@@ -227,7 +232,7 @@ try:
         extensions = [HEADERID_EXT_PATH]
         extension_configs = {
             HEADERID_EXT_PATH: {
-                'level': '2'
+                LEVEL_PARAM: '2'
             }
         }
         md = markdown.Markdown(

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -24,6 +24,16 @@ except ImportError:
 
 
 try:
+    from django.urls import (
+        NoReverseMatch, RegexURLPattern, RegexURLResolver, ResolverMatch, Resolver404, get_script_prefix, reverse, reverse_lazy, resolve
+    )
+except ImportError:
+    from django.core.urlresolvers import (  # Will be removed in Django 2.0
+        NoReverseMatch, RegexURLPattern, RegexURLResolver, ResolverMatch, Resolver404, get_script_prefix, reverse, reverse_lazy, resolve
+    )
+
+
+try:
     import urlparse  # Python 2.x
 except ImportError:
     import urllib.parse as urlparse

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -277,3 +277,11 @@ def template_render(template, context=None, request=None):
     # backends template, e.g. django.template.backends.django.Template
     else:
         return template.render(context, request=request)
+
+
+def set_many(instance, field, value):
+    if django.VERSION < (1, 10):
+        setattr(instance, field, value)
+    else:
+        field = getattr(instance, field)
+        field.set(value)

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -138,6 +138,12 @@ def is_authenticated(user):
     return user.is_authenticated
 
 
+def is_anonymous(user):
+    if django.VERSION < (1, 10):
+        return user.is_anonymous()
+    return user.is_anonymous
+
+
 def get_related_model(field):
     if django.VERSION < (1, 9):
         return _resolve_model(field.rel.to)

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -53,6 +53,18 @@ def is_simple_callable(obj):
     """
     True if the object is a callable that takes no arguments.
     """
+    if not hasattr(inspect, 'signature'):
+        return py2k_is_simple_callable(obj)
+
+    if not callable(obj):
+        return False
+
+    sig = inspect.signature(obj)
+    params = sig.parameters.values()
+    return all(param.default != param.empty for param in params)
+
+
+def py2k_is_simple_callable(obj):
     function = inspect.isfunction(obj)
     method = inspect.ismethod(obj)
 

--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -4,9 +4,6 @@ from __future__ import unicode_literals
 from collections import OrderedDict
 
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
-from django.core.urlresolvers import (
-    NoReverseMatch, Resolver404, get_script_prefix, resolve
-)
 from django.db.models import Manager
 from django.db.models.query import QuerySet
 from django.utils import six
@@ -14,6 +11,9 @@ from django.utils.encoding import python_2_unicode_compatible, smart_text
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.translation import ugettext_lazy as _
 
+from rest_framework.compat import (
+    NoReverseMatch, Resolver404, get_script_prefix, resolve
+)
 from rest_framework.fields import (
     Field, empty, get_attribute, is_simple_callable, iter_options
 )

--- a/rest_framework/reverse.py
+++ b/rest_framework/reverse.py
@@ -3,11 +3,11 @@ Provide urlresolver functions that return fully qualified URLs or view names
 """
 from __future__ import unicode_literals
 
-from django.core.urlresolvers import reverse as django_reverse
-from django.core.urlresolvers import NoReverseMatch
 from django.utils import six
 from django.utils.functional import lazy
 
+from rest_framework.compat import reverse as django_reverse
+from rest_framework.compat import NoReverseMatch
 from rest_framework.settings import api_settings
 from rest_framework.utils.urls import replace_query_param
 
@@ -54,7 +54,7 @@ def reverse(viewname, args=None, kwargs=None, request=None, format=None, **extra
 
 def _reverse(viewname, args=None, kwargs=None, request=None, format=None, **extra):
     """
-    Same as `django.core.urlresolvers.reverse`, but optionally takes a request
+    Same as `django.urls.reverse`, but optionally takes a request
     and returns a fully qualified URL, using the request to get the base URL.
     """
     if format is not None:

--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -20,9 +20,9 @@ from collections import OrderedDict, namedtuple
 
 from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import NoReverseMatch
 
 from rest_framework import exceptions, renderers, views
+from rest_framework.compat import NoReverseMatch
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.schemas import SchemaGenerator

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -2,12 +2,13 @@ from importlib import import_module
 
 from django.conf import settings
 from django.contrib.admindocs.views import simplify_regex
-from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
 from django.utils import six
 from django.utils.encoding import force_text
 
 from rest_framework import exceptions, serializers
-from rest_framework.compat import coreapi, uritemplate, urlparse
+from rest_framework.compat import (
+    RegexURLPattern, RegexURLResolver, coreapi, uritemplate, urlparse
+)
 from rest_framework.request import clone_request
 from rest_framework.views import APIView
 

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -3,14 +3,13 @@ from __future__ import absolute_import, unicode_literals
 import re
 
 from django import template
-from django.core.urlresolvers import NoReverseMatch, reverse
 from django.template import loader
 from django.utils import six
 from django.utils.encoding import force_text, iri_to_uri
 from django.utils.html import escape, format_html, smart_urlquote
 from django.utils.safestring import SafeData, mark_safe
 
-from rest_framework.compat import template_render
+from rest_framework.compat import NoReverseMatch, reverse, template_render
 from rest_framework.renderers import HTMLFormRenderer
 from rest_framework.utils.urls import replace_query_param
 

--- a/rest_framework/urlpatterns.py
+++ b/rest_framework/urlpatterns.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
 from django.conf.urls import include, url
-from django.core.urlresolvers import RegexURLResolver
 
+from rest_framework.compat import RegexURLResolver
 from rest_framework.settings import api_settings
 
 

--- a/rest_framework/utils/breadcrumbs.py
+++ b/rest_framework/utils/breadcrumbs.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from django.core.urlresolvers import get_script_prefix, resolve
+from rest_framework.compat import get_script_prefix, resolve
 
 
 def get_breadcrumbs(url, request=None):

--- a/tests/browsable_api/test_form_rendering.py
+++ b/tests/browsable_api/test_form_rendering.py
@@ -11,6 +11,7 @@ factory = APIRequestFactory()
 class BasicSerializer(serializers.ModelSerializer):
     class Meta:
         model = BasicModel
+        fields = '__all__'
 
 
 class ManyPostView(generics.GenericAPIView):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
 def pytest_configure():
     from django.conf import settings
 
+    MIDDLEWARE = (
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+    )
+
     settings.configure(
         DEBUG_PROPAGATE_EXCEPTIONS=True,
         DATABASES={
@@ -21,12 +28,8 @@ def pytest_configure():
                 'APP_DIRS': True,
             },
         ],
-        MIDDLEWARE_CLASSES=(
-            'django.middleware.common.CommonMiddleware',
-            'django.contrib.sessions.middleware.SessionMiddleware',
-            'django.contrib.auth.middleware.AuthenticationMiddleware',
-            'django.contrib.messages.middleware.MessageMiddleware',
-        ),
+        MIDDLEWARE=MIDDLEWARE,
+        MIDDLEWARE_CLASSES=MIDDLEWARE,
         INSTALLED_APPS=(
             'django.contrib.auth',
             'django.contrib.contenttypes',

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -20,6 +20,7 @@ from rest_framework.authentication import (
 )
 from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import obtain_auth_token
+from rest_framework.compat import is_authenticated
 from rest_framework.response import Response
 from rest_framework.test import APIClient, APIRequestFactory
 from rest_framework.views import APIView
@@ -408,7 +409,7 @@ class FailingAuthAccessedInRenderer(TestCase):
 
             def render(self, data, media_type=None, renderer_context=None):
                 request = renderer_context['request']
-                if request.user.is_authenticated():
+                if is_authenticated(request.user):
                     return b'authenticated'
                 return b'not authenticated'
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -456,7 +456,7 @@ class AttributeModel(models.Model):
 
 class SearchFilterModelFk(models.Model):
     title = models.CharField(max_length=20)
-    attribute = models.ForeignKey(AttributeModel)
+    attribute = models.ForeignKey(AttributeModel, on_delete=models.CASCADE)
 
 
 class SearchFilterFkSerializer(serializers.ModelSerializer):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -76,6 +76,7 @@ if django_filters:
 
         class Meta:
             model = BaseFilterableItem
+            fields = '__all__'
 
     class BaseFilterableItemFilterRootView(generics.ListCreateAPIView):
         queryset = FilterableItem.objects.all()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 
 from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
 from django.db import models
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -14,7 +13,7 @@ from django.utils.dateparse import parse_date
 from django.utils.six.moves import reload_module
 
 from rest_framework import filters, generics, serializers, status
-from rest_framework.compat import django_filters
+from rest_framework.compat import django_filters, reverse
 from rest_framework.test import APIRequestFactory
 
 from .models import BaseFilterableItem, BasicModel, FilterableItem

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -962,7 +962,7 @@ class OneToOneTargetTestModel(models.Model):
 
 
 class OneToOneSourceTestModel(models.Model):
-    target = models.OneToOneField(OneToOneTargetTestModel, primary_key=True)
+    target = models.OneToOneField(OneToOneTargetTestModel, primary_key=True, on_delete=models.CASCADE)
 
 
 class TestModelFieldValues(TestCase):
@@ -990,6 +990,7 @@ class TestUniquenessOverride(TestCase):
         class TestSerializer(serializers.ModelSerializer):
             class Meta:
                 model = TestModel
+                fields = '__all__'
                 extra_kwargs = {'field_1': {'required': False}}
 
         fields = TestSerializer().fields

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -20,7 +20,7 @@ from django.test import TestCase
 from django.utils import six
 
 from rest_framework import serializers
-from rest_framework.compat import unicode_repr
+from rest_framework.compat import set_many, unicode_repr
 
 
 def dedent(blocktext):
@@ -651,7 +651,7 @@ class TestIntegration(TestCase):
             foreign_key=self.foreign_key_target,
             one_to_one=self.one_to_one_target,
         )
-        self.instance.many_to_many = self.many_to_many_targets
+        set_many(self.instance, 'many_to_many', self.many_to_many_targets)
         self.instance.save()
 
     def test_pk_retrival(self):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -4,7 +4,6 @@ import base64
 import unittest
 
 from django.contrib.auth.models import Group, Permission, User
-from django.core.urlresolvers import ResolverMatch
 from django.db import models
 from django.test import TestCase
 
@@ -12,7 +11,7 @@ from rest_framework import (
     HTTP_HEADER_ENCODING, authentication, generics, permissions, serializers,
     status
 )
-from rest_framework.compat import guardian, set_many
+from rest_framework.compat import ResolverMatch, guardian, set_many
 from rest_framework.filters import DjangoObjectPermissionsFilter
 from rest_framework.routers import DefaultRouter
 from rest_framework.test import APIRequestFactory

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -12,7 +12,7 @@ from rest_framework import (
     HTTP_HEADER_ENCODING, authentication, generics, permissions, serializers,
     status
 )
-from rest_framework.compat import guardian
+from rest_framework.compat import guardian, set_many
 from rest_framework.filters import DjangoObjectPermissionsFilter
 from rest_framework.routers import DefaultRouter
 from rest_framework.test import APIRequestFactory
@@ -74,15 +74,15 @@ class ModelPermissionsIntegrationTests(TestCase):
     def setUp(self):
         User.objects.create_user('disallowed', 'disallowed@example.com', 'password')
         user = User.objects.create_user('permitted', 'permitted@example.com', 'password')
-        user.user_permissions = [
+        set_many(user, 'user_permissions', [
             Permission.objects.get(codename='add_basicmodel'),
             Permission.objects.get(codename='change_basicmodel'),
             Permission.objects.get(codename='delete_basicmodel')
-        ]
+        ])
         user = User.objects.create_user('updateonly', 'updateonly@example.com', 'password')
-        user.user_permissions = [
+        set_many(user, 'user_permissions', [
             Permission.objects.get(codename='change_basicmodel'),
-        ]
+        ])
 
         self.permitted_credentials = basic_auth_header('permitted', 'password')
         self.disallowed_credentials = basic_auth_header('disallowed', 'password')

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -13,6 +13,7 @@ from django.utils import six
 
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
+from rest_framework.compat import is_anonymous
 from rest_framework.parsers import BaseParser, FormParser, MultiPartParser
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -169,9 +170,9 @@ class TestUserSetter(TestCase):
 
     def test_user_can_logout(self):
         self.request.user = self.user
-        self.assertFalse(self.request.user.is_anonymous())
+        self.assertFalse(is_anonymous(self.request.user))
         logout(self.request)
-        self.assertTrue(self.request.user.is_anonymous())
+        self.assertTrue(is_anonymous(self.request.user))
 
     def test_logged_in_user_is_set_on_wrapped_request(self):
         login(self.request, self.user)

--- a/tests/test_reverse.py
+++ b/tests/test_reverse.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals
 
 from django.conf.urls import url
-from django.core.urlresolvers import NoReverseMatch
 from django.test import TestCase, override_settings
 
+from rest_framework.compat import NoReverseMatch
 from rest_framework.reverse import reverse
 from rest_framework.test import APIRequestFactory
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -215,4 +215,4 @@ class TestSchemaGenerator(TestCase):
                 }
             }
         )
-        self.assertEquals(schema, expected)
+        self.assertEqual(schema, expected)

--- a/tests/test_urlpatterns.py
+++ b/tests/test_urlpatterns.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 from collections import namedtuple
 
 from django.conf.urls import include, url
-from django.core import urlresolvers
 from django.test import TestCase
 
+from rest_framework.compat import RegexURLResolver, Resolver404
 from rest_framework.test import APIRequestFactory
 from rest_framework.urlpatterns import format_suffix_patterns
 
@@ -28,7 +28,7 @@ class FormatSuffixTests(TestCase):
             urlpatterns = format_suffix_patterns(urlpatterns)
         except Exception:
             self.fail("Failed to apply `format_suffix_patterns` on  the supplied urlpatterns")
-        resolver = urlresolvers.RegexURLResolver(r'^/', urlpatterns)
+        resolver = RegexURLResolver(r'^/', urlpatterns)
         for test_path in test_paths:
             request = factory.get(test_path.path)
             try:
@@ -43,7 +43,7 @@ class FormatSuffixTests(TestCase):
         urlpatterns = format_suffix_patterns([
             url(r'^test/$', dummy_view),
         ])
-        resolver = urlresolvers.RegexURLResolver(r'^/', urlpatterns)
+        resolver = RegexURLResolver(r'^/', urlpatterns)
 
         test_paths = [
             (URLTestPath('/test.api', (), {'format': 'api'}), True),
@@ -55,7 +55,7 @@ class FormatSuffixTests(TestCase):
             request = factory.get(test_path.path)
             try:
                 callback, callback_args, callback_kwargs = resolver.resolve(request.path_info)
-            except urlresolvers.Resolver404:
+            except Resolver404:
                 callback, callback_args, callback_kwargs = (None, None, None)
             if not expected_resolved:
                 assert callback is None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.urlresolvers import NoReverseMatch
+from rest_framework.compat import NoReverseMatch
 
 
 class MockObject(object):


### PR DESCRIPTION
Sorry to recreate #4488 - had to switch branches.

----

## Description

Fixes a number of deprecation warnings generated by DRF. The to-many fix is the only one that really concerns me, as it makes a call to `model_meta.get_field_info`. Not sure if there's a better way to pass that information to the `create`/`update` methods.

There isn't really an easy way to test this without manually running the tests with the `-Werror` flag. That said, django-guardian also generates a number of [warnings](/django-guardian/django-guardian/pull/460) too. Just to test it out, you can install my fork, which has the fixes applied.