### PR TITLE
Deprecate DjangoFilterBackend

### DIFF
--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,5 +1,5 @@
 # Optional packages which may be used with REST framework.
 markdown==2.6.4
 django-guardian==1.4.3
-django-filter==0.13.0
+django-filter==0.15.0
 coreapi==1.32.0

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import datetime
 import unittest
+import warnings
 from decimal import Decimal
 
 from django.conf.urls import url
@@ -133,6 +134,39 @@ class IntegrationTestFiltering(CommonFilteringTestCase):
     """
     Integration tests for filtered list views.
     """
+
+    @unittest.skipUnless(django_filters, 'django-filter not installed')
+    def test_backend_deprecation(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            view = FilterFieldsRootView.as_view()
+            request = factory.get('/')
+            response = view(request).render()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, self.data)
+
+        self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+        self.assertIn("'rest_framework.filters.DjangoFilterBackend' has been deprecated", str(w[-1].message))
+
+    @unittest.skipUnless(django_filters, 'django-filter not installed')
+    def test_no_df_deprecation(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            import django_filters.rest_framework
+
+            class DFFilterFieldsRootView(FilterFieldsRootView):
+                filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
+
+            view = DFFilterFieldsRootView.as_view()
+            request = factory.get('/')
+            response = view(request).render()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, self.data)
+        self.assertEqual(len(w), 0)
 
     @unittest.skipUnless(django_filters, 'django-filter not installed')
     def test_get_filtered_fields_root_view(self):


### PR DESCRIPTION
Attempts to resolve #3371. The deprecation assumes/asserts the presence of the migrated django-filter backend, which requires the recent `0.15` release. Because of the dependency version bump, it might be appropriate to save this for DRF `3.5`?
