### PR TITLE
Fix is_simple_callable py3k compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
     - TOX_ENV=py35-django18
     - TOX_ENV=py34-django18
     - TOX_ENV=py33-django18
-    - TOX_ENV=py32-django18
     - TOX_ENV=py27-django18
     - TOX_ENV=py27-django110
     - TOX_ENV=py35-django110

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import re
+import unittest
 import uuid
 from decimal import Decimal
 
@@ -11,6 +12,67 @@ from django.utils import six, timezone
 
 import rest_framework
 from rest_framework import serializers
+from rest_framework.fields import is_simple_callable
+
+try:
+    import typings
+except ImportError:
+    typings = False
+
+
+# Tests for helper functions.
+# ---------------------------
+
+class TestIsSimpleCallable:
+
+    def test_method(self):
+        class Foo:
+            @classmethod
+            def classmethod(cls):
+                pass
+
+            def valid(self):
+                pass
+
+            def valid_kwargs(self, param='value'):
+                pass
+
+            def invalid(self, param):
+                pass
+
+        assert is_simple_callable(Foo.classmethod)
+
+        # unbound methods
+        assert not is_simple_callable(Foo.valid)
+        assert not is_simple_callable(Foo.valid_kwargs)
+        assert not is_simple_callable(Foo.invalid)
+
+        # bound methods
+        assert is_simple_callable(Foo().valid)
+        assert is_simple_callable(Foo().valid_kwargs)
+        assert not is_simple_callable(Foo().invalid)
+
+    def test_function(self):
+        def simple():
+            pass
+
+        def valid(param='value', param2='value'):
+            pass
+
+        def invalid(param, param2='value'):
+            pass
+
+        assert is_simple_callable(simple)
+        assert is_simple_callable(valid)
+        assert not is_simple_callable(invalid)
+
+    @unittest.skipUnless(typings, 'requires python 3.5')
+    def test_type_annotation(self):
+        # The annotation will otherwise raise a syntax error in python < 3.5
+        exec("def valid(param: str='value'):  pass", locals())
+        valid = locals()['valid']
+
+        assert is_simple_callable(valid)
 
 
 # Tests for field keyword arguments and core functionality.

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ addopts=--tb=short
 [tox]
 envlist =
        py27-{lint,docs},
-       {py27,py32,py33,py34,py35}-django18,
+       {py27,py33,py34,py35}-django18,
        {py27,py34,py35}-django19,
        {py27,py34,py35}-django110,
        {py27,py34,py35}-django{master}
@@ -25,7 +25,6 @@ basepython =
     py35: python3.5
     py34: python3.4
     py33: python3.3
-    py32: python3.2
     py27: python2.7
 
 [testenv:py27-lint]


### PR DESCRIPTION
Supersedes and closes #4508. Also fixes, #4506.