### PR TITLE
Remove code for old Django versions

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -126,7 +126,6 @@ class APIView(View):
                     'Use `.all()` or call `.get_queryset()` instead.'
                 )
             cls.queryset._fetch_all = force_evaluation
-            cls.queryset._result_iter = force_evaluation  # Django <= 1.5
 
         view = super(APIView, cls).as_view(**initkwargs)
         view.cls = cls

--- a/rest_framework/viewsets.py
+++ b/rest_framework/viewsets.py
@@ -79,10 +79,6 @@ class ViewSetMixin(object):
                 handler = getattr(self, action)
                 setattr(self, method, handler)
 
-            # Patch this in as it's otherwise only present from 1.5 onwards
-            if hasattr(self, 'get') and not hasattr(self, 'head'):
-                self.head = self.get
-
             # And continue as usual
             return self.dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
Hello! As Django versions <= 1.5 are unsupported, then this code is not required