### PR TITLE
Add a test for inactive users with token auth.

### DIFF
--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -349,6 +349,25 @@ class TokenAuthTests(BaseTokenAuthTests, TestCase):
             format='json'
         )
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data['non_field_errors'],
+                         [u'Unable to log in with provided credentials.', ])
+
+    def test_token_login_json_inactive_user(self):
+        """
+        Ensure token login view using JSON POST fails if
+        an inactive user is given.
+        """
+        self.user.is_active = False
+        self.user.save()
+        client = APIClient(enforce_csrf_checks=True)
+        response = client.post(
+            '/auth-token/',
+            {'username': self.username, 'password': self.password},
+            format='json'
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data['non_field_errors'],
+                         [u'User account is disabled.', ])
 
     def test_token_login_json_missing_fields(self):
         """Ensure token login view using JSON POST fails if missing fields."""


### PR DESCRIPTION
Related to this issue: https://github.com/tomchristie/django-rest-framework/issues/4520

Add for ObtainAuthToken to make sure it returns "User account is disabled." for inactive users.
