### PR TITLE
Update tox.ini to use latests versions of Django without changing this

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,9 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
        PYTHONWARNINGS=once
 deps =
-        django18: Django==1.8.15
-        django19: Django==1.9.10
-        django110: Django==1.10
+        django18: Django<1.9
+        django19: Django<1.10
+        django110: Django<1.11
         djangomaster: https://github.com/django/django/archive/master.tar.gz
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt


### PR DESCRIPTION
This is a silly change on tox.ini in order to avoid creating a commit for every django minor release, this will link directly to the latest release of the version that is tested.