### PR TITLE
Case insensitive uniqueness validation

### DIFF
--- a/docs/api-guide/validators.md
+++ b/docs/api-guide/validators.md
@@ -61,6 +61,7 @@ It takes a single required argument, and an optional `messages` argument:
 
 * `queryset` *required* - This is the queryset against which uniqueness should be enforced.
 * `message` - The error message that should be used when validation fails.
+* `lookup` - The lookup used to find an existing instance with the value being validated. Defaults to `'exact'`.
 
 This validator should be applied to *serializer fields*, like so:
 

--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -42,11 +42,11 @@ class UniqueValidator(object):
     """
     message = _('This field must be unique.')
 
-    def __init__(self, queryset, message=None, ignore_case=True):
+    def __init__(self, queryset, message=None, lookup='exact'):
         self.queryset = queryset
         self.serializer_field = None
         self.message = message or self.message
-        self.ignore_case = ignore_case
+        self.lookup = lookup
 
     def set_context(self, serializer_field):
         """
@@ -63,8 +63,7 @@ class UniqueValidator(object):
         """
         Filter the queryset to all instances matching the given attribute.
         """
-        field_lookup = 'iexact' if self.ignore_case else 'exact'
-        filter_kwargs = {'%s__%s' % (self.field_name, field_lookup): value}
+        filter_kwargs = {'%s__%s' % (self.field_name, self.lookup): value}
         return qs_filter(queryset, **filter_kwargs)
 
     def exclude_current_instance(self, queryset):

--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -42,11 +42,11 @@ class UniqueValidator(object):
     """
     message = _('This field must be unique.')
 
-    def __init__(self, queryset, ignore_case=True, message=None):
+    def __init__(self, queryset, message=None, ignore_case=True):
         self.queryset = queryset
         self.serializer_field = None
-        self.ignore_case = ignore_case
         self.message = message or self.message
+        self.ignore_case = ignore_case
 
     def set_context(self, serializer_field):
         """

--- a/rest_framework/validators.py
+++ b/rest_framework/validators.py
@@ -42,9 +42,10 @@ class UniqueValidator(object):
     """
     message = _('This field must be unique.')
 
-    def __init__(self, queryset, message=None):
+    def __init__(self, queryset, ignore_case=True, message=None):
         self.queryset = queryset
         self.serializer_field = None
+        self.ignore_case = ignore_case
         self.message = message or self.message
 
     def set_context(self, serializer_field):
@@ -62,7 +63,8 @@ class UniqueValidator(object):
         """
         Filter the queryset to all instances matching the given attribute.
         """
-        filter_kwargs = {self.field_name: value}
+        field_lookup = 'iexact' if self.ignore_case else 'exact'
+        filter_kwargs = {'%s__%s' % (self.field_name, field_lookup): value}
         return qs_filter(queryset, **filter_kwargs)
 
     def exclude_current_instance(self, queryset):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -31,7 +31,7 @@ class RelatedModel(models.Model):
 
 class RelatedModelSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username',
-        validators=[UniqueValidator(queryset=UniquenessModel.objects.all())])  # NOQA
+        validators=[UniqueValidator(queryset=UniquenessModel.objects.all(), lookup='iexact')])  # NOQA
 
     class Meta:
         model = RelatedModel
@@ -103,7 +103,7 @@ class TestUniquenessValidation(TestCase):
             AnotherUniquenessModel._meta.get_field('code').validators, [])
 
     def test_related_model_is_unique(self):
-        data = {'username': 'existing', 'email': 'new-email@example.com'}
+        data = {'username': 'Existing', 'email': 'new-email@example.com'}
         rs = RelatedModelSerializer(data=data)
         self.assertFalse(rs.is_valid())
         self.assertEqual(rs.errors,


### PR DESCRIPTION
Sometimes fields need to be validated as unique in a case insensitive manner, e.g. a usernames. This PR adds a `ignore_case` argument to `UniqueValidator` which causes the queryset lookup to use `iexact`.

Haven't added any tests yet - wanted to first see if you think this is useful and the right approach.