### PR TITLE
added paginated_response for functional views

### DIFF
--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -292,6 +292,7 @@ class RetrieveUpdateDestroyAPIView(mixins.RetrieveModelMixin,
     def delete(self, request, *args, **kwargs):
         return self.destroy(request, *args, **kwargs)
 
+
 def paginated_response(request, queryset, serializer_class, pagination_class=None, **kwargs):
     if pagination_class is None:
         pagination_class = api_settings.DEFAULT_PAGINATION_CLASS
@@ -307,4 +308,3 @@ def paginated_response(request, queryset, serializer_class, pagination_class=Non
 
     serializer = serializer_class(page, many=True)
     return paginator.get_paginated_response(serializer.data)
-

--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -307,3 +307,4 @@ def paginated_response(request, queryset, serializer_class, pagination_class=Non
 
     serializer = serializer_class(page, many=True)
     return paginator.get_paginated_response(serializer.data)
+

--- a/rest_framework/generics.py
+++ b/rest_framework/generics.py
@@ -8,6 +8,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404 as _get_object_or_404
 
 from rest_framework import mixins, views
+from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
 
@@ -290,3 +291,19 @@ class RetrieveUpdateDestroyAPIView(mixins.RetrieveModelMixin,
 
     def delete(self, request, *args, **kwargs):
         return self.destroy(request, *args, **kwargs)
+
+def paginated_response(request, queryset, serializer_class, pagination_class=None, **kwargs):
+    if pagination_class is None:
+        pagination_class = api_settings.DEFAULT_PAGINATION_CLASS
+
+    paginator = pagination_class()
+    for attr, value in kwargs.items():
+        setattr(paginator, attr, value)
+
+    page = paginator.paginate_queryset(queryset, request)
+    if page is None:
+        serializer = serializer_class(queryset, many=True)
+        return Response(serializer.data)
+
+    serializer = serializer_class(page, many=True)
+    return paginator.get_paginated_response(serializer.data)


### PR DESCRIPTION
When writing function based views there is no built-in way to do pagination. This adds that functionality.  I wanted to get some feedback of whether this idea is acceptable before proceeding. Also if I placed it in the correct file.  But if it sounds good, I'll add the docs and testing. I find this extremely useful in using the functional style and it would make it nice to have it built into the framework.

**Some examples:**

**Using the default paginator**
```
response = paginated_response(request, queryset, serializerClass)
```

**Using the a custom paginator**
```
response = paginated_response(request, queryset, serializerClass, customPaginatorClass)
```

**You can always customize the paginator class but  for quick overrides you can throw in an extra argument**
```
response = paginated_response(request, queryset, serializerClass, default_limit=10)
```

Look forward to your feedback.

