### PR TITLE
Corrected `artist` and `album_name` typo in docs

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -99,8 +99,8 @@ For example, the following serializer:
 Would serialize to a representation like this:
 
     {
-        'album_name': 'The Roots',
-        'artist': 'Undun',
+        'album_name': 'Undun',
+        'artist': 'The Roots',
         'tracks': [
             89,
             90,


### PR DESCRIPTION
## Description

`The Roots` are the band: https://en.wikipedia.org/wiki/The_Roots

`Undun` is their album: https://en.wikipedia.org/wiki/Undun

This was reversed in the docs, so I switched them around.