### PR TITLE
Use field name instead of source when generating docs

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -477,7 +477,7 @@ class SchemaGenerator(object):
             required = field.required and method != 'PATCH'
             description = force_text(field.help_text) if field.help_text else ''
             field = coreapi.Field(
-                name=field.source,
+                name=field.field_name,
                 location='form',
                 required=required,
                 description=description,


### PR DESCRIPTION
When generating docs I noticed that the fields listed were the source fields instead of the field name defined. 

So i.e. if you had something like `new_name = serializers.IntegerField(source='db_name')` the generated docs would list db_name instead of new_name.

In my eyes the correct behaviour should be to use the defined name but I am willing to concede if there is a reason for using source.

