### PR TITLE
Allow JSONField to handle HTML form input.

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1756,6 +1756,19 @@ class TestJSONField(FieldValues):
     ]
     field = serializers.JSONField()
 
+    def test_html_input_as_json_string(self):
+        """
+        HTML inputs should be treated as a serialized JSON string.
+        """
+        class TestSerializer(serializers.Serializer):
+            config = serializers.JSONField()
+
+        data = QueryDict(mutable=True)
+        data.update({'config': '{"a":1}'})
+        serializer = TestSerializer(data=data)
+        assert serializer.is_valid()
+        assert serializer.validated_data == {'config': {"a": 1}}
+
 
 class TestBinaryJSONField(FieldValues):
     """


### PR DESCRIPTION
When HTML form input is used, JSONField should treat the input as a JSON encoded string, rather than a JSON primitive.

Closes #4135