### PR TITLE
Do not treat empty non-form input as HTML.

### DIFF
--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -300,7 +300,7 @@ class Request(object):
 
         if stream is None or media_type is None:
             if media_type and not is_form_media_type(media_type):
-                empty_data = MultiValueDict()
+                empty_data = QueryDict('', encoding=self._request._encoding)
             else:
                 empty_data = {}
             empty_files = MultiValueDict()

--- a/rest_framework/request.py
+++ b/rest_framework/request.py
@@ -299,7 +299,10 @@ class Request(object):
             stream = None
 
         if stream is None or media_type is None:
-            empty_data = QueryDict('', encoding=self._request._encoding)
+            if media_type and not is_form_media_type(media_type):
+                empty_data = MultiValueDict()
+            else:
+                empty_data = {}
             empty_files = MultiValueDict()
             return (empty_data, empty_files)
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -201,7 +201,7 @@ class TestAPITestClient(TestCase):
             content_type='application/json'
         )
         self.assertEqual(response.status_code, 200, response.content)
-        self.assertEqual('{"flag":true}', response.content)
+        self.assertEqual(response.data, {"flag": True})
 
 
 class TestAPIRequestFactory(TestCase):


### PR DESCRIPTION
HTML form input has slightly differing behavior than non-form input. In particular any empty BooleanField is treated as `False` by default, because empty checkboxes do not send any value through.

For the case where no data is included in the request body we shouldn't treat this as an HTML input, unless a form content type has been explicitly included. (nb. have confirmed that at least chrome still includes the form content type with 0 length body in the case of submitting a form with a single empty checkbox.)

Refs. #3649
Closes #3891 - thanks for your work @callorico! 😄 
Closes #3892
Closes #3647

This change isn't perfect, but it is the most minimal change that we can make in order to fix the main issue. (BooleanField treated as True for empty input)

Other options would have been:

* Use the `None` sentinel for non-form data. (but don't want to go that way because it'd play less well with Django's existing behavior, and could easily break existing codebases)
* Parse empty content which has a media type included. (don't want to go that way because likely there are clients that always include `Content-Type application/json` regardless of if a body is included or not, and we don't want to fail for all of them.)