### PR TITLE
Fix schema generation with custom page_size pagination param

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -290,9 +290,9 @@ class PageNumberPagination(BasePagination):
             coreapi.Field(name=self.page_query_param, required=False, location='query')
         ]
         if self.page_size_query_param is not None:
-            fields.append([
+            fields.append(
                 coreapi.Field(name=self.page_size_query_param, required=False, location='query')
-            ])
+            )
         return fields
 
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -20,6 +20,7 @@ class MockUser(object):
 
 class ExamplePagination(pagination.PageNumberPagination):
     page_size = 100
+    page_size_query_param = 'page_size'
 
 
 class EmptySerializer(serializers.Serializer):
@@ -64,7 +65,6 @@ class ExampleViewSet(ModelViewSet):
         assert self.action
         return super(ExampleViewSet, self).get_serializer(*args, **kwargs)
 
-
 if coreapi:
     schema_view = get_schema_view(title='Example API')
 else:
@@ -96,6 +96,7 @@ class TestRouterGeneratedSchema(TestCase):
                         action='get',
                         fields=[
                             coreapi.Field('page', required=False, location='query'),
+                            coreapi.Field('page_size', required=False, location='query'),
                             coreapi.Field('ordering', required=False, location='query')
                         ]
                     ),
@@ -136,6 +137,7 @@ class TestRouterGeneratedSchema(TestCase):
                         action='get',
                         fields=[
                             coreapi.Field('page', required=False, location='query'),
+                            coreapi.Field('page_size', required=False, location='query'),
                             coreapi.Field('ordering', required=False, location='query')
                         ]
                     ),


### PR DESCRIPTION
When Pagination class has custom `page_size_query_param` name, schema generation will throw exception:

```
rest_framework/schemas.py:361: in get_link
    if fields and any([field.location in ('form', 'body') for field in fields]):
E   AttributeError: 'list' object has no attribute 'location'
```