### PR TITLE
Use field.source to perform check for writable nested field, not key.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -744,8 +744,8 @@ def raise_errors_on_nested_writes(method_name, serializer, validated_data):
     #     profile = ProfileSerializer()
     assert not any(
         isinstance(field, BaseSerializer) and
-        (key in validated_data) and
-        isinstance(validated_data[key], (list, dict))
+        (field.source in validated_data) and
+        isinstance(validated_data[field.source], (list, dict))
         for key, field in serializer.fields.items()
     ), (
         'The `.{method_name}()` method does not support writable nested '


### PR DESCRIPTION
Doesn't have an associated test case, but this should resolve the issue.

Closes #4312.