### PR TITLE
Enable cursor pagination of value querysets.

### DIFF
--- a/rest_framework/pagination.py
+++ b/rest_framework/pagination.py
@@ -711,7 +711,11 @@ class CursorPagination(BasePagination):
         return replace_query_param(self.base_url, self.cursor_query_param, encoded)
 
     def _get_position_from_instance(self, instance, ordering):
-        attr = getattr(instance, ordering[0].lstrip('-'))
+        field_name = ordering[0].lstrip('-')
+        if isinstance(instance, dict):
+            attr = instance[field_name]
+        else:
+            attr = getattr(instance, field_name)
         return six.text_type(attr)
 
     def get_paginated_response(self, data):


### PR DESCRIPTION
To do `GROUP_BY` queries in django requires one to use `.values()`
eg this groups posts by user getting a count of posts per user.

```
Posts.objects.order_by('user').values('user').annotate(post_count=Count('post'))
```

This would produce a value queryset which serializes its result
objects as dictionaries while `CursorPagination` requires a queryset
with result objects that are model instances.

This commit enables cursor pagination for value querysets.
- had to mangle the tests a bit to test it out. They might need
  some refactoring.
- tried the same for `.values_list()` but it turned out to be
  trickier than I expected since you have to use tuple indexes.
