### PR TITLE
Handle ModelSerializer case for relationships to models with custom pk.

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1167,7 +1167,7 @@ class ModelSerializer(Serializer):
         field_kwargs = get_relation_kwargs(field_name, relation_info)
 
         to_field = field_kwargs.pop('to_field', None)
-        if to_field and not relation_info.related_model._meta.get_field(to_field).primary_key:
+        if to_field and not relation_info.reverse and not relation_info.related_model._meta.get_field(to_field).primary_key:
             field_kwargs['slug_field'] = to_field
             field_class = self.serializer_related_to_field
 

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -238,7 +238,7 @@ def get_relation_kwargs(field_name, relation_info):
     """
     Creates a default instance of a flat relational field.
     """
-    model_field, related_model, to_many, to_field, has_through_model = relation_info
+    model_field, related_model, to_many, to_field, has_through_model, reverse = relation_info
     kwargs = {
         'queryset': related_model._default_manager,
         'view_name': get_detail_view_name(related_model)

--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -23,7 +23,8 @@ RelationInfo = namedtuple('RelationInfo', [
     'related_model',
     'to_many',
     'to_field',
-    'has_through_model'
+    'has_through_model',
+    'reverse'
 ])
 
 
@@ -81,7 +82,8 @@ def _get_forward_relationships(opts):
             related_model=get_related_model(field),
             to_many=False,
             to_field=_get_to_field(field),
-            has_through_model=False
+            has_through_model=False,
+            reverse=False
         )
 
     # Deal with forward many-to-many relationships.
@@ -94,7 +96,8 @@ def _get_forward_relationships(opts):
             to_field=None,
             has_through_model=(
                 not get_remote_field(field).through._meta.auto_created
-            )
+            ),
+            reverse=False
         )
 
     return forward_relations
@@ -118,7 +121,8 @@ def _get_reverse_relationships(opts):
             related_model=related,
             to_many=get_remote_field(relation.field).multiple,
             to_field=_get_to_field(relation.field),
-            has_through_model=False
+            has_through_model=False,
+            reverse=True
         )
 
     # Deal with reverse many-to-many relationships.
@@ -135,7 +139,8 @@ def _get_reverse_relationships(opts):
             has_through_model=(
                 (getattr(get_remote_field(relation.field), 'through', None) is not None) and
                 not get_remote_field(relation.field).through._meta.auto_created
-            )
+            ),
+            reverse=True
         )
 
     return reverse_relations


### PR DESCRIPTION
Closes #3674
Closes #3852

This fix specifically only addresses the issue described by the test cases.
It is possible that there is a related issue for the 'reverse' relationship case that we *also* need to deal with, but we can't do that unless/until we have a reproducible test case for it.