### PR TITLE
Serialize None as valid JSON

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -51,6 +51,9 @@ class BaseRenderer(object):
         raise NotImplementedError('Renderer class requires .render() to be implemented')
 
 
+_NULL_JSON = bytes('null'.encode('ascii'))
+
+
 class JSONRenderer(BaseRenderer):
     """
     Renderer which serializes to JSON.
@@ -87,7 +90,7 @@ class JSONRenderer(BaseRenderer):
         Render `data` into JSON, returning a bytestring.
         """
         if data is None:
-            return bytes()
+            return _NULL_JSON
 
         renderer_context = renderer_context or {}
         indent = self.get_indent(accepted_media_type, renderer_context)

--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -77,10 +77,11 @@ class Response(SimpleTemplateResponse):
             )
             return bytes(ret.encode(charset))
 
-        if not ret:
+        if self.status_code == 204:
             del self['Content-Type']
-
-        return ret
+            return bytes()
+        else:
+            return ret
 
     @property
     def status_text(self):

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -360,6 +360,10 @@ class JSONRendererTests(TestCase):
         content = renderer.render(obj, 'application/json; indent=2')
         self.assertEqual(strip_trailing_whitespace(content.decode('utf-8')), _indented_repr)
 
+    def test_none(self):
+        ret = JSONRenderer().render(None)
+        self.assertEqual(None, json.loads(ret))
+
 
 class UnicodeJSONRendererTests(TestCase):
     """


### PR DESCRIPTION
Currently doing a `return response.Response(None)` is rendered as '' (empty string) by the JSON renderer (this seems to be so since the beginnings: https://github.com/tomchristie/django-rest-framework/blob/4b691c402707775c3048a90531024f3bc5be6f91/rest_framework/renderers.py#L99)

This PR changes it to `null`. Pros and cons of both approaches:

Returning '' (empty string) for None:
- Pro: this makes it easy to generate a 204 (no content) response
- Con: empty string is not actually valid JSON and parsers will croak on it unless they also look at the status code

Returning `null`:
- Pro: this is actually valid JSON and parsers will parse it happily
- Con: generating an empty response body is a little more involved: `return response.Response(None, status=status.HTTP_204_NO_CONTENT)` - but this is in accordance with "explicit is better than implicit"
