### PR TITLE
Add french tutorial links in thrid-party resources

### DIFF
--- a/topics/third-party-resources/index.html
+++ b/topics/third-party-resources/index.html
@@ -603,6 +603,15 @@ You probably want to also tag the version now:
 <li><a href="http://richardtier.com/2014/02/25/django-rest-framework-user-endpoint/">Django Rest Framework User Endpoint</a></li>
 <li><a href="http://richardtier.com/2014/03/06/110/">Check credentials using Django Rest Framework</a></li>
 <li><a href="https://teamtreehouse.com/library/django-rest-framework">Django REST Framework course</a></li>
+<li><a href="https://makina-corpus.com/blog/metier/2015/django-rest-framework-les-serializer-et-les-exceptions-partie-1">[Français] Django Rest Framework : les Serializer et les exceptions</a></li>
+<li><a href="https://makina-corpus.com/blog/metier/2015/django-rest-framework-les-viewset-partie-2">[Français] Django Rest Framework : les Viewset</a></li>
+<li><a href="https://makina-corpus.com/blog/metier/2016/django-rest-framework-fonctionnement-des-routeurs-partie-3">[Français] Django Rest Framework : fonctionnement des routeurs</a></li>
+<li><a href="https://makina-corpus.com/blog/metier/2016/django-rest-framework-integration-des-routeurs-partie-4">[Français] Django Rest Framework : intégration des routeurs</a></li>
+<li><a href="https://makina-corpus.com/blog/metier/2016/django-rest-framework-personnalisation-des-routeurs-partie-5">[Français] Django Rest Framework : personnalisation des routeurs</a></li>
+<li><a href="https://makina-corpus.com/blog/metier/2016/django-rest-framework-la-negociation-de-contenu-partie-6">[Français] Django Rest Framework : négociation de contenu</a></li>
+<li><a href="https://makina-corpus.com/blog/metier/2016/django-rest-framework-le-versioning-avec-drf-partie-7">[Français] Django Rest Framework : versioning avec DRF</a></li>
+<li><a href="https://makina-corpus.com/blog/metier/2016/django-rest-framework-les-tests-partie-8">[Français] Django Rest Framework : les tests</a></li>
+<li><a href="https://makina-corpus.com/blog/metier/2016/django-rest-framework-le-versioning-pour-les-api-rest-hors-serie">[Français] Django Rest Framework : versioning pour les API REST</a></li>
 </ul>
 <h3 id="videos"><a class="toclink" href="#videos">Videos</a></h3>
 <ul>


### PR DESCRIPTION
As proposed by Xavier (https://twitter.com/linovia_net/status/788341380284284928), this adds 9 links to our quite of articles in the form of tutorials (added `[Français]` before each to warn viewers]