### PR TITLE
Fix code formatting missing in 3.5 announcement

### DIFF
--- a/docs/topics/3.5-announcement.md
+++ b/docs/topics/3.5-announcement.md
@@ -246,7 +246,7 @@ be deprecated at a later date.
 ### ModelSerializer 'fields' and 'exclude'
 
 ModelSerializer and HyperlinkedModelSerializer must include either a fields
-option, or an exclude option. The fields = '__all__' shortcut may be used to
+option, or an exclude option. The `fields = '__all__'` shortcut may be used to
 explicitly include all fields.
 
 Failing to set either `fields` or `exclude` raised a pending deprecation warning


### PR DESCRIPTION
... in section ModelSerializer 'fields' and 'exclude'

Fairly obvious, don't need to add more :)