### PR TITLE
Update requirements, Python 3.5 error with naked raise

### DIFF
--- a/requirements/requirements-codestyle.txt
+++ b/requirements/requirements-codestyle.txt
@@ -1,6 +1,6 @@
 # PEP8 code linting, which we run on all commits.
-flake8==2.4.0
-pep8==1.5.7
+flake8==3.0.4
+pep8==1.7.0
 
 # Sort and lint imports
 isort==4.2.5

--- a/requirements/requirements-packaging.txt
+++ b/requirements/requirements-packaging.txt
@@ -2,10 +2,10 @@
 wheel==0.29.0
 
 # Twine for secured PyPI uploads.
-twine==1.6.5
+twine==1.8.1
 
 # Transifex client for managing translation resources.
-transifex-client==0.11
+transifex-client==0.12.2
 
 # Pandoc to have a nice pypi page
 pypandoc

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -445,7 +445,7 @@ class APIView(View):
             renderer_format = getattr(request.accepted_renderer, 'format')
             use_plaintext_traceback = renderer_format not in ('html', 'api', 'admin')
             request.force_plaintext_errors(use_plaintext_traceback)
-        raise
+        raise exc
 
     # Note: Views are made CSRF exempt from within `as_view` as to prevent
     # accidental removal of this exemption in cases where `dispatch` needs to


### PR DESCRIPTION
`raise` with no arguments can only be used in an except clause as of Python 3.5.

While I was in there, updated some outdated packaging/testing packages
