### PR TITLE
changing order of django-filter and core api imports in compat

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -170,6 +170,16 @@ except ImportError:
     JSONField = None
 
 
+# coreapi is optional (Note that uritemplate is a dependency of coreapi)
+try:
+    import coreapi
+    import uritemplate
+except (ImportError, SyntaxError):
+    # SyntaxError is possible under python 3.2
+    coreapi = None
+    uritemplate = None
+
+
 # django-filter is optional
 try:
     import django_filters
@@ -182,16 +192,6 @@ try:
     import crispy_forms
 except ImportError:
     crispy_forms = None
-
-
-# coreapi is optional (Note that uritemplate is a dependency of coreapi)
-try:
-    import coreapi
-    import uritemplate
-except (ImportError, SyntaxError):
-    # SyntaxError is possible under python 3.2
-    coreapi = None
-    uritemplate = None
 
 
 # requests is optional


### PR DESCRIPTION
## Description

when using with django-filter and rest_framework_swagger need to import coreapi before django-filter as django filter tries to load rest_framework.coreapi which is undefined at this point