### PR TITLE
PEP8 and pyflakes fixes

### DIFF
--- a/requirements/requirements-codestyle.txt
+++ b/requirements/requirements-codestyle.txt
@@ -1,6 +1,6 @@
 # PEP8 code linting, which we run on all commits.
-flake8==2.4.0
-pep8==1.5.7
+flake8==3.0.4
+pep8==1.7.0
 
 # Sort and lint imports
 isort==4.2.5

--- a/requirements/requirements-packaging.txt
+++ b/requirements/requirements-packaging.txt
@@ -2,10 +2,10 @@
 wheel==0.29.0
 
 # Twine for secured PyPI uploads.
-twine==1.6.5
+twine==1.8.1
 
 # Transifex client for managing translation resources.
-transifex-client==0.11
+transifex-client==0.12.2
 
 # Pandoc to have a nice pypi page
 pypandoc

--- a/rest_framework/permissions.py
+++ b/rest_framework/permissions.py
@@ -7,7 +7,6 @@ from django.http import Http404
 
 from rest_framework.compat import is_authenticated
 
-
 SAFE_METHODS = ('GET', 'HEAD', 'OPTIONS')
 
 

--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -9,24 +9,30 @@ REST framework also provides an HTML renderer that renders the browsable API.
 from __future__ import unicode_literals
 
 import json
-from collections import OrderedDict
 
 from django import forms
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.core.paginator import Page
 from django.http.multipartparser import parse_header
 from django.template import Template, loader
 from django.test.client import encode_multipart
-from django.utils import six
 
-from rest_framework import VERSION, exceptions, serializers, status
+from rest_framework import VERSION, exceptions, status
 from rest_framework.compat import (
     INDENT_SEPARATORS, LONG_SEPARATORS, SHORT_SEPARATORS, coreapi,
     template_render
 )
 from rest_framework.exceptions import ParseError
+from rest_framework.fields import (
+    BooleanField, ChoiceField, DateField, DateTimeField, EmailField, Field,
+    FileField, FilePathField, FloatField, HiddenField, IntegerField,
+    MultipleChoiceField, OrderedDict, TimeField, URLField, six
+)
+from rest_framework.relations import (
+    ImproperlyConfigured, ManyRelatedField, RelatedField
+)
 from rest_framework.request import is_form_media_type, override_method
+from rest_framework.serializers import ListSerializer, Serializer
 from rest_framework.settings import api_settings
 from rest_framework.utils import encoders
 from rest_framework.utils.breadcrumbs import get_breadcrumbs
@@ -48,7 +54,8 @@ class BaseRenderer(object):
     render_style = 'text'
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
-        raise NotImplementedError('Renderer class requires .render() to be implemented')
+        raise NotImplementedError(
+            'Renderer class requires .render() to be implemented')
 
 
 class JSONRenderer(BaseRenderer):
@@ -64,7 +71,7 @@ class JSONRenderer(BaseRenderer):
     # We don't set a charset because JSON is a binary encoding,
     # that can be encoded as utf-8, utf-16 or utf-32.
     # See: http://www.ietf.org/rfc/rfc4627.txt
-    # Also: http://lucumr.pocoo.org/2013/7/19/application-mimetypes-and-encodings/
+    # http://lucumr.pocoo.org/2013/7/19/application-mimetypes-and-encodings/
     charset = None
 
     def get_indent(self, accepted_media_type, renderer_context):
@@ -72,7 +79,8 @@ class JSONRenderer(BaseRenderer):
             # If the media type looks like 'application/json; indent=4',
             # then pretty print the result.
             # Note that we coerce `indent=0` into `indent=None`.
-            base_media_type, params = parse_header(accepted_media_type.encode('ascii'))
+            base_media_type, params = parse_header(
+                accepted_media_type.encode('ascii'))
             try:
                 return zero_as_none(max(min(int(params['indent']), 8), 0))
             except (KeyError, ValueError, TypeError):
@@ -192,7 +200,8 @@ class TemplateHTMLRenderer(BaseRenderer):
         elif hasattr(view, 'template_name'):
             return [view.template_name]
         raise ImproperlyConfigured(
-            'Returned a template response with no `template_name` attribute set on either the view or response'
+            'Returned a template response with no `template_name` attribute '
+            'set on either the view or response'
         )
 
     def get_exception_template(self, response):
@@ -260,88 +269,93 @@ class HTMLFormRenderer(BaseRenderer):
     base_template = 'form.html'
 
     default_style = ClassLookupDict({
-        serializers.Field: {
+        Field: {
             'base_template': 'input.html',
             'input_type': 'text'
         },
-        serializers.EmailField: {
+        EmailField: {
             'base_template': 'input.html',
             'input_type': 'email'
         },
-        serializers.URLField: {
+        URLField: {
             'base_template': 'input.html',
             'input_type': 'url'
         },
-        serializers.IntegerField: {
+        IntegerField: {
             'base_template': 'input.html',
             'input_type': 'number'
         },
-        serializers.FloatField: {
+        FloatField: {
             'base_template': 'input.html',
             'input_type': 'number'
         },
-        serializers.DateTimeField: {
+        DateTimeField: {
             'base_template': 'input.html',
             'input_type': 'datetime-local'
         },
-        serializers.DateField: {
+        DateField: {
             'base_template': 'input.html',
             'input_type': 'date'
         },
-        serializers.TimeField: {
+        TimeField: {
             'base_template': 'input.html',
             'input_type': 'time'
         },
-        serializers.FileField: {
+        FileField: {
             'base_template': 'input.html',
             'input_type': 'file'
         },
-        serializers.BooleanField: {
+        BooleanField: {
             'base_template': 'checkbox.html'
         },
-        serializers.ChoiceField: {
+        ChoiceField: {
             'base_template': 'select.html',  # Also valid: 'radio.html'
         },
-        serializers.MultipleChoiceField: {
-            'base_template': 'select_multiple.html',  # Also valid: 'checkbox_multiple.html'
+        MultipleChoiceField: {
+            'base_template': 'select_multiple.html',
+            # Also valid: 'checkbox_multiple.html'
         },
-        serializers.RelatedField: {
+        RelatedField: {
             'base_template': 'select.html',  # Also valid: 'radio.html'
         },
-        serializers.ManyRelatedField: {
-            'base_template': 'select_multiple.html',  # Also valid: 'checkbox_multiple.html'
+        ManyRelatedField: {
+            'base_template': 'select_multiple.html',
+            # Also valid: 'checkbox_multiple.html'
         },
-        serializers.Serializer: {
+        Serializer: {
             'base_template': 'fieldset.html'
         },
-        serializers.ListSerializer: {
+        ListSerializer: {
             'base_template': 'list_fieldset.html'
         },
-        serializers.FilePathField: {
+        FilePathField: {
             'base_template': 'select.html',
         },
     })
 
     def render_field(self, field, parent_style):
-        if isinstance(field._field, serializers.HiddenField):
+        if isinstance(field._field, HiddenField):
             return ''
 
         style = dict(self.default_style[field])
         style.update(field.style)
         if 'template_pack' not in style:
-            style['template_pack'] = parent_style.get('template_pack', self.template_pack)
+            style['template_pack'] = parent_style.get('template_pack',
+                                                      self.template_pack)
         style['renderer'] = self
 
         # Get a clone of the field with text-only value representation.
         field = field.as_form_field()
 
-        if style.get('input_type') == 'datetime-local' and isinstance(field.value, six.text_type):
+        if style.get('input_type') == 'datetime-local' and isinstance(
+                field.value, six.text_type):
             field.value = field.value.rstrip('Z')
 
         if 'template' in style:
             template_name = style['template']
         else:
-            template_name = style['template_pack'].strip('/') + '/' + style['base_template']
+            template_name = style['template_pack'].strip('/') + '/' + style[
+                'base_template']
 
         template = loader.get_template(template_name)
         context = {'field': field, 'style': style}
@@ -388,7 +402,8 @@ class BrowsableAPIRenderer(BaseRenderer):
         renderers = [renderer for renderer in view.renderer_classes
                      if not issubclass(renderer, BrowsableAPIRenderer)]
         non_template_renderers = [renderer for renderer in renderers
-                                  if not hasattr(renderer, 'get_template_names')]
+                                  if
+                                  not hasattr(renderer, 'get_template_names')]
 
         if not renderers:
             return None
@@ -410,7 +425,8 @@ class BrowsableAPIRenderer(BaseRenderer):
 
         render_style = getattr(renderer, 'render_style', 'text')
         assert render_style in ['text', 'binary'], 'Expected .render_style ' \
-            '"text" or "binary", but got "%s"' % render_style
+                                                   '"text" or "binary", but ' \
+                                                   'got "%s"' % render_style
         if render_style == 'binary':
             return '[%d bytes of binary content]' % len(content)
 
@@ -431,7 +447,8 @@ class BrowsableAPIRenderer(BaseRenderer):
             return False  # Doesn't have permissions
         return True
 
-    def _get_serializer(self, serializer_class, view_instance, request, *args, **kwargs):
+    def _get_serializer(self, serializer_class, view_instance, request, *args,
+                        **kwargs):
         kwargs['context'] = {
             'request': request,
             'format': self.format,
@@ -478,10 +495,10 @@ class BrowsableAPIRenderer(BaseRenderer):
             has_serializer = getattr(view, 'get_serializer', None)
             has_serializer_class = getattr(view, 'serializer_class', None)
 
-            if (
-                (not has_serializer and not has_serializer_class) or
-                not any(is_form_media_type(parser.media_type) for parser in view.parser_classes)
-            ):
+            if ((not has_serializer and not has_serializer_class) or
+                    not any(
+                        is_form_media_type(parser.media_type) for parser in
+                        view.parser_classes)):
                 return
 
             if existing_serializer is not None:
@@ -492,16 +509,21 @@ class BrowsableAPIRenderer(BaseRenderer):
 
             if has_serializer:
                 if method in ('PUT', 'PATCH'):
-                    serializer = view.get_serializer(instance=instance, **kwargs)
+                    serializer = view.get_serializer(instance=instance,
+                                                     **kwargs)
                 else:
                     serializer = view.get_serializer(**kwargs)
             else:
                 # at this point we must have a serializer_class
                 if method in ('PUT', 'PATCH'):
-                    serializer = self._get_serializer(view.serializer_class, view,
-                                                      request, instance=instance, **kwargs)
+                    serializer = self._get_serializer(view.serializer_class,
+                                                      view,
+                                                      request,
+                                                      instance=instance,
+                                                      **kwargs)
                 else:
-                    serializer = self._get_serializer(view.serializer_class, view,
+                    serializer = self._get_serializer(view.serializer_class,
+                                                      view,
                                                       request, **kwargs)
 
             return self.render_form_for_serializer(serializer)
@@ -569,7 +591,8 @@ class BrowsableAPIRenderer(BaseRenderer):
                     label='Media type',
                     choices=choices,
                     initial=initial,
-                    widget=forms.Select(attrs={'data-override': 'content-type'})
+                    widget=forms.Select(
+                        attrs={'data-override': 'content-type'})
                 )
                 _content = forms.CharField(
                     label='Content',
@@ -583,7 +606,8 @@ class BrowsableAPIRenderer(BaseRenderer):
         return view.get_view_name()
 
     def get_description(self, view, status_code):
-        if status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN):
+        if status_code in (
+                status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN):
             return ''
         return view.get_view_description(html=True)
 
@@ -591,7 +615,8 @@ class BrowsableAPIRenderer(BaseRenderer):
         return get_breadcrumbs(request.path, request)
 
     def get_filter_form(self, data, view, request):
-        if not hasattr(view, 'get_queryset') or not hasattr(view, 'filter_backends'):
+        if not hasattr(view, 'get_queryset') or not hasattr(view,
+                                                            'filter_backends'):
             return
 
         # Infer if this is a list view or not.
@@ -631,9 +656,11 @@ class BrowsableAPIRenderer(BaseRenderer):
 
         renderer = self.get_default_renderer(view)
 
-        raw_data_post_form = self.get_raw_data_form(data, view, 'POST', request)
+        raw_data_post_form = self.get_raw_data_form(data, view, 'POST',
+                                                    request)
         raw_data_put_form = self.get_raw_data_form(data, view, 'PUT', request)
-        raw_data_patch_form = self.get_raw_data_form(data, view, 'PATCH', request)
+        raw_data_patch_form = self.get_raw_data_form(data, view, 'PATCH',
+                                                     request)
         raw_data_put_or_patch_form = raw_data_put_form or raw_data_patch_form
 
         response_headers = OrderedDict(sorted(response.items()))
@@ -644,19 +671,22 @@ class BrowsableAPIRenderer(BaseRenderer):
                 renderer_content_type += ' ;%s' % renderer.charset
         response_headers['Content-Type'] = renderer_content_type
 
-        if getattr(view, 'paginator', None) and view.paginator.display_page_controls:
+        if getattr(view, 'paginator',
+                   None) and view.paginator.display_page_controls:
             paginator = view.paginator
         else:
             paginator = None
 
         csrf_cookie_name = settings.CSRF_COOKIE_NAME
-        csrf_header_name = getattr(settings, 'CSRF_HEADER_NAME', 'HTTP_X_CSRFToken')  # Fallback for Django 1.8
+        csrf_header_name = getattr(settings, 'CSRF_HEADER_NAME',
+                                   'HTTP_X_CSRFToken')  # Fallback Django 1.8
         if csrf_header_name.startswith('HTTP_'):
             csrf_header_name = csrf_header_name[5:]
         csrf_header_name = csrf_header_name.replace('_', '-')
 
         context = {
-            'content': self.get_content(renderer, data, accepted_media_type, renderer_context),
+            'content': self.get_content(renderer, data, accepted_media_type,
+                                        renderer_context),
             'view': view,
             'request': request,
             'response': response,
@@ -667,13 +697,18 @@ class BrowsableAPIRenderer(BaseRenderer):
             'paginator': paginator,
             'breadcrumblist': self.get_breadcrumbs(request),
             'allowed_methods': view.allowed_methods,
-            'available_formats': [renderer_cls.format for renderer_cls in view.renderer_classes],
+            'available_formats': [renderer_cls.format for renderer_cls in
+                                  view.renderer_classes],
             'response_headers': response_headers,
 
-            'put_form': self.get_rendered_html_form(data, view, 'PUT', request),
-            'post_form': self.get_rendered_html_form(data, view, 'POST', request),
-            'delete_form': self.get_rendered_html_form(data, view, 'DELETE', request),
-            'options_form': self.get_rendered_html_form(data, view, 'OPTIONS', request),
+            'put_form': self.get_rendered_html_form(data, view, 'PUT',
+                                                    request),
+            'post_form': self.get_rendered_html_form(data, view, 'POST',
+                                                     request),
+            'delete_form': self.get_rendered_html_form(data, view, 'DELETE',
+                                                       request),
+            'options_form': self.get_rendered_html_form(data, view, 'OPTIONS',
+                                                        request),
 
             'filter_form': self.get_filter_form(data, view, request),
 
@@ -699,7 +734,8 @@ class BrowsableAPIRenderer(BaseRenderer):
 
         template = loader.get_template(self.template)
         context = self.get_context(data, accepted_media_type, renderer_context)
-        ret = template_render(template, context, request=renderer_context['request'])
+        ret = template_render(template, context,
+                              request=renderer_context['request'])
 
         # Munge DELETE Response code to allow us to return content
         # (Do this *after* we've rendered the template so that we include
@@ -726,8 +762,11 @@ class AdminRenderer(BrowsableAPIRenderer):
         if response.status_code == status.HTTP_400_BAD_REQUEST:
             # Errors still need to display the list or detail information.
             # The only way we can get at that is to simulate a GET request.
-            self.error_form = self.get_rendered_html_form(data, view, request.method, request)
-            self.error_title = {'POST': 'Create', 'PUT': 'Edit'}.get(request.method, 'Errors')
+            self.error_form = self.get_rendered_html_form(data, view,
+                                                          request.method,
+                                                          request)
+            self.error_title = {'POST': 'Create', 'PUT': 'Edit'}.get(
+                request.method, 'Errors')
 
             with override_method(view, request, 'GET') as request:
                 response = view.get(request, *view.args, **view.kwargs)
@@ -735,10 +774,12 @@ class AdminRenderer(BrowsableAPIRenderer):
 
         template = loader.get_template(self.template)
         context = self.get_context(data, accepted_media_type, renderer_context)
-        ret = template_render(template, context, request=renderer_context['request'])
+        ret = template_render(template, context,
+                              request=renderer_context['request'])
 
         # Creation and deletion should use redirects in the admin style.
-        if (response.status_code == status.HTTP_201_CREATED) and ('Location' in response):
+        if (response.status_code == status.HTTP_201_CREATED) \
+                and ('Location' in response):
             response.status_code = status.HTTP_303_SEE_OTHER
             response['Location'] = request.build_absolute_uri()
             ret = ''
@@ -818,7 +859,8 @@ class CoreJSONRenderer(BaseRenderer):
     format = 'corejson'
 
     def __init__(self):
-        assert coreapi, 'Using CoreJSONRenderer, but `coreapi` is not installed.'
+        assert coreapi, 'Using CoreJSONRenderer, but `coreapi` is not ' \
+                        'installed.'
 
     def render(self, data, media_type=None, renderer_context=None):
         indent = bool(renderer_context.get('indent', 0))

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -5,35 +5,39 @@ from importlib import import_module
 
 from django.conf import settings
 from django.contrib.admindocs.views import simplify_regex
-from django.utils import six
 from django.utils.encoding import force_text, smart_text
 
-from rest_framework import exceptions, renderers, serializers
+from rest_framework import exceptions, renderers
 from rest_framework.compat import (
     RegexURLPattern, RegexURLResolver, coreapi, uritemplate, urlparse
 )
+from rest_framework.fields import (
+    BooleanField, DecimalField, Field, FileField, FloatField, HiddenField,
+    IntegerField, MultipleChoiceField, six
+)
+from rest_framework.relations import ManyRelatedField
 from rest_framework.request import clone_request
 from rest_framework.response import Response
+from rest_framework.serializers import ListSerializer, Serializer
 from rest_framework.settings import api_settings
 from rest_framework.utils import formatting
 from rest_framework.utils.field_mapping import ClassLookupDict
 from rest_framework.utils.model_meta import _get_pk
 from rest_framework.views import APIView
 
-
 header_regex = re.compile('^[a-zA-Z][0-9A-Za-z_]*:')
 
 types_lookup = ClassLookupDict({
-    serializers.Field: 'string',
-    serializers.IntegerField: 'integer',
-    serializers.FloatField: 'number',
-    serializers.DecimalField: 'number',
-    serializers.BooleanField: 'boolean',
-    serializers.FileField: 'file',
-    serializers.MultipleChoiceField: 'array',
-    serializers.ManyRelatedField: 'array',
-    serializers.Serializer: 'object',
-    serializers.ListSerializer: 'array'
+    Field: 'string',
+    IntegerField: 'integer',
+    FloatField: 'number',
+    DecimalField: 'number',
+    BooleanField: 'boolean',
+    FileField: 'file',
+    MultipleChoiceField: 'array',
+    ManyRelatedField: 'array',
+    Serializer: 'object',
+    ListSerializer: 'array'
 })
 
 
@@ -104,6 +108,7 @@ class EndpointInspector(object):
     """
     A class to determine the available API endpoints that a project exposes.
     """
+
     def __init__(self, patterns=None, urlconf=None):
         if patterns is None:
             if urlconf is None:
@@ -176,10 +181,8 @@ class EndpointInspector(object):
         if hasattr(callback, 'actions'):
             return [method.upper() for method in callback.actions.keys()]
 
-        return [
-            method for method in
-            callback.cls().allowed_methods if method not in ('OPTIONS', 'HEAD')
-        ]
+        return [method for method in callback.cls().allowed_methods
+                if method not in ('OPTIONS', 'HEAD')]
 
 
 class SchemaGenerator(object):
@@ -193,8 +196,9 @@ class SchemaGenerator(object):
     }
     endpoint_inspector_cls = EndpointInspector
 
-    # Map the method names we use for viewset actions onto external schema names.
-    # These give us names that are more suitable for the external representation.
+    # Map the method names we use for viewset actions onto external schema
+    # names. These give us names that are more suitable for the external
+    # representation.
     # Set by 'SCHEMA_COERCE_METHOD_NAMES'.
     coerce_method_names = None
 
@@ -223,7 +227,8 @@ class SchemaGenerator(object):
         Generate a `coreapi.Document` representing the API schema.
         """
         if self.endpoints is None:
-            inspector = self.endpoint_inspector_cls(self.patterns, self.urlconf)
+            inspector = self.endpoint_inspector_cls(self.patterns,
+                                                    self.urlconf)
             self.endpoints = inspector.get_api_endpoints()
 
         links = self.get_links(request)
@@ -358,7 +363,8 @@ class SchemaGenerator(object):
         fields += self.get_pagination_fields(path, method, view)
         fields += self.get_filter_fields(path, method, view)
 
-        if fields and any([field.location in ('form', 'body') for field in fields]):
+        if fields and any(
+                [field.location in ('form', 'body') for field in fields]):
             encoding = self.get_encoding(path, method, view)
         else:
             encoding = None
@@ -438,7 +444,8 @@ class SchemaGenerator(object):
         fields = []
 
         for variable in uritemplate.variables(path):
-            field = coreapi.Field(name=variable, location='path', required=True)
+            field = coreapi.Field(name=variable, location='path',
+                                  required=True)
             fields.append(field)
 
         return fields
@@ -456,7 +463,7 @@ class SchemaGenerator(object):
 
         serializer = view.get_serializer()
 
-        if isinstance(serializer, serializers.ListSerializer):
+        if isinstance(serializer, ListSerializer):
             return [
                 coreapi.Field(
                     name='data',
@@ -466,16 +473,17 @@ class SchemaGenerator(object):
                 )
             ]
 
-        if not isinstance(serializer, serializers.Serializer):
+        if not isinstance(serializer, Serializer):
             return []
 
         fields = []
         for field in serializer.fields.values():
-            if field.read_only or isinstance(field, serializers.HiddenField):
+            if field.read_only or isinstance(field, HiddenField):
                 continue
 
             required = field.required and method != 'PATCH'
-            description = force_text(field.help_text) if field.help_text else ''
+            description = force_text(
+                field.help_text) if field.help_text else ''
             field = coreapi.Field(
                 name=field.field_name,
                 location='form',
@@ -517,27 +525,30 @@ class SchemaGenerator(object):
         the schema document.
 
         /users/                   ("users", "list"), ("users", "create")
-        /users/{pk}/              ("users", "read"), ("users", "update"), ("users", "delete")
-        /users/enabled/           ("users", "enabled")  # custom viewset list action
-        /users/{pk}/star/         ("users", "star")     # custom viewset detail action
-        /users/{pk}/groups/       ("users", "groups", "list"), ("users", "groups", "create")
-        /users/{pk}/groups/{pk}/  ("users", "groups", "read"), ("users", "groups", "update"), ("users", "groups", "delete")
+        /users/{pk}/              ("users", "read"), ("users", "update"),
+                                    ("users", "delete")
+        /users/enabled/           ("users", "enabled")  # custom viewset list
+        /users/{pk}/star/         ("users", "star")     # custom viewset detail
+        /users/{pk}/groups/       ("users", "groups", "list"),
+                                    ("users", "groups", "create")
+        /users/{pk}/groups/{pk}/  ("users", "groups", "read"),
+                                    ("users", "groups", "update"),
+                                    ("users", "groups", "delete")
         """
         if hasattr(view, 'action'):
             # Viewsets have explicitly named actions.
             action = view.action
         else:
-            # Views have no associated action, so we determine one from the method.
+            # Views have no associated action, so we determine one from the
+            # method.
             if is_list_view(subpath, method, view):
                 action = 'list'
             else:
                 action = self.default_mapping[method.lower()]
 
-        named_path_components = [
-            component for component
-            in subpath.strip('/').split('/')
-            if '{' not in component
-        ]
+        named_path_components = [component for component
+                                 in subpath.strip('/').split('/')
+                                 if '{' not in component]
 
         if is_custom_action(action):
             # Custom action, eg "/users/{pk}/activate/", "/users/active/"
@@ -562,8 +573,10 @@ def get_schema_view(title=None, url=None, renderer_classes=None):
     """
     generator = SchemaGenerator(title=title, url=url)
     if renderer_classes is None:
-        if renderers.BrowsableAPIRenderer in api_settings.DEFAULT_RENDERER_CLASSES:
-            rclasses = [renderers.CoreJSONRenderer, renderers.BrowsableAPIRenderer]
+        if renderers.BrowsableAPIRenderer in \
+                api_settings.DEFAULT_RENDERER_CLASSES:
+            rclasses = [renderers.CoreJSONRenderer,
+                        renderers.BrowsableAPIRenderer]
         else:
             rclasses = [renderers.CoreJSONRenderer]
     else:

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -445,7 +445,7 @@ class APIView(View):
             renderer_format = getattr(request.accepted_renderer, 'format')
             use_plaintext_traceback = renderer_format not in ('html', 'api', 'admin')
             request.force_plaintext_errors(use_plaintext_traceback)
-        raise
+        raise exc
 
     # Note: Views are made CSRF exempt from within `as_view` as to prevent
     # accidental removal of this exemption in cases where `dispatch` needs to

--- a/tests/browsable_api/test_form_rendering.py
+++ b/tests/browsable_api/test_form_rendering.py
@@ -33,10 +33,8 @@ class TestManyPostView(TestCase):
         for item in items:
             BasicModel(text=item).save()
         self.objects = BasicModel.objects
-        self.data = [
-            {'id': obj.id, 'text': obj.text}
-            for obj in self.objects.all()
-        ]
+        self.data = [{'id': obj.id, 'text': obj.text}
+                     for obj in self.objects.all()]
         self.view = ManyPostView.as_view()
 
     def test_post_many_post_view(self):
@@ -44,7 +42,8 @@ class TestManyPostView(TestCase):
         POST request to a view that returns a list of objects should
         still successfully return the browsable API with a rendered form.
 
-        Regression test for https://github.com/tomchristie/django-rest-framework/pull/3164
+        Regression test for
+        https://github.com/tomchristie/django-rest-framework/pull/3164
         """
         data = {}
         request = factory.post('/', data, format='json')

--- a/tests/test_atomic_requests.py
+++ b/tests/test_atomic_requests.py
@@ -45,6 +45,7 @@ class NonAtomicAPIExceptionView(APIView):
         BasicModel.objects.all()
         raise Http404
 
+
 urlpatterns = (
     url(r'^$', NonAtomicAPIExceptionView.as_view()),
 )
@@ -89,7 +90,8 @@ class DBTransactionErrorTests(TestCase):
         Transaction is eventually managed by outer-most transaction atomic
         block. DRF do not try to interfere here.
 
-        We let django deal with the transaction when it will catch the Exception.
+        We let django deal with the transaction when it will catch the
+        Exception.
         """
         request = factory.post('/')
         with self.assertNumQueries(3):

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -85,10 +85,8 @@ class TestRootView(TestCase):
         for item in items:
             BasicModel(text=item).save()
         self.objects = BasicModel.objects
-        self.data = [
-            {'id': obj.id, 'text': obj.text}
-            for obj in self.objects.all()
-        ]
+        self.data = [{'id': obj.id, 'text': obj.text}
+                     for obj in self.objects.all()]
         self.view = RootView.as_view()
 
     def test_get_root_view(self):
@@ -122,8 +120,10 @@ class TestRootView(TestCase):
         request = factory.put('/', data, format='json')
         with self.assertNumQueries(0):
             response = self.view(request).render()
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(response.data, {"detail": 'Method "PUT" not allowed.'})
+        self.assertEqual(response.status_code,
+                         status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.data,
+                         {"detail": 'Method "PUT" not allowed.'})
 
     def test_delete_root_view(self):
         """
@@ -132,8 +132,10 @@ class TestRootView(TestCase):
         request = factory.delete('/')
         with self.assertNumQueries(0):
             response = self.view(request).render()
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(response.data, {"detail": 'Method "DELETE" not allowed.'})
+        self.assertEqual(response.status_code,
+                         status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.data,
+                         {"detail": 'Method "DELETE" not allowed.'})
 
     def test_post_cannot_set_id(self):
         """
@@ -156,7 +158,8 @@ class TestRootView(TestCase):
         request = factory.post('/', data, HTTP_ACCEPT='text/html')
         response = self.view(request).render()
         expected_error = '<span class="help-block">Ensure this field has no more than 100 characters.</span>'
-        self.assertIn(expected_error, response.rendered_content.decode('utf-8'))
+        self.assertIn(expected_error,
+                      response.rendered_content.decode('utf-8'))
 
 
 EXPECTED_QUERIES_FOR_PUT = 2
@@ -171,10 +174,8 @@ class TestInstanceView(TestCase):
         for item in items:
             BasicModel(text=item).save()
         self.objects = BasicModel.objects.exclude(text='filtered out')
-        self.data = [
-            {'id': obj.id, 'text': obj.text}
-            for obj in self.objects.all()
-        ]
+        self.data = [{'id': obj.id, 'text': obj.text}
+                     for obj in self.objects.all()]
         self.view = InstanceView.as_view()
         self.slug_based_view = SlugBasedInstanceView.as_view()
 
@@ -196,8 +197,10 @@ class TestInstanceView(TestCase):
         request = factory.post('/', data, format='json')
         with self.assertNumQueries(0):
             response = self.view(request).render()
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(response.data, {"detail": 'Method "POST" not allowed.'})
+        self.assertEqual(response.status_code,
+                         status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.data,
+                         {"detail": 'Method "POST" not allowed.'})
 
     def test_put_instance_view(self):
         """
@@ -280,7 +283,8 @@ class TestInstanceView(TestCase):
         """
         data = {'text': 'foo'}
         filtered_out_pk = BasicModel.objects.filter(text='filtered out')[0].pk
-        request = factory.put('/{0}'.format(filtered_out_pk), data, format='json')
+        request = factory.put('/{0}'.format(filtered_out_pk), data,
+                              format='json')
         response = self.view(request, pk=filtered_out_pk).render()
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -303,7 +307,8 @@ class TestInstanceView(TestCase):
         request = factory.put('/', data, HTTP_ACCEPT='text/html')
         response = self.view(request, pk=1).render()
         expected_error = '<span class="help-block">Ensure this field has no more than 100 characters.</span>'
-        self.assertIn(expected_error, response.rendered_content.decode('utf-8'))
+        self.assertIn(expected_error,
+                      response.rendered_content.decode('utf-8'))
 
 
 class TestFKInstanceView(TestCase):
@@ -318,10 +323,8 @@ class TestFKInstanceView(TestCase):
             ForeignKeySource(name='source_' + item, target=t).save()
 
         self.objects = ForeignKeySource.objects
-        self.data = [
-            {'id': obj.id, 'name': obj.name}
-            for obj in self.objects.all()
-        ]
+        self.data = [{'id': obj.id, 'name': obj.name}
+                     for obj in self.objects.all()]
         self.view = FKInstanceView.as_view()
 
 
@@ -339,10 +342,8 @@ class TestOverriddenGetObject(TestCase):
         for item in items:
             BasicModel(text=item).save()
         self.objects = BasicModel.objects
-        self.data = [
-            {'id': obj.id, 'text': obj.text}
-            for obj in self.objects.all()
-        ]
+        self.data = [{'id': obj.id, 'text': obj.text}
+                     for obj in self.objects.all()]
 
         class OverriddenGetObjectView(generics.RetrieveUpdateDestroyAPIView):
             """
@@ -477,10 +478,8 @@ class TestFilterBackendAppliedToViews(TestCase):
         for item in items:
             BasicModel(text=item).save()
         self.objects = BasicModel.objects
-        self.data = [
-            {'id': obj.id, 'text': obj.text}
-            for obj in self.objects.all()
-        ]
+        self.data = [{'id': obj.id, 'text': obj.text}
+                     for obj in self.objects.all()]
 
     def test_get_root_view_filters_by_name_with_filter_backend(self):
         """
@@ -493,7 +492,8 @@ class TestFilterBackendAppliedToViews(TestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data, [{'id': 1, 'text': 'foo'}])
 
-    def test_get_root_view_filters_out_all_models_with_exclusive_filter_backend(self):
+    def test_get_root_view_filters_out_all_models_with_exclusive_filter_backend(
+            self):
         """
         GET requests to ListCreateAPIView should return empty list when all models are filtered out.
         """
@@ -507,17 +507,20 @@ class TestFilterBackendAppliedToViews(TestCase):
         """
         GET requests to RetrieveUpdateDestroyAPIView should raise 404 when model filtered out.
         """
-        instance_view = InstanceView.as_view(filter_backends=(ExclusiveFilterBackend,))
+        instance_view = InstanceView.as_view(
+            filter_backends=(ExclusiveFilterBackend,))
         request = factory.get('/1')
         response = instance_view(request, pk=1).render()
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(response.data, {'detail': 'Not found.'})
 
-    def test_get_instance_view_will_return_single_object_when_filter_does_not_exclude_it(self):
+    def test_get_instance_view_will_return_single_object_when_filter_does_not_exclude_it(
+            self):
         """
         GET requests to RetrieveUpdateDestroyAPIView should return a single object when not excluded
         """
-        instance_view = InstanceView.as_view(filter_backends=(InclusiveFilterBackend,))
+        instance_view = InstanceView.as_view(
+            filter_backends=(InclusiveFilterBackend,))
         request = factory.get('/1')
         response = instance_view(request, pk=1).render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,11 +4,14 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.test import TestCase
 
-from rest_framework import (
-    exceptions, metadata, serializers, status, versioning, views
+from rest_framework import exceptions, metadata, status, versioning, views
+from rest_framework.fields import (
+    CharField, ChoiceField, IntegerField, ListField, NullBooleanField
 )
+from rest_framework.relations import PrimaryKeyRelatedField, RelatedField
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.request import Request
+from rest_framework.serializers import ModelSerializer, Serializer
 from rest_framework.test import APIRequestFactory
 
 from .models import BasicModel
@@ -21,6 +24,7 @@ class TestMetadata:
         """
         OPTIONS requests to views should return a valid 200 response.
         """
+
         class ExampleView(views.APIView):
             """Example view."""
             pass
@@ -46,8 +50,9 @@ class TestMetadata:
     def test_none_metadata(self):
         """
         OPTIONS requests to views where `metadata_class = None` should raise
-        a MethodNotAllowed exception, which will result in an HTTP 405 response.
+        a MethodNotAllowed exception, which will result in an HTTP 405 response
         """
+
         class ExampleView(views.APIView):
             metadata_class = None
 
@@ -61,27 +66,29 @@ class TestMetadata:
         On generic views OPTIONS should return an 'actions' key with metadata
         on the fields that may be supplied to PUT and POST requests.
         """
-        class NestedField(serializers.Serializer):
-            a = serializers.IntegerField()
-            b = serializers.IntegerField()
 
-        class ExampleSerializer(serializers.Serializer):
-            choice_field = serializers.ChoiceField(['red', 'green', 'blue'])
-            integer_field = serializers.IntegerField(
+        class NestedField(Serializer):
+            a = IntegerField()
+            b = IntegerField()
+
+        class ExampleSerializer(Serializer):
+            choice_field = ChoiceField(['red', 'green', 'blue'])
+            integer_field = IntegerField(
                 min_value=1, max_value=1000
             )
-            char_field = serializers.CharField(
+            char_field = CharField(
                 required=False, min_length=3, max_length=40
             )
-            list_field = serializers.ListField(
-                child=serializers.ListField(
-                    child=serializers.IntegerField()
+            list_field = ListField(
+                child=ListField(
+                    child=IntegerField()
                 )
             )
             nested_field = NestedField()
 
         class ExampleView(views.APIView):
             """Example view."""
+
             def post(self, request):
                 pass
 
@@ -179,13 +186,15 @@ class TestMetadata:
         If a user does not have global permissions on an action, then any
         metadata associated with it should not be included in OPTION responses.
         """
-        class ExampleSerializer(serializers.Serializer):
-            choice_field = serializers.ChoiceField(['red', 'green', 'blue'])
-            integer_field = serializers.IntegerField(max_value=10)
-            char_field = serializers.CharField(required=False)
+
+        class ExampleSerializer(Serializer):
+            choice_field = ChoiceField(['red', 'green', 'blue'])
+            integer_field = IntegerField(max_value=10)
+            char_field = CharField(required=False)
 
         class ExampleView(views.APIView):
             """Example view."""
+
             def post(self, request):
                 pass
 
@@ -209,13 +218,15 @@ class TestMetadata:
         If a user does not have object permissions on an action, then any
         metadata associated with it should not be included in OPTION responses.
         """
-        class ExampleSerializer(serializers.Serializer):
-            choice_field = serializers.ChoiceField(['red', 'green', 'blue'])
-            integer_field = serializers.IntegerField(max_value=10)
-            char_field = serializers.CharField(required=False)
+
+        class ExampleSerializer(Serializer):
+            choice_field = ChoiceField(['red', 'green', 'blue'])
+            integer_field = IntegerField(max_value=10)
+            char_field = CharField(required=False)
 
         class ExampleView(views.APIView):
             """Example view."""
+
             def post(self, request):
                 pass
 
@@ -243,7 +254,7 @@ class TestMetadata:
 
             def get_serializer(self):
                 assert hasattr(self.request, 'version')
-                return serializers.Serializer()
+                return Serializer()
 
         view = ExampleView.as_view()
         view(request=request)
@@ -257,7 +268,7 @@ class TestMetadata:
 
             def get_serializer(self):
                 assert hasattr(self.request, 'versioning_scheme')
-                return serializers.Serializer()
+                return Serializer()
 
         scheme = versioning.QueryParameterVersioning
         view = ExampleView.as_view(versioning_class=scheme)
@@ -267,7 +278,7 @@ class TestMetadata:
 class TestSimpleMetadataFieldInfo(TestCase):
     def test_null_boolean_field_info_type(self):
         options = metadata.SimpleMetadata()
-        field_info = options.get_field_info(serializers.NullBooleanField())
+        field_info = options.get_field_info(NullBooleanField())
         self.assertEqual(field_info['type'], 'boolean')
 
     def test_related_field_choices(self):
@@ -275,7 +286,7 @@ class TestSimpleMetadataFieldInfo(TestCase):
         BasicModel.objects.create()
         with self.assertNumQueries(0):
             field_info = options.get_field_info(
-                serializers.RelatedField(queryset=BasicModel.objects.all())
+                RelatedField(queryset=BasicModel.objects.all())
             )
         self.assertNotIn('choices', field_info)
 
@@ -287,16 +298,18 @@ class TestModelSerializerMetadata(TestCase):
         on the fields that may be supplied to PUT and POST requests. It should
         not fail when a read_only PrimaryKeyRelatedField is present
         """
+
         class Parent(models.Model):
-            integer_field = models.IntegerField(validators=[MinValueValidator(1), MaxValueValidator(1000)])
+            integer_field = models.IntegerField(
+                validators=[MinValueValidator(1), MaxValueValidator(1000)])
             children = models.ManyToManyField('Child')
             name = models.CharField(max_length=100, blank=True, null=True)
 
         class Child(models.Model):
             name = models.CharField(max_length=100)
 
-        class ExampleSerializer(serializers.ModelSerializer):
-            children = serializers.PrimaryKeyRelatedField(read_only=True, many=True)
+        class ExampleSerializer(ModelSerializer):
+            children = PrimaryKeyRelatedField(read_only=True, many=True)
 
             class Meta:
                 model = Parent
@@ -304,6 +317,7 @@ class TestModelSerializerMetadata(TestCase):
 
         class ExampleView(views.APIView):
             """Example view."""
+
             def post(self, request):
                 pass
 

--- a/tests/test_multitable_inheritance.py
+++ b/tests/test_multitable_inheritance.py
@@ -17,7 +17,8 @@ class ChildModel(ParentModel):
 
 
 class AssociatedModel(RESTFrameworkModel):
-    ref = models.OneToOneField(ParentModel, primary_key=True, on_delete=models.CASCADE)
+    ref = models.OneToOneField(ParentModel, primary_key=True,
+                               on_delete=models.CASCADE)
     name = models.CharField(max_length=100)
 
 
@@ -36,7 +37,6 @@ class AssociatedModelSerializer(serializers.ModelSerializer):
 
 # Tests
 class InheritedModelSerializationTests(TestCase):
-
     def test_multitable_inherited_model_fields_as_expected(self):
         """
         Assert that the parent pointer field is not included in the fields

--- a/tests/test_one_to_one_with_inheritance.py
+++ b/tests/test_one_to_one_with_inheritance.py
@@ -5,9 +5,6 @@ from django.test import TestCase
 
 from rest_framework import serializers
 from tests.models import RESTFrameworkModel
-
-
-# Models
 from tests.test_multitable_inheritance import ChildModel
 
 
@@ -26,7 +23,6 @@ class DerivedModelSerializer(serializers.ModelSerializer):
 
 
 class ChildAssociatedModelSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = ChildAssociatedModel
         fields = ['id', 'child_name']
@@ -34,7 +30,6 @@ class ChildAssociatedModelSerializer(serializers.ModelSerializer):
 
 # Tests
 class InheritedModelSerializationTests(TestCase):
-
     def test_multitable_inherited_model_fields_as_expected(self):
         """
         Assert that the parent pointer field is not included in the fields

--- a/tests/test_relations_generic.py
+++ b/tests/test_relations_generic.py
@@ -8,7 +8,8 @@ from django.db import models
 from django.test import TestCase
 from django.utils.encoding import python_2_unicode_compatible
 
-from rest_framework import serializers
+from rest_framework.relations import StringRelatedField
+from rest_framework.serializers import ModelSerializer
 
 
 @python_2_unicode_compatible
@@ -51,7 +52,8 @@ class Note(models.Model):
 
 class TestGenericRelations(TestCase):
     def setUp(self):
-        self.bookmark = Bookmark.objects.create(url='https://www.djangoproject.com/')
+        self.bookmark = Bookmark.objects.create(
+            url='https://www.djangoproject.com/')
         Tag.objects.create(tagged_item=self.bookmark, tag='django')
         Tag.objects.create(tagged_item=self.bookmark, tag='python')
         self.note = Note.objects.create(text='Remember the milk')
@@ -63,8 +65,8 @@ class TestGenericRelations(TestCase):
         IE. A reverse generic relationship.
         """
 
-        class BookmarkSerializer(serializers.ModelSerializer):
-            tags = serializers.StringRelatedField(many=True)
+        class BookmarkSerializer(ModelSerializer):
+            tags = StringRelatedField(many=True)
 
             class Meta:
                 model = Bookmark
@@ -83,8 +85,8 @@ class TestGenericRelations(TestCase):
         IE. A forward generic relationship.
         """
 
-        class TagSerializer(serializers.ModelSerializer):
-            tagged_item = serializers.StringRelatedField()
+        class TagSerializer(ModelSerializer):
+            tagged_item = StringRelatedField()
 
             class Meta:
                 model = Tag

--- a/tests/test_relations_hyperlink.py
+++ b/tests/test_relations_hyperlink.py
@@ -11,7 +11,8 @@ from tests.models import (
 )
 
 factory = APIRequestFactory()
-request = factory.get('/')  # Just to ensure we have a request in the serializer context
+request = factory.get(
+    '/')  # Just to ensure we have a request in the serializer context
 
 
 def dummy_view(request, pk):
@@ -20,13 +21,20 @@ def dummy_view(request, pk):
 
 urlpatterns = [
     url(r'^dummyurl/(?P<pk>[0-9]+)/$', dummy_view, name='dummy-url'),
-    url(r'^manytomanysource/(?P<pk>[0-9]+)/$', dummy_view, name='manytomanysource-detail'),
-    url(r'^manytomanytarget/(?P<pk>[0-9]+)/$', dummy_view, name='manytomanytarget-detail'),
-    url(r'^foreignkeysource/(?P<pk>[0-9]+)/$', dummy_view, name='foreignkeysource-detail'),
-    url(r'^foreignkeytarget/(?P<pk>[0-9]+)/$', dummy_view, name='foreignkeytarget-detail'),
-    url(r'^nullableforeignkeysource/(?P<pk>[0-9]+)/$', dummy_view, name='nullableforeignkeysource-detail'),
-    url(r'^onetoonetarget/(?P<pk>[0-9]+)/$', dummy_view, name='onetoonetarget-detail'),
-    url(r'^nullableonetoonesource/(?P<pk>[0-9]+)/$', dummy_view, name='nullableonetoonesource-detail'),
+    url(r'^manytomanysource/(?P<pk>[0-9]+)/$', dummy_view,
+        name='manytomanysource-detail'),
+    url(r'^manytomanytarget/(?P<pk>[0-9]+)/$', dummy_view,
+        name='manytomanytarget-detail'),
+    url(r'^foreignkeysource/(?P<pk>[0-9]+)/$', dummy_view,
+        name='foreignkeysource-detail'),
+    url(r'^foreignkeytarget/(?P<pk>[0-9]+)/$', dummy_view,
+        name='foreignkeytarget-detail'),
+    url(r'^nullableforeignkeysource/(?P<pk>[0-9]+)/$', dummy_view,
+        name='nullableforeignkeysource-detail'),
+    url(r'^onetoonetarget/(?P<pk>[0-9]+)/$', dummy_view,
+        name='onetoonetarget-detail'),
+    url(r'^nullableonetoonesource/(?P<pk>[0-9]+)/$', dummy_view,
+        name='nullableonetoonesource-detail'),
 ]
 
 
@@ -57,7 +65,8 @@ class ForeignKeySourceSerializer(serializers.HyperlinkedModelSerializer):
 
 
 # Nullable ForeignKey
-class NullableForeignKeySourceSerializer(serializers.HyperlinkedModelSerializer):
+class NullableForeignKeySourceSerializer(serializers.
+                                         HyperlinkedModelSerializer):
     class Meta:
         model = NullableForeignKeySource
         fields = ('url', 'name', 'target')
@@ -84,83 +93,141 @@ class HyperlinkedManyToManyTests(TestCase):
 
     def test_relative_hyperlinks(self):
         queryset = ManyToManySource.objects.all()
-        serializer = ManyToManySourceSerializer(queryset, many=True, context={'request': None})
+        serializer = ManyToManySourceSerializer(queryset, many=True,
+                                                context={'request': None})
         expected = [
-            {'url': '/manytomanysource/1/', 'name': 'source-1', 'targets': ['/manytomanytarget/1/']},
-            {'url': '/manytomanysource/2/', 'name': 'source-2', 'targets': ['/manytomanytarget/1/', '/manytomanytarget/2/']},
-            {'url': '/manytomanysource/3/', 'name': 'source-3', 'targets': ['/manytomanytarget/1/', '/manytomanytarget/2/', '/manytomanytarget/3/']}
+            {'url': '/manytomanysource/1/', 'name': 'source-1',
+             'targets': ['/manytomanytarget/1/']},
+            {'url': '/manytomanysource/2/', 'name': 'source-2',
+             'targets': ['/manytomanytarget/1/', '/manytomanytarget/2/']},
+            {'url': '/manytomanysource/3/', 'name': 'source-3',
+             'targets': ['/manytomanytarget/1/', '/manytomanytarget/2/',
+                         '/manytomanytarget/3/']}
         ]
         with self.assertNumQueries(4):
             self.assertEqual(serializer.data, expected)
 
     def test_many_to_many_retrieve(self):
         queryset = ManyToManySource.objects.all()
-        serializer = ManyToManySourceSerializer(queryset, many=True, context={'request': request})
+        serializer = ManyToManySourceSerializer(queryset, many=True,
+                                                context={'request': request})
         expected = [
-            {'url': 'http://testserver/manytomanysource/1/', 'name': 'source-1', 'targets': ['http://testserver/manytomanytarget/1/']},
-            {'url': 'http://testserver/manytomanysource/2/', 'name': 'source-2', 'targets': ['http://testserver/manytomanytarget/1/', 'http://testserver/manytomanytarget/2/']},
-            {'url': 'http://testserver/manytomanysource/3/', 'name': 'source-3', 'targets': ['http://testserver/manytomanytarget/1/', 'http://testserver/manytomanytarget/2/', 'http://testserver/manytomanytarget/3/']}
+            {'url': 'http://testserver/manytomanysource/1/',
+             'name': 'source-1',
+             'targets': ['http://testserver/manytomanytarget/1/']},
+            {'url': 'http://testserver/manytomanysource/2/',
+             'name': 'source-2',
+             'targets': ['http://testserver/manytomanytarget/1/',
+                         'http://testserver/manytomanytarget/2/']},
+            {'url': 'http://testserver/manytomanysource/3/',
+             'name': 'source-3',
+             'targets': ['http://testserver/manytomanytarget/1/',
+                         'http://testserver/manytomanytarget/2/',
+                         'http://testserver/manytomanytarget/3/']}
         ]
         with self.assertNumQueries(4):
             self.assertEqual(serializer.data, expected)
 
     def test_many_to_many_retrieve_prefetch_related(self):
         queryset = ManyToManySource.objects.all().prefetch_related('targets')
-        serializer = ManyToManySourceSerializer(queryset, many=True, context={'request': request})
+        serializer = ManyToManySourceSerializer(queryset, many=True,
+                                                context={'request': request})
         with self.assertNumQueries(2):
             serializer.data
 
     def test_reverse_many_to_many_retrieve(self):
         queryset = ManyToManyTarget.objects.all()
-        serializer = ManyToManyTargetSerializer(queryset, many=True, context={'request': request})
+        serializer = ManyToManyTargetSerializer(queryset, many=True,
+                                                context={'request': request})
         expected = [
-            {'url': 'http://testserver/manytomanytarget/1/', 'name': 'target-1', 'sources': ['http://testserver/manytomanysource/1/', 'http://testserver/manytomanysource/2/', 'http://testserver/manytomanysource/3/']},
-            {'url': 'http://testserver/manytomanytarget/2/', 'name': 'target-2', 'sources': ['http://testserver/manytomanysource/2/', 'http://testserver/manytomanysource/3/']},
-            {'url': 'http://testserver/manytomanytarget/3/', 'name': 'target-3', 'sources': ['http://testserver/manytomanysource/3/']}
+            {'url': 'http://testserver/manytomanytarget/1/',
+             'name': 'target-1',
+             'sources': ['http://testserver/manytomanysource/1/',
+                         'http://testserver/manytomanysource/2/',
+                         'http://testserver/manytomanysource/3/']},
+            {'url': 'http://testserver/manytomanytarget/2/',
+             'name': 'target-2',
+             'sources': ['http://testserver/manytomanysource/2/',
+                         'http://testserver/manytomanysource/3/']},
+            {'url': 'http://testserver/manytomanytarget/3/',
+             'name': 'target-3',
+             'sources': ['http://testserver/manytomanysource/3/']}
         ]
         with self.assertNumQueries(4):
             self.assertEqual(serializer.data, expected)
 
     def test_many_to_many_update(self):
-        data = {'url': 'http://testserver/manytomanysource/1/', 'name': 'source-1', 'targets': ['http://testserver/manytomanytarget/1/', 'http://testserver/manytomanytarget/2/', 'http://testserver/manytomanytarget/3/']}
+        data = {'url': 'http://testserver/manytomanysource/1/',
+                'name': 'source-1',
+                'targets': ['http://testserver/manytomanytarget/1/',
+                            'http://testserver/manytomanytarget/2/',
+                            'http://testserver/manytomanytarget/3/']}
         instance = ManyToManySource.objects.get(pk=1)
-        serializer = ManyToManySourceSerializer(instance, data=data, context={'request': request})
+        serializer = ManyToManySourceSerializer(instance, data=data,
+                                                context={'request': request})
         self.assertTrue(serializer.is_valid())
         serializer.save()
         self.assertEqual(serializer.data, data)
 
         # Ensure source 1 is updated, and everything else is as expected
         queryset = ManyToManySource.objects.all()
-        serializer = ManyToManySourceSerializer(queryset, many=True, context={'request': request})
+        serializer = ManyToManySourceSerializer(queryset, many=True,
+                                                context={'request': request})
         expected = [
-            {'url': 'http://testserver/manytomanysource/1/', 'name': 'source-1', 'targets': ['http://testserver/manytomanytarget/1/', 'http://testserver/manytomanytarget/2/', 'http://testserver/manytomanytarget/3/']},
-            {'url': 'http://testserver/manytomanysource/2/', 'name': 'source-2', 'targets': ['http://testserver/manytomanytarget/1/', 'http://testserver/manytomanytarget/2/']},
-            {'url': 'http://testserver/manytomanysource/3/', 'name': 'source-3', 'targets': ['http://testserver/manytomanytarget/1/', 'http://testserver/manytomanytarget/2/', 'http://testserver/manytomanytarget/3/']}
+            {'url': 'http://testserver/manytomanysource/1/',
+             'name': 'source-1',
+             'targets': ['http://testserver/manytomanytarget/1/',
+                         'http://testserver/manytomanytarget/2/',
+                         'http://testserver/manytomanytarget/3/']},
+            {'url': 'http://testserver/manytomanysource/2/',
+             'name': 'source-2',
+             'targets': ['http://testserver/manytomanytarget/1/',
+                         'http://testserver/manytomanytarget/2/']},
+            {'url': 'http://testserver/manytomanysource/3/',
+             'name': 'source-3',
+             'targets': ['http://testserver/manytomanytarget/1/',
+                         'http://testserver/manytomanytarget/2/',
+                         'http://testserver/manytomanytarget/3/']}
         ]
         self.assertEqual(serializer.data, expected)
 
     def test_reverse_many_to_many_update(self):
-        data = {'url': 'http://testserver/manytomanytarget/1/', 'name': 'target-1', 'sources': ['http://testserver/manytomanysource/1/']}
+        data = {'url': 'http://testserver/manytomanytarget/1/',
+                'name': 'target-1',
+                'sources': ['http://testserver/manytomanysource/1/']}
         instance = ManyToManyTarget.objects.get(pk=1)
-        serializer = ManyToManyTargetSerializer(instance, data=data, context={'request': request})
+        serializer = ManyToManyTargetSerializer(instance, data=data,
+                                                context={'request': request})
         self.assertTrue(serializer.is_valid())
         serializer.save()
         self.assertEqual(serializer.data, data)
 
         # Ensure target 1 is updated, and everything else is as expected
         queryset = ManyToManyTarget.objects.all()
-        serializer = ManyToManyTargetSerializer(queryset, many=True, context={'request': request})
+        serializer = ManyToManyTargetSerializer(queryset, many=True,
+                                                context={'request': request})
         expected = [
-            {'url': 'http://testserver/manytomanytarget/1/', 'name': 'target-1', 'sources': ['http://testserver/manytomanysource/1/']},
-            {'url': 'http://testserver/manytomanytarget/2/', 'name': 'target-2', 'sources': ['http://testserver/manytomanysource/2/', 'http://testserver/manytomanysource/3/']},
-            {'url': 'http://testserver/manytomanytarget/3/', 'name': 'target-3', 'sources': ['http://testserver/manytomanysource/3/']}
+            {'url': 'http://testserver/manytomanytarget/1/',
+             'name': 'target-1',
+             'sources': ['http://testserver/manytomanysource/1/']},
+            {'url': 'http://testserver/manytomanytarget/2/',
+             'name': 'target-2',
+             'sources': ['http://testserver/manytomanysource/2/',
+                         'http://testserver/manytomanysource/3/']},
+            {'url': 'http://testserver/manytomanytarget/3/',
+             'name': 'target-3',
+             'sources': ['http://testserver/manytomanysource/3/']}
 
         ]
         self.assertEqual(serializer.data, expected)
 
     def test_many_to_many_create(self):
-        data = {'url': 'http://testserver/manytomanysource/4/', 'name': 'source-4', 'targets': ['http://testserver/manytomanytarget/1/', 'http://testserver/manytomanytarget/3/']}
-        serializer = ManyToManySourceSerializer(data=data, context={'request': request})
+        data = {'url': 'http://testserver/manytomanysource/4/',
+                'name': 'source-4',
+                'targets': ['http://testserver/manytomanytarget/1/',
+                            'http://testserver/manytomanytarget/3/']}
+        serializer = ManyToManySourceSerializer(data=data,
+                                                context={'request': request})
         self.assertTrue(serializer.is_valid())
         obj = serializer.save()
         self.assertEqual(serializer.data, data)
@@ -168,18 +235,35 @@ class HyperlinkedManyToManyTests(TestCase):
 
         # Ensure source 4 is added, and everything else is as expected
         queryset = ManyToManySource.objects.all()
-        serializer = ManyToManySourceSerializer(queryset, many=True, context={'request': request})
+        serializer = ManyToManySourceSerializer(queryset, many=True,
+                                                context={'request': request})
         expected = [
-            {'url': 'http://testserver/manytomanysource/1/', 'name': 'source-1', 'targets': ['http://testserver/manytomanytarget/1/']},
-            {'url': 'http://testserver/manytomanysource/2/', 'name': 'source-2', 'targets': ['http://testserver/manytomanytarget/1/', 'http://testserver/manytomanytarget/2/']},
-            {'url': 'http://testserver/manytomanysource/3/', 'name': 'source-3', 'targets': ['http://testserver/manytomanytarget/1/', 'http://testserver/manytomanytarget/2/', 'http://testserver/manytomanytarget/3/']},
-            {'url': 'http://testserver/manytomanysource/4/', 'name': 'source-4', 'targets': ['http://testserver/manytomanytarget/1/', 'http://testserver/manytomanytarget/3/']}
+            {'url': 'http://testserver/manytomanysource/1/',
+             'name': 'source-1',
+             'targets': ['http://testserver/manytomanytarget/1/']},
+            {'url': 'http://testserver/manytomanysource/2/',
+             'name': 'source-2',
+             'targets': ['http://testserver/manytomanytarget/1/',
+                         'http://testserver/manytomanytarget/2/']},
+            {'url': 'http://testserver/manytomanysource/3/',
+             'name': 'source-3',
+             'targets': ['http://testserver/manytomanytarget/1/',
+                         'http://testserver/manytomanytarget/2/',
+                         'http://testserver/manytomanytarget/3/']},
+            {'url': 'http://testserver/manytomanysource/4/',
+             'name': 'source-4',
+             'targets': ['http://testserver/manytomanytarget/1/',
+                         'http://testserver/manytomanytarget/3/']}
         ]
         self.assertEqual(serializer.data, expected)
 
     def test_reverse_many_to_many_create(self):
-        data = {'url': 'http://testserver/manytomanytarget/4/', 'name': 'target-4', 'sources': ['http://testserver/manytomanysource/1/', 'http://testserver/manytomanysource/3/']}
-        serializer = ManyToManyTargetSerializer(data=data, context={'request': request})
+        data = {'url': 'http://testserver/manytomanytarget/4/',
+                'name': 'target-4',
+                'sources': ['http://testserver/manytomanysource/1/',
+                            'http://testserver/manytomanysource/3/']}
+        serializer = ManyToManyTargetSerializer(data=data,
+                                                context={'request': request})
         self.assertTrue(serializer.is_valid())
         obj = serializer.save()
         self.assertEqual(serializer.data, data)
@@ -187,12 +271,25 @@ class HyperlinkedManyToManyTests(TestCase):
 
         # Ensure target 4 is added, and everything else is as expected
         queryset = ManyToManyTarget.objects.all()
-        serializer = ManyToManyTargetSerializer(queryset, many=True, context={'request': request})
+        serializer = ManyToManyTargetSerializer(queryset, many=True,
+                                                context={'request': request})
         expected = [
-            {'url': 'http://testserver/manytomanytarget/1/', 'name': 'target-1', 'sources': ['http://testserver/manytomanysource/1/', 'http://testserver/manytomanysource/2/', 'http://testserver/manytomanysource/3/']},
-            {'url': 'http://testserver/manytomanytarget/2/', 'name': 'target-2', 'sources': ['http://testserver/manytomanysource/2/', 'http://testserver/manytomanysource/3/']},
-            {'url': 'http://testserver/manytomanytarget/3/', 'name': 'target-3', 'sources': ['http://testserver/manytomanysource/3/']},
-            {'url': 'http://testserver/manytomanytarget/4/', 'name': 'target-4', 'sources': ['http://testserver/manytomanysource/1/', 'http://testserver/manytomanysource/3/']}
+            {'url': 'http://testserver/manytomanytarget/1/',
+             'name': 'target-1',
+             'sources': ['http://testserver/manytomanysource/1/',
+                         'http://testserver/manytomanysource/2/',
+                         'http://testserver/manytomanysource/3/']},
+            {'url': 'http://testserver/manytomanytarget/2/',
+             'name': 'target-2',
+             'sources': ['http://testserver/manytomanysource/2/',
+                         'http://testserver/manytomanysource/3/']},
+            {'url': 'http://testserver/manytomanytarget/3/',
+             'name': 'target-3',
+             'sources': ['http://testserver/manytomanysource/3/']},
+            {'url': 'http://testserver/manytomanytarget/4/',
+             'name': 'target-4',
+             'sources': ['http://testserver/manytomanysource/1/',
+                         'http://testserver/manytomanysource/3/']}
         ]
         self.assertEqual(serializer.data, expected)
 
@@ -210,62 +307,99 @@ class HyperlinkedForeignKeyTests(TestCase):
 
     def test_foreign_key_retrieve(self):
         queryset = ForeignKeySource.objects.all()
-        serializer = ForeignKeySourceSerializer(queryset, many=True, context={'request': request})
+        serializer = ForeignKeySourceSerializer(queryset, many=True,
+                                                context={'request': request})
         expected = [
-            {'url': 'http://testserver/foreignkeysource/1/', 'name': 'source-1', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/foreignkeysource/2/', 'name': 'source-2', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/foreignkeysource/3/', 'name': 'source-3', 'target': 'http://testserver/foreignkeytarget/1/'}
+            {'url': 'http://testserver/foreignkeysource/1/',
+             'name': 'source-1',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/foreignkeysource/2/',
+             'name': 'source-2',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/foreignkeysource/3/',
+             'name': 'source-3',
+             'target': 'http://testserver/foreignkeytarget/1/'}
         ]
         with self.assertNumQueries(1):
             self.assertEqual(serializer.data, expected)
 
     def test_reverse_foreign_key_retrieve(self):
         queryset = ForeignKeyTarget.objects.all()
-        serializer = ForeignKeyTargetSerializer(queryset, many=True, context={'request': request})
+        serializer = ForeignKeyTargetSerializer(queryset, many=True,
+                                                context={'request': request})
         expected = [
-            {'url': 'http://testserver/foreignkeytarget/1/', 'name': 'target-1', 'sources': ['http://testserver/foreignkeysource/1/', 'http://testserver/foreignkeysource/2/', 'http://testserver/foreignkeysource/3/']},
-            {'url': 'http://testserver/foreignkeytarget/2/', 'name': 'target-2', 'sources': []},
+            {'url': 'http://testserver/foreignkeytarget/1/',
+             'name': 'target-1',
+             'sources': ['http://testserver/foreignkeysource/1/',
+                         'http://testserver/foreignkeysource/2/',
+                         'http://testserver/foreignkeysource/3/']},
+            {'url': 'http://testserver/foreignkeytarget/2/',
+             'name': 'target-2', 'sources': []},
         ]
         with self.assertNumQueries(3):
             self.assertEqual(serializer.data, expected)
 
     def test_foreign_key_update(self):
-        data = {'url': 'http://testserver/foreignkeysource/1/', 'name': 'source-1', 'target': 'http://testserver/foreignkeytarget/2/'}
+        data = {'url': 'http://testserver/foreignkeysource/1/',
+                'name': 'source-1',
+                'target': 'http://testserver/foreignkeytarget/2/'}
         instance = ForeignKeySource.objects.get(pk=1)
-        serializer = ForeignKeySourceSerializer(instance, data=data, context={'request': request})
+        serializer = ForeignKeySourceSerializer(instance, data=data,
+                                                context={'request': request})
         self.assertTrue(serializer.is_valid())
         serializer.save()
         self.assertEqual(serializer.data, data)
 
         # Ensure source 1 is updated, and everything else is as expected
         queryset = ForeignKeySource.objects.all()
-        serializer = ForeignKeySourceSerializer(queryset, many=True, context={'request': request})
+        serializer = ForeignKeySourceSerializer(queryset, many=True,
+                                                context={'request': request})
         expected = [
-            {'url': 'http://testserver/foreignkeysource/1/', 'name': 'source-1', 'target': 'http://testserver/foreignkeytarget/2/'},
-            {'url': 'http://testserver/foreignkeysource/2/', 'name': 'source-2', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/foreignkeysource/3/', 'name': 'source-3', 'target': 'http://testserver/foreignkeytarget/1/'}
+            {'url': 'http://testserver/foreignkeysource/1/',
+             'name': 'source-1',
+             'target': 'http://testserver/foreignkeytarget/2/'},
+            {'url': 'http://testserver/foreignkeysource/2/',
+             'name': 'source-2',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/foreignkeysource/3/',
+             'name': 'source-3',
+             'target': 'http://testserver/foreignkeytarget/1/'}
         ]
         self.assertEqual(serializer.data, expected)
 
     def test_foreign_key_update_incorrect_type(self):
-        data = {'url': 'http://testserver/foreignkeysource/1/', 'name': 'source-1', 'target': 2}
+        data = {'url': 'http://testserver/foreignkeysource/1/',
+                'name': 'source-1', 'target': 2}
         instance = ForeignKeySource.objects.get(pk=1)
-        serializer = ForeignKeySourceSerializer(instance, data=data, context={'request': request})
+        serializer = ForeignKeySourceSerializer(instance, data=data,
+                                                context={'request': request})
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors, {'target': ['Incorrect type. Expected URL string, received int.']})
+        self.assertEqual(serializer.errors, {
+            'target': ['Incorrect type. Expected URL string, received int.']})
 
     def test_reverse_foreign_key_update(self):
-        data = {'url': 'http://testserver/foreignkeytarget/2/', 'name': 'target-2', 'sources': ['http://testserver/foreignkeysource/1/', 'http://testserver/foreignkeysource/3/']}
+        data = {'url': 'http://testserver/foreignkeytarget/2/',
+                'name': 'target-2',
+                'sources': ['http://testserver/foreignkeysource/1/',
+                            'http://testserver/foreignkeysource/3/']}
         instance = ForeignKeyTarget.objects.get(pk=2)
-        serializer = ForeignKeyTargetSerializer(instance, data=data, context={'request': request})
+        serializer = ForeignKeyTargetSerializer(instance, data=data,
+                                                context={'request': request})
         self.assertTrue(serializer.is_valid())
         # We shouldn't have saved anything to the db yet since save
         # hasn't been called.
         queryset = ForeignKeyTarget.objects.all()
-        new_serializer = ForeignKeyTargetSerializer(queryset, many=True, context={'request': request})
+        new_serializer = ForeignKeyTargetSerializer(queryset, many=True,
+                                                    context={
+                                                        'request': request})
         expected = [
-            {'url': 'http://testserver/foreignkeytarget/1/', 'name': 'target-1', 'sources': ['http://testserver/foreignkeysource/1/', 'http://testserver/foreignkeysource/2/', 'http://testserver/foreignkeysource/3/']},
-            {'url': 'http://testserver/foreignkeytarget/2/', 'name': 'target-2', 'sources': []},
+            {'url': 'http://testserver/foreignkeytarget/1/',
+             'name': 'target-1',
+             'sources': ['http://testserver/foreignkeysource/1/',
+                         'http://testserver/foreignkeysource/2/',
+                         'http://testserver/foreignkeysource/3/']},
+            {'url': 'http://testserver/foreignkeytarget/2/',
+             'name': 'target-2', 'sources': []},
         ]
         self.assertEqual(new_serializer.data, expected)
 
@@ -274,16 +408,25 @@ class HyperlinkedForeignKeyTests(TestCase):
 
         # Ensure target 2 is update, and everything else is as expected
         queryset = ForeignKeyTarget.objects.all()
-        serializer = ForeignKeyTargetSerializer(queryset, many=True, context={'request': request})
+        serializer = ForeignKeyTargetSerializer(queryset, many=True,
+                                                context={'request': request})
         expected = [
-            {'url': 'http://testserver/foreignkeytarget/1/', 'name': 'target-1', 'sources': ['http://testserver/foreignkeysource/2/']},
-            {'url': 'http://testserver/foreignkeytarget/2/', 'name': 'target-2', 'sources': ['http://testserver/foreignkeysource/1/', 'http://testserver/foreignkeysource/3/']},
+            {'url': 'http://testserver/foreignkeytarget/1/',
+             'name': 'target-1',
+             'sources': ['http://testserver/foreignkeysource/2/']},
+            {'url': 'http://testserver/foreignkeytarget/2/',
+             'name': 'target-2',
+             'sources': ['http://testserver/foreignkeysource/1/',
+                         'http://testserver/foreignkeysource/3/']},
         ]
         self.assertEqual(serializer.data, expected)
 
     def test_foreign_key_create(self):
-        data = {'url': 'http://testserver/foreignkeysource/4/', 'name': 'source-4', 'target': 'http://testserver/foreignkeytarget/2/'}
-        serializer = ForeignKeySourceSerializer(data=data, context={'request': request})
+        data = {'url': 'http://testserver/foreignkeysource/4/',
+                'name': 'source-4',
+                'target': 'http://testserver/foreignkeytarget/2/'}
+        serializer = ForeignKeySourceSerializer(data=data,
+                                                context={'request': request})
         self.assertTrue(serializer.is_valid())
         obj = serializer.save()
         self.assertEqual(serializer.data, data)
@@ -291,18 +434,31 @@ class HyperlinkedForeignKeyTests(TestCase):
 
         # Ensure source 1 is updated, and everything else is as expected
         queryset = ForeignKeySource.objects.all()
-        serializer = ForeignKeySourceSerializer(queryset, many=True, context={'request': request})
+        serializer = ForeignKeySourceSerializer(queryset, many=True,
+                                                context={'request': request})
         expected = [
-            {'url': 'http://testserver/foreignkeysource/1/', 'name': 'source-1', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/foreignkeysource/2/', 'name': 'source-2', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/foreignkeysource/3/', 'name': 'source-3', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/foreignkeysource/4/', 'name': 'source-4', 'target': 'http://testserver/foreignkeytarget/2/'},
+            {'url': 'http://testserver/foreignkeysource/1/',
+             'name': 'source-1',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/foreignkeysource/2/',
+             'name': 'source-2',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/foreignkeysource/3/',
+             'name': 'source-3',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/foreignkeysource/4/',
+             'name': 'source-4',
+             'target': 'http://testserver/foreignkeytarget/2/'},
         ]
         self.assertEqual(serializer.data, expected)
 
     def test_reverse_foreign_key_create(self):
-        data = {'url': 'http://testserver/foreignkeytarget/3/', 'name': 'target-3', 'sources': ['http://testserver/foreignkeysource/1/', 'http://testserver/foreignkeysource/3/']}
-        serializer = ForeignKeyTargetSerializer(data=data, context={'request': request})
+        data = {'url': 'http://testserver/foreignkeytarget/3/',
+                'name': 'target-3',
+                'sources': ['http://testserver/foreignkeysource/1/',
+                            'http://testserver/foreignkeysource/3/']}
+        serializer = ForeignKeyTargetSerializer(data=data,
+                                                context={'request': request})
         self.assertTrue(serializer.is_valid())
         obj = serializer.save()
         self.assertEqual(serializer.data, data)
@@ -310,20 +466,30 @@ class HyperlinkedForeignKeyTests(TestCase):
 
         # Ensure target 4 is added, and everything else is as expected
         queryset = ForeignKeyTarget.objects.all()
-        serializer = ForeignKeyTargetSerializer(queryset, many=True, context={'request': request})
+        serializer = ForeignKeyTargetSerializer(queryset, many=True,
+                                                context={'request': request})
         expected = [
-            {'url': 'http://testserver/foreignkeytarget/1/', 'name': 'target-1', 'sources': ['http://testserver/foreignkeysource/2/']},
-            {'url': 'http://testserver/foreignkeytarget/2/', 'name': 'target-2', 'sources': []},
-            {'url': 'http://testserver/foreignkeytarget/3/', 'name': 'target-3', 'sources': ['http://testserver/foreignkeysource/1/', 'http://testserver/foreignkeysource/3/']},
+            {'url': 'http://testserver/foreignkeytarget/1/',
+             'name': 'target-1',
+             'sources': ['http://testserver/foreignkeysource/2/']},
+            {'url': 'http://testserver/foreignkeytarget/2/',
+             'name': 'target-2', 'sources': []},
+            {'url': 'http://testserver/foreignkeytarget/3/',
+             'name': 'target-3',
+             'sources': ['http://testserver/foreignkeysource/1/',
+                         'http://testserver/foreignkeysource/3/']},
         ]
         self.assertEqual(serializer.data, expected)
 
     def test_foreign_key_update_with_invalid_null(self):
-        data = {'url': 'http://testserver/foreignkeysource/1/', 'name': 'source-1', 'target': None}
+        data = {'url': 'http://testserver/foreignkeysource/1/',
+                'name': 'source-1', 'target': None}
         instance = ForeignKeySource.objects.get(pk=1)
-        serializer = ForeignKeySourceSerializer(instance, data=data, context={'request': request})
+        serializer = ForeignKeySourceSerializer(instance, data=data,
+                                                context={'request': request})
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors, {'target': ['This field may not be null.']})
+        self.assertEqual(serializer.errors,
+                         {'target': ['This field may not be null.']})
 
 
 @override_settings(ROOT_URLCONF='tests.test_relations_hyperlink')
@@ -334,22 +500,32 @@ class HyperlinkedNullableForeignKeyTests(TestCase):
         for idx in range(1, 4):
             if idx == 3:
                 target = None
-            source = NullableForeignKeySource(name='source-%d' % idx, target=target)
+            source = NullableForeignKeySource(name='source-%d' % idx,
+                                              target=target)
             source.save()
 
     def test_foreign_key_retrieve_with_null(self):
         queryset = NullableForeignKeySource.objects.all()
-        serializer = NullableForeignKeySourceSerializer(queryset, many=True, context={'request': request})
+        serializer = NullableForeignKeySourceSerializer(
+            queryset, many=True,
+            context={'request': request})
         expected = [
-            {'url': 'http://testserver/nullableforeignkeysource/1/', 'name': 'source-1', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/nullableforeignkeysource/2/', 'name': 'source-2', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/nullableforeignkeysource/3/', 'name': 'source-3', 'target': None},
+            {'url': 'http://testserver/nullableforeignkeysource/1/',
+             'name': 'source-1',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/nullableforeignkeysource/2/',
+             'name': 'source-2',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/nullableforeignkeysource/3/',
+             'name': 'source-3', 'target': None},
         ]
         self.assertEqual(serializer.data, expected)
 
     def test_foreign_key_create_with_valid_null(self):
-        data = {'url': 'http://testserver/nullableforeignkeysource/4/', 'name': 'source-4', 'target': None}
-        serializer = NullableForeignKeySourceSerializer(data=data, context={'request': request})
+        data = {'url': 'http://testserver/nullableforeignkeysource/4/',
+                'name': 'source-4', 'target': None}
+        serializer = NullableForeignKeySourceSerializer(data=data, context={
+            'request': request})
         self.assertTrue(serializer.is_valid())
         obj = serializer.save()
         self.assertEqual(serializer.data, data)
@@ -357,12 +533,20 @@ class HyperlinkedNullableForeignKeyTests(TestCase):
 
         # Ensure source 4 is created, and everything else is as expected
         queryset = NullableForeignKeySource.objects.all()
-        serializer = NullableForeignKeySourceSerializer(queryset, many=True, context={'request': request})
+        serializer = NullableForeignKeySourceSerializer(
+            queryset, many=True,
+            context={'request': request})
         expected = [
-            {'url': 'http://testserver/nullableforeignkeysource/1/', 'name': 'source-1', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/nullableforeignkeysource/2/', 'name': 'source-2', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/nullableforeignkeysource/3/', 'name': 'source-3', 'target': None},
-            {'url': 'http://testserver/nullableforeignkeysource/4/', 'name': 'source-4', 'target': None}
+            {'url': 'http://testserver/nullableforeignkeysource/1/',
+             'name': 'source-1',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/nullableforeignkeysource/2/',
+             'name': 'source-2',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/nullableforeignkeysource/3/',
+             'name': 'source-3', 'target': None},
+            {'url': 'http://testserver/nullableforeignkeysource/4/',
+             'name': 'source-4', 'target': None}
         ]
         self.assertEqual(serializer.data, expected)
 
@@ -371,9 +555,13 @@ class HyperlinkedNullableForeignKeyTests(TestCase):
         The emptystring should be interpreted as null in the context
         of relationships.
         """
-        data = {'url': 'http://testserver/nullableforeignkeysource/4/', 'name': 'source-4', 'target': ''}
-        expected_data = {'url': 'http://testserver/nullableforeignkeysource/4/', 'name': 'source-4', 'target': None}
-        serializer = NullableForeignKeySourceSerializer(data=data, context={'request': request})
+        data = {'url': 'http://testserver/nullableforeignkeysource/4/',
+                'name': 'source-4', 'target': ''}
+        expected_data = {
+            'url': 'http://testserver/nullableforeignkeysource/4/',
+            'name': 'source-4', 'target': None}
+        serializer = NullableForeignKeySourceSerializer(data=data, context={
+            'request': request})
         self.assertTrue(serializer.is_valid())
         obj = serializer.save()
         self.assertEqual(serializer.data, expected_data)
@@ -381,30 +569,47 @@ class HyperlinkedNullableForeignKeyTests(TestCase):
 
         # Ensure source 4 is created, and everything else is as expected
         queryset = NullableForeignKeySource.objects.all()
-        serializer = NullableForeignKeySourceSerializer(queryset, many=True, context={'request': request})
+        serializer = NullableForeignKeySourceSerializer(
+            queryset, many=True,
+            context={'request': request})
         expected = [
-            {'url': 'http://testserver/nullableforeignkeysource/1/', 'name': 'source-1', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/nullableforeignkeysource/2/', 'name': 'source-2', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/nullableforeignkeysource/3/', 'name': 'source-3', 'target': None},
-            {'url': 'http://testserver/nullableforeignkeysource/4/', 'name': 'source-4', 'target': None}
+            {'url': 'http://testserver/nullableforeignkeysource/1/',
+             'name': 'source-1',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/nullableforeignkeysource/2/',
+             'name': 'source-2',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/nullableforeignkeysource/3/',
+             'name': 'source-3', 'target': None},
+            {'url': 'http://testserver/nullableforeignkeysource/4/',
+             'name': 'source-4', 'target': None}
         ]
         self.assertEqual(serializer.data, expected)
 
     def test_foreign_key_update_with_valid_null(self):
-        data = {'url': 'http://testserver/nullableforeignkeysource/1/', 'name': 'source-1', 'target': None}
+        data = {'url': 'http://testserver/nullableforeignkeysource/1/',
+                'name': 'source-1', 'target': None}
         instance = NullableForeignKeySource.objects.get(pk=1)
-        serializer = NullableForeignKeySourceSerializer(instance, data=data, context={'request': request})
+        serializer = NullableForeignKeySourceSerializer(
+            instance, data=data,
+            context={'request': request})
         self.assertTrue(serializer.is_valid())
         serializer.save()
         self.assertEqual(serializer.data, data)
 
         # Ensure source 1 is updated, and everything else is as expected
         queryset = NullableForeignKeySource.objects.all()
-        serializer = NullableForeignKeySourceSerializer(queryset, many=True, context={'request': request})
+        serializer = NullableForeignKeySourceSerializer(
+            queryset, many=True,
+            context={'request': request})
         expected = [
-            {'url': 'http://testserver/nullableforeignkeysource/1/', 'name': 'source-1', 'target': None},
-            {'url': 'http://testserver/nullableforeignkeysource/2/', 'name': 'source-2', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/nullableforeignkeysource/3/', 'name': 'source-3', 'target': None},
+            {'url': 'http://testserver/nullableforeignkeysource/1/',
+             'name': 'source-1', 'target': None},
+            {'url': 'http://testserver/nullableforeignkeysource/2/',
+             'name': 'source-2',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/nullableforeignkeysource/3/',
+             'name': 'source-3', 'target': None},
         ]
         self.assertEqual(serializer.data, expected)
 
@@ -413,21 +618,33 @@ class HyperlinkedNullableForeignKeyTests(TestCase):
         The emptystring should be interpreted as null in the context
         of relationships.
         """
-        data = {'url': 'http://testserver/nullableforeignkeysource/1/', 'name': 'source-1', 'target': ''}
-        expected_data = {'url': 'http://testserver/nullableforeignkeysource/1/', 'name': 'source-1', 'target': None}
+        data = {'url': 'http://testserver/nullableforeignkeysource/1/',
+                'name': 'source-1', 'target': ''}
+        expected_data = {
+            'url': 'http://testserver/nullableforeignkeysource/1/',
+            'name': 'source-1', 'target': None}
         instance = NullableForeignKeySource.objects.get(pk=1)
-        serializer = NullableForeignKeySourceSerializer(instance, data=data, context={'request': request})
+        serializer = NullableForeignKeySourceSerializer(
+            instance, data=data,
+            context={'request': request})
         self.assertTrue(serializer.is_valid())
         serializer.save()
         self.assertEqual(serializer.data, expected_data)
 
         # Ensure source 1 is updated, and everything else is as expected
         queryset = NullableForeignKeySource.objects.all()
-        serializer = NullableForeignKeySourceSerializer(queryset, many=True, context={'request': request})
+        serializer = NullableForeignKeySourceSerializer(
+            queryset,
+            many=True,
+            context={'request': request})
         expected = [
-            {'url': 'http://testserver/nullableforeignkeysource/1/', 'name': 'source-1', 'target': None},
-            {'url': 'http://testserver/nullableforeignkeysource/2/', 'name': 'source-2', 'target': 'http://testserver/foreignkeytarget/1/'},
-            {'url': 'http://testserver/nullableforeignkeysource/3/', 'name': 'source-3', 'target': None},
+            {'url': 'http://testserver/nullableforeignkeysource/1/',
+             'name': 'source-1', 'target': None},
+            {'url': 'http://testserver/nullableforeignkeysource/2/',
+             'name': 'source-2',
+             'target': 'http://testserver/foreignkeytarget/1/'},
+            {'url': 'http://testserver/nullableforeignkeysource/3/',
+             'name': 'source-3', 'target': None},
         ]
         self.assertEqual(serializer.data, expected)
 
@@ -444,9 +661,14 @@ class HyperlinkedNullableOneToOneTests(TestCase):
 
     def test_reverse_foreign_key_retrieve_with_null(self):
         queryset = OneToOneTarget.objects.all()
-        serializer = NullableOneToOneTargetSerializer(queryset, many=True, context={'request': request})
+        serializer = NullableOneToOneTargetSerializer(
+            queryset,
+            many=True,
+            context={'request': request})
         expected = [
-            {'url': 'http://testserver/onetoonetarget/1/', 'name': 'target-1', 'nullable_source': 'http://testserver/nullableonetoonesource/1/'},
-            {'url': 'http://testserver/onetoonetarget/2/', 'name': 'target-2', 'nullable_source': None},
+            {'url': 'http://testserver/onetoonetarget/1/', 'name': 'target-1',
+             'nullable_source': 'http://testserver/nullableonetoonesource/1/'},
+            {'url': 'http://testserver/onetoonetarget/2/', 'name': 'target-2',
+             'nullable_source': None},
         ]
         self.assertEqual(serializer.data, expected)

--- a/tests/test_relations_pk.py
+++ b/tests/test_relations_pk.py
@@ -248,7 +248,8 @@ class PKForeignKeyTests(TestCase):
         instance = ForeignKeySource.objects.get(pk=1)
         serializer = ForeignKeySourceSerializer(instance, data=data)
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors, {'target': ['Incorrect type. Expected pk value, received %s.' % six.text_type.__name__]})
+        self.assertEqual(serializer.errors, {'target': [
+            'Incorrect type. Expected pk value, received %s.' % six.text_type.__name__]})
 
     def test_reverse_foreign_key_update(self):
         data = {'id': 2, 'name': 'target-2', 'sources': [1, 3]}
@@ -319,7 +320,8 @@ class PKForeignKeyTests(TestCase):
         instance = ForeignKeySource.objects.get(pk=1)
         serializer = ForeignKeySourceSerializer(instance, data=data)
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors, {'target': ['This field may not be null.']})
+        self.assertEqual(serializer.errors,
+                         {'target': ['This field may not be null.']})
 
     def test_foreign_key_with_unsaved(self):
         source = ForeignKeySource(name='source-unsaved')
@@ -345,9 +347,11 @@ class PKForeignKeyTests(TestCase):
         Let's say we wanted to fill the non-nullable model field inside
         Model.save(), we would make it empty and not required.
         """
+
         class ModelSerializer(ForeignKeySourceSerializer):
             class Meta(ForeignKeySourceSerializer.Meta):
                 extra_kwargs = {'target': {'required': False}}
+
         serializer = ModelSerializer(data={'name': 'test'})
         serializer.is_valid(raise_exception=True)
         self.assertNotIn('target', serializer.validated_data)
@@ -360,7 +364,8 @@ class PKNullableForeignKeyTests(TestCase):
         for idx in range(1, 4):
             if idx == 3:
                 target = None
-            source = NullableForeignKeySource(name='source-%d' % idx, target=target)
+            source = NullableForeignKeySource(name='source-%d' % idx,
+                                              target=target)
             source.save()
 
     def test_foreign_key_retrieve_with_null(self):

--- a/tests/test_relations_slug.py
+++ b/tests/test_relations_slug.py
@@ -73,7 +73,8 @@ class SlugForeignKeyTests(TestCase):
         queryset = ForeignKeyTarget.objects.all()
         serializer = ForeignKeyTargetSerializer(queryset, many=True)
         expected = [
-            {'id': 1, 'name': 'target-1', 'sources': ['source-1', 'source-2', 'source-3']},
+            {'id': 1, 'name': 'target-1',
+             'sources': ['source-1', 'source-2', 'source-3']},
             {'id': 2, 'name': 'target-2', 'sources': []},
         ]
         self.assertEqual(serializer.data, expected)
@@ -107,10 +108,12 @@ class SlugForeignKeyTests(TestCase):
         instance = ForeignKeySource.objects.get(pk=1)
         serializer = ForeignKeySourceSerializer(instance, data=data)
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors, {'target': ['Object with name=123 does not exist.']})
+        self.assertEqual(serializer.errors,
+                         {'target': ['Object with name=123 does not exist.']})
 
     def test_reverse_foreign_key_update(self):
-        data = {'id': 2, 'name': 'target-2', 'sources': ['source-1', 'source-3']}
+        data = {'id': 2, 'name': 'target-2',
+                'sources': ['source-1', 'source-3']}
         instance = ForeignKeyTarget.objects.get(pk=2)
         serializer = ForeignKeyTargetSerializer(instance, data=data)
         self.assertTrue(serializer.is_valid())
@@ -119,7 +122,8 @@ class SlugForeignKeyTests(TestCase):
         queryset = ForeignKeyTarget.objects.all()
         new_serializer = ForeignKeyTargetSerializer(queryset, many=True)
         expected = [
-            {'id': 1, 'name': 'target-1', 'sources': ['source-1', 'source-2', 'source-3']},
+            {'id': 1, 'name': 'target-1',
+             'sources': ['source-1', 'source-2', 'source-3']},
             {'id': 2, 'name': 'target-2', 'sources': []},
         ]
         self.assertEqual(new_serializer.data, expected)
@@ -157,7 +161,8 @@ class SlugForeignKeyTests(TestCase):
         self.assertEqual(serializer.data, expected)
 
     def test_reverse_foreign_key_create(self):
-        data = {'id': 3, 'name': 'target-3', 'sources': ['source-1', 'source-3']}
+        data = {'id': 3, 'name': 'target-3',
+                'sources': ['source-1', 'source-3']}
         serializer = ForeignKeyTargetSerializer(data=data)
         self.assertTrue(serializer.is_valid())
         obj = serializer.save()
@@ -179,7 +184,8 @@ class SlugForeignKeyTests(TestCase):
         instance = ForeignKeySource.objects.get(pk=1)
         serializer = ForeignKeySourceSerializer(instance, data=data)
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors, {'target': ['This field may not be null.']})
+        self.assertEqual(serializer.errors,
+                         {'target': ['This field may not be null.']})
 
 
 class SlugNullableForeignKeyTests(TestCase):
@@ -189,7 +195,8 @@ class SlugNullableForeignKeyTests(TestCase):
         for idx in range(1, 4):
             if idx == 3:
                 target = None
-            source = NullableForeignKeySource(name='source-%d' % idx, target=target)
+            source = NullableForeignKeySource(name='source-%d' % idx,
+                                              target=target)
             source.save()
 
     def test_foreign_key_retrieve_with_null(self):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -32,6 +32,7 @@ class MockJsonRenderer(BaseRenderer):
 class MockTextMediaRenderer(BaseRenderer):
     media_type = 'text/html'
 
+
 DUMMYSTATUS = status.HTTP_200_OK
 DUMMYCONTENT = 'dummycontent'
 
@@ -77,7 +78,8 @@ class MockViewSettingContentType(APIView):
     renderer_classes = (RendererA, RendererB, RendererC)
 
     def get(self, request, **kwargs):
-        return Response(DUMMYCONTENT, status=DUMMYSTATUS, content_type='setbyview')
+        return Response(DUMMYCONTENT, status=DUMMYSTATUS,
+                        content_type='setbyview')
 
 
 class JSONView(APIView):
@@ -89,7 +91,7 @@ class JSONView(APIView):
 
 
 class HTMLView(APIView):
-    renderer_classes = (BrowsableAPIRenderer, )
+    renderer_classes = (BrowsableAPIRenderer,)
 
     def get(self, request, **kwargs):
         return Response('text')
@@ -117,17 +119,20 @@ class HTMLNewModelView(generics.ListCreateAPIView):
 new_model_viewset_router = routers.DefaultRouter()
 new_model_viewset_router.register(r'', HTMLNewModelViewSet)
 
-
 urlpatterns = [
-    url(r'^setbyview$', MockViewSettingContentType.as_view(renderer_classes=[RendererA, RendererB, RendererC])),
-    url(r'^.*\.(?P<format>.+)$', MockView.as_view(renderer_classes=[RendererA, RendererB, RendererC])),
-    url(r'^$', MockView.as_view(renderer_classes=[RendererA, RendererB, RendererC])),
+    url(r'^setbyview$', MockViewSettingContentType.as_view(
+        renderer_classes=[RendererA, RendererB, RendererC])),
+    url(r'^.*\.(?P<format>.+)$',
+        MockView.as_view(renderer_classes=[RendererA, RendererB, RendererC])),
+    url(r'^$',
+        MockView.as_view(renderer_classes=[RendererA, RendererB, RendererC])),
     url(r'^html$', HTMLView.as_view()),
     url(r'^json$', JSONView.as_view()),
     url(r'^html1$', HTMLView1.as_view()),
     url(r'^html_new_model$', HTMLNewModelView.as_view()),
     url(r'^html_new_model_viewset', include(new_model_viewset_router.urls)),
-    url(r'^restframework', include('rest_framework.urls', namespace='rest_framework'))
+    url(r'^restframework',
+        include('rest_framework.urls', namespace='rest_framework'))
 ]
 
 
@@ -137,10 +142,13 @@ class RendererIntegrationTests(TestCase):
     """
     End-to-end testing of renderers using an ResponseMixin on a generic view.
     """
+
     def test_default_renderer_serializes_content(self):
-        """If the Accept header is not set the default renderer should serialize the response."""
+        """If the Accept header is not set the default renderer should
+        serialize the response."""
         resp = self.client.get('/')
-        self.assertEqual(resp['Content-Type'], RendererA.media_type + '; charset=utf-8')
+        self.assertEqual(resp['Content-Type'],
+                         RendererA.media_type + '; charset=utf-8')
         self.assertEqual(resp.content, RENDERER_A_SERIALIZER(DUMMYCONTENT))
         self.assertEqual(resp.status_code, DUMMYSTATUS)
 
@@ -148,29 +156,36 @@ class RendererIntegrationTests(TestCase):
         """No response must be included in HEAD requests."""
         resp = self.client.head('/')
         self.assertEqual(resp.status_code, DUMMYSTATUS)
-        self.assertEqual(resp['Content-Type'], RendererA.media_type + '; charset=utf-8')
+        self.assertEqual(resp['Content-Type'],
+                         RendererA.media_type + '; charset=utf-8')
         self.assertEqual(resp.content, six.b(''))
 
     def test_default_renderer_serializes_content_on_accept_any(self):
-        """If the Accept header is set to */* the default renderer should serialize the response."""
+        """If the Accept header is set to */* the default renderer should
+        serialize the response."""
         resp = self.client.get('/', HTTP_ACCEPT='*/*')
-        self.assertEqual(resp['Content-Type'], RendererA.media_type + '; charset=utf-8')
+        self.assertEqual(resp['Content-Type'],
+                         RendererA.media_type + '; charset=utf-8')
         self.assertEqual(resp.content, RENDERER_A_SERIALIZER(DUMMYCONTENT))
         self.assertEqual(resp.status_code, DUMMYSTATUS)
 
     def test_specified_renderer_serializes_content_default_case(self):
-        """If the Accept header is set the specified renderer should serialize the response.
+        """If the Accept header is set the specified renderer should serialize
+        the response.
         (In this case we check that works for the default renderer)"""
         resp = self.client.get('/', HTTP_ACCEPT=RendererA.media_type)
-        self.assertEqual(resp['Content-Type'], RendererA.media_type + '; charset=utf-8')
+        self.assertEqual(resp['Content-Type'],
+                         RendererA.media_type + '; charset=utf-8')
         self.assertEqual(resp.content, RENDERER_A_SERIALIZER(DUMMYCONTENT))
         self.assertEqual(resp.status_code, DUMMYSTATUS)
 
     def test_specified_renderer_serializes_content_non_default_case(self):
-        """If the Accept header is set the specified renderer should serialize the response.
+        """If the Accept header is set the specified renderer should serialize
+        the response.
         (In this case we check that works for a non-default renderer)"""
         resp = self.client.get('/', HTTP_ACCEPT=RendererB.media_type)
-        self.assertEqual(resp['Content-Type'], RendererB.media_type + '; charset=utf-8')
+        self.assertEqual(resp['Content-Type'],
+                         RendererB.media_type + '; charset=utf-8')
         self.assertEqual(resp.content, RENDERER_B_SERIALIZER(DUMMYCONTENT))
         self.assertEqual(resp.status_code, DUMMYSTATUS)
 
@@ -178,24 +193,29 @@ class RendererIntegrationTests(TestCase):
         """If a 'format' query is specified, the renderer with the matching
         format attribute should serialize the response."""
         resp = self.client.get('/?format=%s' % RendererB.format)
-        self.assertEqual(resp['Content-Type'], RendererB.media_type + '; charset=utf-8')
+        self.assertEqual(resp['Content-Type'],
+                         RendererB.media_type + '; charset=utf-8')
         self.assertEqual(resp.content, RENDERER_B_SERIALIZER(DUMMYCONTENT))
         self.assertEqual(resp.status_code, DUMMYSTATUS)
 
     def test_specified_renderer_serializes_content_on_format_kwargs(self):
-        """If a 'format' keyword arg is specified, the renderer with the matching
-        format attribute should serialize the response."""
+        """If a 'format' keyword arg is specified, the renderer with the
+        matching format attribute should serialize the response."""
         resp = self.client.get('/something.formatb')
-        self.assertEqual(resp['Content-Type'], RendererB.media_type + '; charset=utf-8')
+        self.assertEqual(resp['Content-Type'],
+                         RendererB.media_type + '; charset=utf-8')
         self.assertEqual(resp.content, RENDERER_B_SERIALIZER(DUMMYCONTENT))
         self.assertEqual(resp.status_code, DUMMYSTATUS)
 
-    def test_specified_renderer_is_used_on_format_query_with_matching_accept(self):
+    def test_specified_renderer_is_used_on_format_query_with_matching_accept(
+            self):
         """If both a 'format' query and a matching Accept header specified,
-        the renderer with the matching format attribute should serialize the response."""
+        the renderer with the matching format attribute should serialize the
+        response."""
         resp = self.client.get('/?format=%s' % RendererB.format,
                                HTTP_ACCEPT=RendererB.media_type)
-        self.assertEqual(resp['Content-Type'], RendererB.media_type + '; charset=utf-8')
+        self.assertEqual(resp['Content-Type'],
+                         RendererB.media_type + '; charset=utf-8')
         self.assertEqual(resp.content, RENDERER_B_SERIALIZER(DUMMYCONTENT))
         self.assertEqual(resp.status_code, DUMMYSTATUS)
 
@@ -203,12 +223,14 @@ class RendererIntegrationTests(TestCase):
 @override_settings(ROOT_URLCONF='tests.test_response')
 class UnsupportedMediaTypeTests(TestCase):
     def test_should_allow_posting_json(self):
-        response = self.client.post('/json', data='{"test": 123}', content_type='application/json')
+        response = self.client.post('/json', data='{"test": 123}',
+                                    content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
 
     def test_should_not_allow_posting_xml(self):
-        response = self.client.post('/json', data='<test>123</test>', content_type='application/xml')
+        response = self.client.post('/json', data='<test>123</test>',
+                                    content_type='application/xml')
 
         self.assertEqual(response.status_code, 415)
 
@@ -223,6 +245,7 @@ class Issue122Tests(TestCase):
     """
     Tests that covers #122.
     """
+
     def test_only_html_renderer(self):
         """
         Test if no infinite recursion occurs.
@@ -241,6 +264,7 @@ class Issue467Tests(TestCase):
     """
     Tests for #467
     """
+
     def test_form_has_label_and_help_text(self):
         resp = self.client.get('/html_new_model')
         self.assertEqual(resp['Content-Type'], 'text/html; charset=utf-8')
@@ -253,6 +277,7 @@ class Issue807Tests(TestCase):
     """
     Covers #807
     """
+
     def test_does_not_append_charset_by_default(self):
         """
         Renderers don't include a charset unless set explicitly.
@@ -269,7 +294,8 @@ class Issue807Tests(TestCase):
         """
         headers = {"HTTP_ACCEPT": RendererC.media_type}
         resp = self.client.get('/', **headers)
-        expected = "{0}; charset={1}".format(RendererC.media_type, RendererC.charset)
+        expected = "{0}; charset={1}".format(RendererC.media_type,
+                                             RendererC.charset)
         self.assertEqual(expected, resp['Content-Type'])
 
     def test_content_type_set_explicitly_on_response(self):

--- a/tests/test_serializer_nested.py
+++ b/tests/test_serializer_nested.py
@@ -1,15 +1,16 @@
 from django.http import QueryDict
 
-from rest_framework import serializers
+from rest_framework.fields import IntegerField, MultipleChoiceField
+from rest_framework.serializers import ListSerializer, Serializer
 
 
 class TestNestedSerializer:
     def setup(self):
-        class NestedSerializer(serializers.Serializer):
-            one = serializers.IntegerField(max_value=10)
-            two = serializers.IntegerField(max_value=10)
+        class NestedSerializer(Serializer):
+            one = IntegerField(max_value=10)
+            two = IntegerField(max_value=10)
 
-        class TestSerializer(serializers.Serializer):
+        class TestSerializer(Serializer):
             nested = NestedSerializer()
 
         self.Serializer = TestSerializer
@@ -50,10 +51,10 @@ class TestNestedSerializer:
 
 class TestNotRequiredNestedSerializer:
     def setup(self):
-        class NestedSerializer(serializers.Serializer):
-            one = serializers.IntegerField(max_value=10)
+        class NestedSerializer(Serializer):
+            one = IntegerField(max_value=10)
 
-        class TestSerializer(serializers.Serializer):
+        class TestSerializer(Serializer):
             nested = NestedSerializer(required=False)
 
         self.Serializer = TestSerializer
@@ -79,10 +80,10 @@ class TestNotRequiredNestedSerializer:
 
 class TestNestedSerializerWithMany:
     def setup(self):
-        class NestedSerializer(serializers.Serializer):
-            example = serializers.IntegerField(max_value=10)
+        class NestedSerializer(Serializer):
+            example = IntegerField(max_value=10)
 
-        class TestSerializer(serializers.Serializer):
+        class TestSerializer(Serializer):
             allow_null = NestedSerializer(many=True, allow_null=True)
             not_allow_null = NestedSerializer(many=True)
             allow_empty = NestedSerializer(many=True, allow_empty=True)
@@ -119,7 +120,8 @@ class TestNestedSerializerWithMany:
 
         assert not serializer.is_valid()
 
-        expected_errors = {'not_allow_null': [serializer.error_messages['null']]}
+        expected_errors = {
+            'not_allow_null': [serializer.error_messages['null']]}
         assert serializer.errors == expected_errors
 
     def test_run_the_field_validation_even_if_the_field_is_null(self):
@@ -171,16 +173,17 @@ class TestNestedSerializerWithMany:
 
         assert not serializer.is_valid()
 
-        expected_errors = {'not_allow_empty': {'non_field_errors': [serializers.ListSerializer.default_error_messages['empty']]}}
+        expected_errors = {'not_allow_empty': {'non_field_errors': [
+            ListSerializer.default_error_messages['empty']]}}
         assert serializer.errors == expected_errors
 
 
 class TestNestedSerializerWithList:
     def setup(self):
-        class NestedSerializer(serializers.Serializer):
-            example = serializers.MultipleChoiceField(choices=[1, 2, 3])
+        class NestedSerializer(Serializer):
+            example = MultipleChoiceField(choices=[1, 2, 3])
 
-        class TestSerializer(serializers.Serializer):
+        class TestSerializer(Serializer):
             nested = NestedSerializer()
 
         self.Serializer = TestSerializer

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,7 +43,8 @@ urlpatterns = [
     url(r'^resource/customname$', CustomNameResourceInstance.as_view()),
     url(r'^resource/(?P<key>[0-9]+)$', ResourceInstance.as_view()),
     url(r'^resource/(?P<key>[0-9]+)/$', NestedResourceRoot.as_view()),
-    url(r'^resource/(?P<key>[0-9]+)/(?P<other>[A-Za-z]+)$', NestedResourceInstance.as_view()),
+    url(r'^resource/(?P<key>[0-9]+)/(?P<other>[A-Za-z]+)$',
+        NestedResourceInstance.as_view()),
 ]
 
 
@@ -52,6 +53,7 @@ class BreadcrumbTests(TestCase):
     """
     Tests the breadcrumb functionality used by the HTML renderer.
     """
+
     def test_root_breadcrumbs(self):
         url = '/'
         self.assertEqual(
@@ -130,6 +132,7 @@ class ResolveModelTests(TestCase):
     provided argument is a Django model class itself, or a properly
     formatted string representation of one.
     """
+
     def test_resolve_django_model(self):
         resolved_model = _resolve_model(BasicModel)
         self.assertEqual(resolved_model, BasicModel)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ObjectDoesNotExist
+
 from rest_framework.compat import NoReverseMatch
 
 


### PR DESCRIPTION
This is a follow-up to #4600 and fixes the pyflakes problems produced there.  Unfortunately (fortunately!), this exposed a bunch of PEP8 warnings that are now fixed.  I was pretty rigorous about the line length.

One thing that some people might not like is that where it used to say `serializers.Serializer` in the files I changed, it now says `Serializer`.  I'm not averse to the other way but it was a simpler fix to just move it over since we were using classes like `serializers.ModelField` all over the place which was incorrect because `ModelField` is in `fields`.

I did not change any functionality nor fix any code warnings - just formatting and imports.