### PR TITLE
added on_delete=models.CASCADE to models.ForeignKey in the documentation

### DIFF
--- a/docs/api-guide/relations.md
+++ b/docs/api-guide/relations.md
@@ -39,7 +39,7 @@ In order to explain the various types of relational fields, we'll use a couple o
         artist = models.CharField(max_length=100)
 
     class Track(models.Model):
-        album = models.ForeignKey(Album, related_name='tracks')
+        album = models.ForeignKey(Album, related_name='tracks', on_delete=models.CASCADE)
         order = models.IntegerField()
         title = models.CharField(max_length=100)
         duration = models.IntegerField()
@@ -484,7 +484,7 @@ Note that reverse relationships are not automatically included by the `ModelSeri
 You'll normally want to ensure that you've set an appropriate `related_name` argument on the relationship, that you can use as the field name.  For example:
 
     class Track(models.Model):
-        album = models.ForeignKey(Album, related_name='tracks')
+        album = models.ForeignKey(Album, related_name='tracks', on_delete=models.CASCADE)
         ...
 
 If you have not set a related name for the reverse relationship, you'll need to use the automatically generated related name in the `fields` argument.  For example:
@@ -508,7 +508,7 @@ For example, given the following model for a tag, which has a generic relationsh
         See: https://docs.djangoproject.com/en/dev/ref/contrib/contenttypes/
         """
         tag_name = models.SlugField()
-        content_type = models.ForeignKey(ContentType)
+        content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
         object_id = models.PositiveIntegerField()
         tagged_object = GenericForeignKey('content_type', 'object_id')
 

--- a/docs/tutorial/4-authentication-and-permissions.md
+++ b/docs/tutorial/4-authentication-and-permissions.md
@@ -14,7 +14,7 @@ First, let's add a couple of fields.  One of those fields will be used to repres
 
 Add the following two fields to the `Snippet` model in `models.py`.
 
-    owner = models.ForeignKey('auth.User', related_name='snippets')
+    owner = models.ForeignKey('auth.User', related_name='snippets', on_delete=models.CASCADE)
     highlighted = models.TextField()
 
 We'd also need to make sure that when the model is saved, that we populate the highlighted field, using the `pygments` code highlighting library.


### PR DESCRIPTION
Django 2 demands this key, although ``on_delete=models.CASCADE`` is already default.

I specifically did not touch the documentation for the release notes for v. 3. I can update the PR if requested.

