### PR TITLE
Introduced a .editorconfig file for consisten coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+# Docstrings and comments use max_line_length = 79
+[*.py]
+max_line_length = 119
+
+# Minified JavaScript files shouldn't be changed
+[**.min.js]
+indent_style = ignore
+insert_final_newline = ignore

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage.*
 !.gitignore
 !.travis.yml
 !.isort.cfg
+!.editorconfig


### PR DESCRIPTION
Before you merge, could you please verify the settings. There's some trailing whitespace in the Markdown-files, maybe that's intentional?
