### PR TITLE
Fix: Add Numeric field type in utils/field_mapping.py

### DIFF
--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -12,13 +12,7 @@ from rest_framework.compat import DecimalValidator
 from rest_framework.validators import UniqueValidator
 
 NUMERIC_FIELD_TYPES = (
-    models.BigIntegerField,
-    models.DecimalField,
-    models.FloatField,
-    models.IntegerField,
-    models.PositiveIntegerField,
-    models.PositiveSmallIntegerField,
-    models.SmallIntegerField,
+    models.IntegerField, models.FloatField, models.DecimalField
 )
 
 

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -12,7 +12,13 @@ from rest_framework.compat import DecimalValidator
 from rest_framework.validators import UniqueValidator
 
 NUMERIC_FIELD_TYPES = (
-    models.IntegerField, models.FloatField, models.DecimalField
+    models.BigIntegerField,
+    models.DecimalField,
+    models.FloatField,
+    models.IntegerField,
+    models.PositiveInteger,
+    models.PositiveSmallIntegerField,
+    models.SmallIntegerField,
 )
 
 

--- a/rest_framework/utils/field_mapping.py
+++ b/rest_framework/utils/field_mapping.py
@@ -16,7 +16,7 @@ NUMERIC_FIELD_TYPES = (
     models.DecimalField,
     models.FloatField,
     models.IntegerField,
-    models.PositiveInteger,
+    models.PositiveIntegerField,
     models.PositiveSmallIntegerField,
     models.SmallIntegerField,
 )

--- a/tests/models.py
+++ b/tests/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import uuid
 
+from django.core.validators import MinValueValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
@@ -88,3 +89,9 @@ class NullableOneToOneSource(RESTFrameworkModel):
     target = models.OneToOneField(
         OneToOneTarget, null=True, blank=True,
         related_name='nullable_source', on_delete=models.CASCADE)
+
+
+# min_value with PositiveIntegerField
+class MinValueItem(RESTFrameworkModel):
+    integer = models.IntegerField(validators=[MinValueValidator(0)])
+    positive_integer = models.PositiveIntegerField()

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -9,6 +9,7 @@ import pytest
 from rest_framework import serializers
 from rest_framework.compat import unicode_repr
 
+from .models import MinValueItem
 from .utils import MockObject
 
 
@@ -67,6 +68,21 @@ class TestSerializer:
         serializer = self.Serializer(data=data)
         assert not serializer.is_valid()
         assert serializer.errors == {'non_field_errors': ['No data provided']}
+
+
+class TestMinValueSerializer:
+    def setup(self):
+        class ExampleSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = MinValueItem
+                fields = ('integer', 'positive_integer')
+        self.serializer = ExampleSerializer()
+
+    def test_min_value_for_integer_field(self):
+        assert self.serializer['integer'].min_value == 0
+
+    def test_min_value_for_positive_integer_field(self):
+        assert self.serializer['positive_integer'].min_value == 0
 
 
 class TestValidateMethod:


### PR DESCRIPTION
I noticed a model serializer on a model with a `PositiveIntegerField` will give something like:

```
MyPositiveIntegerObjectSerializer():
    age = IntegerField(allow_null=True, required=False)
```

If we use an `IntegerField` with a `min_value`, we get something like:

```
MyMinValueIntegerObjectSerializer():
    age = IntegerField(allow_null=True, required=False,  min_value=10)
```

My point is: we should have a `min_value=0` for `positiveIntegerField`.

In serializers.py, we call `get_field_kwargs` from utils/field_mapping.py

What extract the `min_value` is: 

```python
    # Ensure that max_value is passed explicitly as a keyword arg,
    # rather than as a validator.
    min_value = next((
        validator.limit_value for validator in validator_kwarg
        if isinstance(validator, validators.MinValueValidator)
    ), None)
    if min_value is not None and isinstance(model_field, NUMERIC_FIELD_TYPES):
        kwargs['min_value'] = min_value
        validator_kwarg = [
            validator for validator in validator_kwarg
            if not isinstance(validator, validators.MinValueValidator)
        ]
```

The fact is: **`NUMERIC_FIELD_TYPES` only contains IntegerField, FloatField, DecimalField**

See beginning of utils/field_mapping.py

```python
NUMERIC_FIELD_TYPES = (
    models.IntegerField, models.FloatField, models.DecimalField
)
```

Hope I'm not missing something more obvious here.
While I was at it, I added some other numeric types than `PositiveIntegerField`.

Cheers folks, keep rocking 🎸 

