### PR TITLE
Add runshell script

### DIFF
--- a/runshell.py
+++ b/runshell.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python
+import django
+import sys
+from django.core.management import execute_from_command_line
+
+
+def runshell():
+    from tests import conftest
+    conftest.pytest_configure()
+
+    execute_from_command_line(
+        sys.argv[:1] +
+        ['migrate', '--noinput', '-v', '0'] +
+        (['--run-syncdb'] if django.VERSION >= (1, 9) else []))
+
+    argv = sys.argv[:1] + ['shell'] + sys.argv[1:]
+    execute_from_command_line(argv)
+
+
+if __name__ == '__main__':
+    runshell()

--- a/tests/models.py
+++ b/tests/models.py
@@ -73,7 +73,7 @@ class NullableForeignKeySource(RESTFrameworkModel):
 class NullableUUIDForeignKeySource(RESTFrameworkModel):
     name = models.CharField(max_length=100)
     target = models.ForeignKey(ForeignKeyTarget, null=True, blank=True,
-                               related_name='nullable_sources',
+                               related_name='nullable_uuid_sources',
                                verbose_name='Optional target object',
                                on_delete=models.CASCADE)
 


### PR DESCRIPTION
This is adapted from `django-filter`. It essentially allows you to run the django shell in DRF's test environment. 
