### PR TITLE
Don't lose exception info

### DIFF
--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -445,7 +445,7 @@ class APIView(View):
             renderer_format = getattr(request.accepted_renderer, 'format')
             use_plaintext_traceback = renderer_format not in ('html', 'api', 'admin')
             request.force_plaintext_errors(use_plaintext_traceback)
-        raise exc
+        raise
 
     # Note: Views are made CSRF exempt from within `as_view` as to prevent
     # accidental removal of this exemption in cases where `dispatch` needs to


### PR DESCRIPTION
Closes #4631. If anyone wants to progress this forward for Python 3.5+ we'll need test cases demonstrating the correct behavior in both cases.