### PR TITLE
Add test showing error

### DIFF
--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -41,6 +41,10 @@ class OneFieldModel(models.Model):
     char_field = models.CharField(max_length=100)
 
 
+class ExtendedModel(OneFieldModel):
+    text_field = models.TextField(max_length=100)
+
+
 class RegularFieldsModel(models.Model):
     """
     A model class for testing regular flat fields.
@@ -140,6 +144,26 @@ class TestModelSerializer(TestCase):
             serializer.is_valid()
         msginitial = 'Cannot use ModelSerializer with Abstract Models.'
         assert str(excinfo.exception).startswith(msginitial)
+
+    def test_inheritance(self):
+        """
+        Check serializer contains only correct fields
+        """
+        class TestSerializer(serializers.ModelSerializer):
+
+            class Meta:
+                model = ExtendedModel
+                fields = '__all__'
+
+        instance = ExtendedModel.objects.create(
+            char_field="An Instance",
+            text_field="""To check only the two fields plus id are present in data"""
+        )
+
+        serializer = TestSerializer(instance)
+        data = serializer.data
+        assert len(data.keys()) == 3
+        assert data.keys() == ['id', 'char_field', 'text_field',]
 
 
 class TestRegularFieldMappings(TestCase):


### PR DESCRIPTION
This is a failing test case showing (at least part of) the cause for the test failures against Django master from #4574 (and https://github.com/carltongibson/django-filter/issues/521)

The issue arrises when using an inherited model and the `fields = '__all__'` shortcut. In that case, against Django master, the `serialiser.data` includes an additional/spurious `'onefieldmodel_ptr'` field. 

To see the single error run: 

     $ tox -e py35-djangomaster -- tests/test_model_serializer.py

Output is then: 

```
========================================== FAILURES ===========================================
____________________________ TestModelSerializer.test_inheritance _____________________________
tests/test_model_serializer.py:165: in test_inheritance
    assert len(data.keys()) == 3
E   AssertionError: assert 4 == 3
E    +  where 4 = len(odict_keys(['id', 'char_field', 'text_field', 'onefieldmodel_ptr']))
E    +    where odict_keys(['id', 'char_field', 'text_field', 'onefieldmodel_ptr']) = <built-in method keys of ReturnDict object at 0x1080e9de0>()
E    +      where <built-in method keys of ReturnDict object at 0x1080e9de0> = {'id': 1, 'text_field': 'To check only the two fields plus id are present in data', 'onefieldmodel_ptr': 1, 'char_field': 'An Instance'}.keys
============================= 1 failed, 42 passed in 2.29 seconds=============================
```