### PR TITLE
handle error when no links are found

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -263,6 +263,8 @@ class SchemaGenerator(object):
             view_endpoints.append((path, method, view))
 
         # Only generate the path prefix for paths that will be included
+        if not paths:
+            return None
         prefix = self.determine_path_prefix(paths)
 
         for path, method, view in view_endpoints:


### PR DESCRIPTION
## Description

This is to address https://github.com/tomchristie/django-rest-raml/issues/5

The problem is that if you try to generate RAML docs when you haven't set up any views, you get the above error (min called on an empty list).  

unfortunately, this PR is not very helpful since it doesn't actually surface a readable error to the user.  

Next steps:
- this PR should be updated to surface a readable error to the User in the browser.  Open to thoughts on best way to address...

