### PR TITLE
Update versions of Django on tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,9 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
        PYTHONWARNINGS=once
 deps =
-        django18: Django==1.8.15
-        django19: Django==1.9.10
-        django110: Django==1.10.2
+        django18: Django==1.8.16
+        django19: Django==1.9.11
+        django110: Django==1.10.3
         djangomaster: https://github.com/django/django/archive/master.tar.gz
         -rrequirements/requirements-testing.txt
         -rrequirements/requirements-optionals.txt


### PR DESCRIPTION
Bump release versions to 1.10.3, 1.9.11 and 1.8.16

More info on:

https://www.djangoproject.com/weblog/2016/nov/01/security-releases/