### PR TITLE
swagger template processing fix

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -452,6 +452,9 @@ class SchemaGenerator(object):
         """
         fields = []
 
+        if not hasattr(uritemplate, 'variables'):
+            return fields
+
         for variable in uritemplate.variables(path):
             field = coreapi.Field(name=variable, location='path', required=True)
             fields.append(field)


### PR DESCRIPTION
I don't know what this trace means, but this code helps
```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/exception.py", line 39, in inner
    response = get_response(request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/views.py", line 477, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/views.py", line 437, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/views.py", line 448, in raise_uncaught_exception
    raise exc
AttributeError: 'module' object has no attribute 'variables'
```