### PR TITLE
Invalidate any existing prefetch cache on PUT requests.

### DIFF
--- a/docs/api-guide/testing.md
+++ b/docs/api-guide/testing.md
@@ -187,7 +187,12 @@ As usual CSRF validation will only apply to any session authenticated views.  Th
 # RequestsClient
 
 REST framework also includes a client for interacting with your application
-using the popular Python library, `requests`.
+using the popular Python library, `requests`. This may be useful if:
+
+* You are expecting to interface with the API primarily from another Python service,
+and want to test the service at the same level as the client will see.
+* You want to write tests in such a way that they can also be run against a staging or
+live environment. (See "Live tests" below.)
 
 This exposes exactly the same interface as if you were using a requests session
 directly.
@@ -197,6 +202,10 @@ directly.
     assert response.status_code == 200
 
 Note that the requests client requires you to pass fully qualified URLs.
+
+## `RequestsClient` and working with the database
+
+The `RequestsClient` class is useful if
 
 ## Headers & Authentication
 

--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -71,9 +71,8 @@ class UpdateModelMixin(object):
 
         if getattr(instance, '_prefetched_objects_cache', None):
             # If 'prefetch_related' has been applied to a queryset, we need to
-            # refresh the instance from the database.
-            instance = self.get_object()
-            serializer = self.get_serializer(instance)
+            # forcibly invalidate the prefetch cache on the instance.
+            instance._prefetched_objects_cache = {}
 
         return Response(serializer.data)
 


### PR DESCRIPTION
Invalidate the prefetch cache instead of reloading the object from the database when a prefetch_related queryset is used with a PUT request.

Would be nice to also have a test case demonstrating why this approach has a different behavioral effect.

Closes #4661.
Refs #4553.