### PR TITLE
fixed url checker ':' to 'http'

### DIFF
--- a/rest_framework/test.py
+++ b/rest_framework/test.py
@@ -114,7 +114,7 @@ if requests is not None:
             self.mount('https://', adapter)
 
         def request(self, method, url, *args, **kwargs):
-            if ':' not in url:
+            if not url.startswith('http'):
                 raise ValueError('Missing "http:" or "https:". Use a fully qualified URL, eg "http://testserver%s"' % url)
             return super(RequestsClient, self).request(method, url, *args, **kwargs)
 


### PR DESCRIPTION
## Description

[RequestClient](https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/test.py#L117) In this line it's checking with ':'. But think when url="example.com:2121" then this this check can't be OK. So if it checks only for `http` or `https` then we can use `http` for checking. :) That's all. :+1: 