### PR TITLE
Do not ignore source when building fields dynamically

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -995,13 +995,15 @@ class ModelSerializer(Serializer):
                 fields[field_name] = declared_fields[field_name]
                 continue
 
+            extra_field_kwargs = extra_kwargs.get(field_name, {})
+            source = extra_field_kwargs.get('source') or field_name
+
             # Determine the serializer field class and keyword arguments.
             field_class, field_kwargs = self.build_field(
-                field_name, info, model, depth
+                source, info, model, depth
             )
 
             # Include any kwargs defined in `Meta.extra_kwargs`
-            extra_field_kwargs = extra_kwargs.get(field_name, {})
             field_kwargs = self.include_extra_kwargs(
                 field_kwargs, extra_field_kwargs
             )


### PR DESCRIPTION


This commit fixes the issue when you set the keyword argument `source`
and your have not set the serializer fields explicitly. Then the
construction of field failed because there is not actually any model
field with that name.

However, you are still able to imply the name of model field by
taking advantage of the `source` keyword argument.