### PR TITLE
Allow required false and default

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -55,6 +55,8 @@ The `default` is not applied during partial update operations. In the partial up
 
 May be set to a function or other callable, in which case the value will be evaluated each time it is used. When called, it will receive no arguments. If the callable has a `set_context` method, that will be called each time before getting the value with the field instance as only argument. This works the same way as for [validators](validators.md#using-set_context).
 
+When serializing the instance, default will be used if the the object attribute or dictionary key is not present in the instance.
+
 Note that setting a `default` value implies that the field is not required. Including both the `default` and `required` keyword arguments is invalid and will raise an error.
 
 ### `source`

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -443,7 +443,7 @@ class Field(object):
             return get_attribute(instance, self.source_attrs)
         except (KeyError, AttributeError) as exc:
             if self.default is not empty:
-                return self.default
+                return self.get_default()
             if not self.required:
                 raise SkipField()
             msg = (

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -442,7 +442,9 @@ class Field(object):
         try:
             return get_attribute(instance, self.source_attrs)
         except (KeyError, AttributeError) as exc:
-            if not self.required and self.default is empty:
+            if self.default is not empty:
+                return self.default
+            if not self.required:
                 raise SkipField()
             msg = (
                 'Got {exc_type} when attempting to get a value for field '

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -313,6 +313,7 @@ class TestNotRequiredOutput:
         serializer.save()
         assert serializer.data == {'included': 'abc'}
 
+    @pytest.mark.skipif(True, reason='Disabling pending removal')
     def test_default_required_output_for_dict(self):
         """
         'default="something"' should require dictionary key.
@@ -328,6 +329,7 @@ class TestNotRequiredOutput:
         with pytest.raises(KeyError):
             serializer.data
 
+    @pytest.mark.skipif(True, reason='Disabling pending removal')
     def test_default_required_output_for_object(self):
         """
         'default="something"' should require object attribute.
@@ -343,6 +345,44 @@ class TestNotRequiredOutput:
         serializer = ExampleSerializer(instance)
         with pytest.raises(AttributeError):
             serializer.data
+
+
+class TestDefaultOutput:
+    def setup(self):
+        class ExampleSerializer(serializers.Serializer):
+            has_default = serializers.CharField(default='abc')
+            no_default = serializers.CharField()
+        self.Serializer = ExampleSerializer
+
+    def test_default_used_for_dict(self):
+        """
+        'default="something"' should be used if dictionary key is missing from input.
+        """
+        serializer = self.Serializer({'no_default': 'def'})
+        assert serializer.data == {'has_default': 'abc', 'no_default': 'def'}
+
+    def test_default_used_for_object(self):
+        """
+        'default="something"' should be used if object attribute is missing from input.
+        """
+        instance = MockObject(no_default='def')
+        serializer = self.Serializer(instance)
+        assert serializer.data == {'has_default': 'abc', 'no_default': 'def'}
+
+    def test_default_not_used_when_in_dict(self):
+        """
+        'default="something"' should not be used if dictionary key is present in input.
+        """
+        serializer = self.Serializer({'has_default': 'ghi', 'no_default': 'def'})
+        assert serializer.data == {'has_default': 'ghi', 'no_default': 'def'}
+
+    def test_default_not_used_when_in_object(self):
+        """
+        'default="something"' should not be used if object attribute is present in input.
+        """
+        instance = MockObject(has_default='ghi', no_default='def')
+        serializer = self.Serializer(instance)
+        assert serializer.data == {'has_default': 'ghi', 'no_default': 'def'}
 
 
 class TestCacheSerializerData:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -313,44 +313,12 @@ class TestNotRequiredOutput:
         serializer.save()
         assert serializer.data == {'included': 'abc'}
 
-    @pytest.mark.skipif(True, reason='Disabling pending removal')
-    def test_default_required_output_for_dict(self):
-        """
-        'default="something"' should require dictionary key.
-
-        We need to handle this as the field will have an implicit
-        'required=False', but it should still have a value.
-        """
-        class ExampleSerializer(serializers.Serializer):
-            omitted = serializers.CharField(default='abc')
-            included = serializers.CharField()
-
-        serializer = ExampleSerializer({'included': 'abc'})
-        with pytest.raises(KeyError):
-            serializer.data
-
-    @pytest.mark.skipif(True, reason='Disabling pending removal')
-    def test_default_required_output_for_object(self):
-        """
-        'default="something"' should require object attribute.
-
-        We need to handle this as the field will have an implicit
-        'required=False', but it should still have a value.
-        """
-        class ExampleSerializer(serializers.Serializer):
-            omitted = serializers.CharField(default='abc')
-            included = serializers.CharField()
-
-        instance = MockObject(included='abc')
-        serializer = ExampleSerializer(instance)
-        with pytest.raises(AttributeError):
-            serializer.data
-
 
 class TestDefaultOutput:
     def setup(self):
         class ExampleSerializer(serializers.Serializer):
-            has_default = serializers.CharField(default='abc')
+            has_default = serializers.CharField(default='x')
+            has_default_callable = serializers.CharField(default=lambda: 'y')
             no_default = serializers.CharField()
         self.Serializer = ExampleSerializer
 
@@ -358,31 +326,31 @@ class TestDefaultOutput:
         """
         'default="something"' should be used if dictionary key is missing from input.
         """
-        serializer = self.Serializer({'no_default': 'def'})
-        assert serializer.data == {'has_default': 'abc', 'no_default': 'def'}
+        serializer = self.Serializer({'no_default': 'abc'})
+        assert serializer.data == {'has_default': 'x', 'has_default_callable': 'y', 'no_default': 'abc'}
 
     def test_default_used_for_object(self):
         """
         'default="something"' should be used if object attribute is missing from input.
         """
-        instance = MockObject(no_default='def')
+        instance = MockObject(no_default='abc')
         serializer = self.Serializer(instance)
-        assert serializer.data == {'has_default': 'abc', 'no_default': 'def'}
+        assert serializer.data == {'has_default': 'x', 'has_default_callable': 'y', 'no_default': 'abc'}
 
     def test_default_not_used_when_in_dict(self):
         """
         'default="something"' should not be used if dictionary key is present in input.
         """
-        serializer = self.Serializer({'has_default': 'ghi', 'no_default': 'def'})
-        assert serializer.data == {'has_default': 'ghi', 'no_default': 'def'}
+        serializer = self.Serializer({'has_default': 'def', 'has_default_callable': 'ghi', 'no_default': 'abc'})
+        assert serializer.data == {'has_default': 'def', 'has_default_callable': 'ghi', 'no_default': 'abc'}
 
     def test_default_not_used_when_in_object(self):
         """
         'default="something"' should not be used if object attribute is present in input.
         """
-        instance = MockObject(has_default='ghi', no_default='def')
+        instance = MockObject(has_default='def', has_default_callable='ghi', no_default='abc')
         serializer = self.Serializer(instance)
-        assert serializer.data == {'has_default': 'ghi', 'no_default': 'def'}
+        assert serializer.data == {'has_default': 'def', 'has_default_callable': 'ghi', 'no_default': 'abc'}
 
 
 class TestCacheSerializerData:


### PR DESCRIPTION
Fix for the issue described in #2785. 

When serializing an dict or object, now the default value is used if the key or attribute is missing from the dict or object. Previously a KeyError or AttributeError was raised.

Two tests failed after implementing the change, which was to be expected as they specifically targeted the behaviour of key or attribute being required even if default is set for the field (serializers.py, TestNotRequiredOutput). 
They have been replaced by tests targeting the use of defaults when key or attribute is not present in the instance. 

Deserialization seems unaffected.

What isn't clear to me is what the rationale was of explicitly requiring the instance key/attribute to be present, even if a default is provided, so I'm wondering if there's a scenario I'm overlooking.