### PR TITLE
django-filters rest_framework module import fix

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -187,6 +187,7 @@ This will automatically create a `FilterSet` class for the given fields, and wil
 For more advanced filtering requirements you can specify a `FilterSet` class that should be used by the view.  For example:
 
     import django_filters
+    import django_filters.rest_framework
     from myapp.models import Product
     from myapp.serializers import ProductSerializer
     from rest_framework import generics
@@ -213,7 +214,7 @@ You can also span relationships using `django-filter`, let's assume that each
 product has foreign key to `Manufacturer` model, so we create filter that
 filters using `Manufacturer` name. For example:
 
-    import django_filters
+    import django_filters.rest_framework
     from myapp.models import Product
     from myapp.serializers import ProductSerializer
     from rest_framework import generics
@@ -230,6 +231,7 @@ This enables us to make queries like:
 This is nice, but it exposes the Django's double underscore convention as part of the API.  If you instead want to explicitly name the filter argument you can instead explicitly include it on the `FilterSet` class:
 
     import django_filters
+    import django_filters.rest_framework
     from myapp.models import Product
     from myapp.serializers import ProductSerializer
     from rest_framework import generics


### PR DESCRIPTION
## Description

Minor documentation fix. Currently one cannot use:

```
import django_filters
print(django_filters.rest_framework)
```

This would throw an attribute error exception. Instead, should be changed to:

```
import django_filters.rest_framework
```

As stated in official [documentation](http://django-filter.readthedocs.io/en/develop/guide/rest_framework.html?highlight=rest#integration-with-drf).

Changes regarding this issue were made in [Filtering](http://www.django-rest-framework.org/api-guide/filtering/) chapter of DRF documentation.