### PR TITLE
Update the Python doc links to use https and point to Python 3

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -669,7 +669,7 @@ The [django-rest-framework-hstore][django-rest-framework-hstore] package provide
 [html-and-forms]: ../topics/html-and-forms.md
 [FILE_UPLOAD_HANDLERS]: https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-FILE_UPLOAD_HANDLERS
 [ecma262]: http://ecma-international.org/ecma-262/5.1/#sec-15.9.1.15
-[strftime]: http://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
+[strftime]: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
 [django-widgets]: https://docs.djangoproject.com/en/dev/ref/forms/widgets/
 [iso8601]: http://www.w3.org/TR/NOTE-datetime
 [drf-compound-fields]: https://drf-compound-fields.readthedocs.io

--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -456,7 +456,7 @@ An integer of 0 or more, that may be used to specify the number of application p
 
 Default: `None`
 
-[cite]: http://www.python.org/dev/peps/pep-0020/
+[cite]: https://www.python.org/dev/peps/pep-0020/
 [rfc4627]: http://www.ietf.org/rfc/rfc4627.txt
 [heroku-minified-json]: https://github.com/interagent/http-api-design#keep-json-minified-in-all-responses
-[strftime]: http://docs.python.org/2/library/time.html#time.strftime
+[strftime]: https://docs.python.org/3/library/time.html#time.strftime


### PR DESCRIPTION
- Use https to access Python doc
- Point to Python 3 documentation instead of the legacy Python 2.