### PR TITLE
Change DEFAULT_PERMISSION_CLASSES to a list in quickstart.md

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -118,7 +118,9 @@ We'd also like to set a few global settings.  We'd like to turn on pagination, a
     )
 
     REST_FRAMEWORK = {
-        'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAdminUser',),
+        'DEFAULT_PERMISSION_CLASSES': [
+            'rest_framework.permissions.IsAdminUser',
+        ],
         'PAGE_SIZE': 10
     }
 


### PR DESCRIPTION
Hi! 👋 

As discussed on #4731, it is somewhat easy make a mistake when following the quickstart tutorial. This change should help newcomers understand that ``DEFAULT_PERMISSION_CLASSES`` needs to be an iterable.

