### PR TITLE
Allow periods by default in lookup values of urls

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -230,7 +230,7 @@ class SimpleRouter(BaseRouter):
         # consume `.json` style suffixes and should break at '/' boundaries.
         lookup_field = getattr(viewset, 'lookup_field', 'pk')
         lookup_url_kwarg = getattr(viewset, 'lookup_url_kwarg', None) or lookup_field
-        lookup_value = getattr(viewset, 'lookup_value_regex', '[^/.]+')
+        lookup_value = getattr(viewset, 'lookup_value_regex', '[^/]+')
         return base_regex.format(
             lookup_prefix=lookup_prefix,
             lookup_url_kwarg=lookup_url_kwarg,

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -249,7 +249,7 @@ class TestTrailingSlashIncluded(TestCase):
         self.urls = self.router.urls
 
     def test_urls_have_trailing_slash_by_default(self):
-        expected = ['^notes/$', '^notes/(?P<pk>[^/.]+)/$']
+        expected = ['^notes/$', '^notes/(?P<pk>[^/]+)/$']
         for idx in range(len(expected)):
             self.assertEqual(expected[idx], self.urls[idx].regex.pattern)
 
@@ -264,7 +264,7 @@ class TestTrailingSlashRemoved(TestCase):
         self.urls = self.router.urls
 
     def test_urls_can_have_trailing_slash_removed(self):
-        expected = ['^notes$', '^notes/(?P<pk>[^/.]+)$']
+        expected = ['^notes$', '^notes/(?P<pk>[^/]+)$']
         for idx in range(len(expected)):
             self.assertEqual(expected[idx], self.urls[idx].regex.pattern)
 


### PR DESCRIPTION
This just a suggestion to not disallow periods in lookup fields by default.  It looks like this was added intentionally so I'd be curious to know why its included, but can be persuaded otherwise if there's good reason for it.

