### PR TITLE
Updated Link ti Django Docs

### DIFF
--- a/docs/api-guide/throttling.md
+++ b/docs/api-guide/throttling.md
@@ -193,5 +193,5 @@ The following is an example of a rate throttle, that will randomly throttle 1 in
 [cite]: https://dev.twitter.com/docs/error-codes-responses
 [permissions]: permissions.md
 [identifing-clients]: http://oxpedia.org/wiki/index.php?title=AppSuite:Grizzly#Multiple_Proxies_in_front_of_the_cluster
-[cache-setting]: https://docs.djangoproject.com/en/stable/stable/settings/#caches
+[cache-setting]: https://docs.djangoproject.com/en/stable/ref/settings/#caches
 [cache-docs]: https://docs.djangoproject.com/en/stable/topics/cache/#setting-up-the-cache


### PR DESCRIPTION
The Url to the settings/#caches Link changed in Django documentation, only one line changed.