### PR TITLE
Writable nested model serializer #4739

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -422,7 +422,7 @@ class Field(object):
                 if getattr(self.root, 'partial', False):
                     return empty
                 return self.default_empty_html
-            ret = dictionary[self.field_name]
+            ret = dictionary.getlist(self.field_name)
             if ret == '' and self.allow_null:
                 # If the field is blank, and null is a valid value then
                 # determine if we should use null instead.

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -454,26 +454,29 @@ class Serializer(BaseSerializer):
         ret = OrderedDict()
         errors = OrderedDict()
         fields = self._writable_fields
-
         for field in fields:
             validate_method = getattr(self, 'validate_' + field.field_name, None)
             primitive_value = field.get_value(data)
-            try:
-                validated_value = field.run_validation(primitive_value)
-                if validate_method is not None:
-                    validated_value = validate_method(validated_value)
-            except ValidationError as exc:
-                errors[field.field_name] = exc.detail
-            except DjangoValidationError as exc:
-                errors[field.field_name] = get_error_detail(exc)
-            except SkipField:
-                pass
+            validated_list = []
+            for inner_data in primitive_value:
+                try:
+                    validated_value = field.run_validation(inner_data)
+                    validated_list.append(validated_value)
+                    if validate_method is not None:
+                        validated_list.append(validate_method(validated_value))
+                except ValidationError as exc:
+                    errors[field.field_name] = exc.detail
+                except DjangoValidationError as exc:
+                    errors[field.field_name] = get_error_detail(exc)
+                except SkipField:
+                    pass
             else:
-                set_value(ret, field.source_attrs, validated_value)
-
+                if len(validated_list) > 1:
+                    set_value(ret, field.source_attrs, validated_list)
+                else:
+                    set_value(ret, field.source_attrs, validated_list[0])
         if errors:
             raise ValidationError(errors)
-
         return ret
 
     def to_representation(self, instance):

--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -362,10 +362,15 @@ class Serializer(BaseSerializer):
 
     @cached_property
     def _writable_fields(self):
-        return [
-            field for field in self.fields.values()
-            if (not field.read_only) or (field.default is not empty)
-        ]
+        ret = []
+        for field in self.fields.values():
+            if re.compile("\_set$").findall(field.source):
+                for field in field.child._writable_fields:
+                    ret.append(field)
+                continue
+            if (not field.read_only) or (field.default is not empty):
+                ret.append(field)
+        return ret
 
     @cached_property
     def _readable_fields(self):


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/tomchristie/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description


Writable nested ModelsSerializer does not work properly.

My opinion on this issue is not related to Json
I am sorry if I have the wrong knowledge.
I do not know much.

_writable_fields Method (in serializers.py) receives incorrect values.
I think they should always get a field.
But in this case, Method also gets a serializer.

In nested serializers, the fields are listed below in the serializer.
So I think (is_valid) returns null.

In my modified code,
If you send the request using the name of the serializer field as the name of the model field,

Numerous nested also works fine.


Of course I do not think this is the answer.

But I think it should work this way.

Forgive me if I was rude.
I am not good at English.

Thank you for your kind answers.


#4739
