### PR TITLE
Add per-view custom exception handler support

### DIFF
--- a/docs/api-guide/views.md
+++ b/docs/api-guide/views.md
@@ -73,6 +73,8 @@ The following methods are used by REST framework to instantiate the various plug
 
 ### .get_content_negotiator(self)
 
+### .get_exception_handler(self)
+
 ## API policy implementation methods
 
 The following methods are called before dispatching to the handler method.

--- a/rest_framework/views.py
+++ b/rest_framework/views.py
@@ -286,6 +286,12 @@ class APIView(View):
             self._negotiator = self.content_negotiation_class()
         return self._negotiator
 
+    def get_exception_handler(self):
+        """
+        Returns the exception handler that this view uses.
+        """
+        return api_settings.EXCEPTION_HANDLER
+
     # API policy implementation methods
 
     def perform_content_negotiation(self, request, force=False):
@@ -428,7 +434,7 @@ class APIView(View):
             else:
                 exc.status_code = status.HTTP_403_FORBIDDEN
 
-        exception_handler = self.settings.EXCEPTION_HANDLER
+        exception_handler = self.get_exception_handler()
 
         context = self.get_exception_handler_context()
         response = exception_handler(exc, context)


### PR DESCRIPTION
## Description

It is possible to set custom exception handler using the `EXCEPTION_HANDLER` setting key.
But it's hard to override exception handler on per-view basis.
To do this it's necessary to override `rest_framework.view.APIView.handle_exception` method.
What is unreasonably complex.

This PR adds ability to easily override custom exception handler on view using `rest_framework.view.APIView.get_exception_handler` method.