### PR TITLE
Fixed ListField empty check which ignored multi-part list elements

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -1521,12 +1521,15 @@ class ListField(Field):
         self.child.bind(field_name='', parent=self)
 
     def get_value(self, dictionary):
-        if self.field_name not in dictionary:
-            if getattr(self.root, 'partial', False):
-                return empty
         # We override the default field access in order to support
         # lists in HTML forms.
         if html.is_html_input(dictionary):
+            if getattr(self.root, 'partial', False):
+                if self.field_name not in dictionary:
+                    regexp = re.compile(html.HTML_LIST_REGEXP_FORMAT % re.escape(self.field_name))
+                    if not any(regexp.match(key) for key in dictionary.keys()):
+                        return empty
+
             val = dictionary.getlist(self.field_name, [])
             if len(val) > 0:
                 # Support QueryDict lists in HTML input.

--- a/rest_framework/utils/html.py
+++ b/rest_framework/utils/html.py
@@ -6,6 +6,9 @@ import re
 from django.utils.datastructures import MultiValueDict
 
 
+HTML_LIST_REGEXP_FORMAT = r'^%s\[([0-9]+)\](.*)$'
+
+
 def is_html_input(dictionary):
     # MultiDict type datastructures are used to represent HTML form input,
     # which may have more than one value for each key.
@@ -46,7 +49,7 @@ def parse_html_list(dictionary, prefix=''):
     ]
     """
     ret = {}
-    regex = re.compile(r'^%s\[([0-9]+)\](.*)$' % re.escape(prefix))
+    regex = re.compile(HTML_LIST_REGEXP_FORMAT % re.escape(prefix))
     for field, value in dictionary.items():
         match = regex.match(field)
         if not match:


### PR DESCRIPTION
FIxed ListField empty check.

It was ignoring multi-part elements with parts like `emails[0]`, `emails[1]` because previous check logic only checked if field name (in this example `emails`) was in dictionary which won't match indexed list declarations.