### PR TITLE
Added PrimaryKeyRelatedField in SchemaGenerator

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -33,6 +33,7 @@ types_lookup = ClassLookupDict({
     serializers.FileField: 'file',
     serializers.MultipleChoiceField: 'array',
     serializers.ManyRelatedField: 'array',
+    serializers.PrimaryKeyRelatedField: 'integer',
     serializers.Serializer: 'object',
     serializers.ListSerializer: 'array'
 })


### PR DESCRIPTION
The PrimaryKeyRelatedField was missing in the SchemaGenerator types_lookup.
All foreign keys was returned as string from get_serializer_fields