### PR TITLE
Optional removal of `Content-Type` header

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 # just Django, but for the purposes of development and testing
 # there are a number of packages that are useful to install.
 
-# Laying these out as seperate requirements files, allows us to
-# only included the relevent sets when running tox, and ensures
+# Laying these out as separate requirements files, allows us to
+# only included the relevant sets when running tox, and ensures
 # we are only ever declaring our dependencies in one place.
 
 -r requirements/requirements-optionals.txt

--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -91,7 +91,7 @@ class DestroyModelMixin(object):
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
         self.perform_destroy(instance)
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        return Response(status=status.HTTP_204_NO_CONTENT, content_type=request.content_type)
 
     def perform_destroy(self, instance):
         instance.delete()

--- a/rest_framework/response.py
+++ b/rest_framework/response.py
@@ -11,6 +11,7 @@ from django.utils import six
 from django.utils.six.moves.http_client import responses
 
 from rest_framework.serializers import Serializer
+from rest_framework.settings import api_settings
 
 
 class Response(SimpleTemplateResponse):
@@ -77,7 +78,7 @@ class Response(SimpleTemplateResponse):
             )
             return bytes(ret.encode(charset))
 
-        if not ret:
+        if api_settings.REMOVE_CONTENT_TYPE_ON_HTTP_204 and not ret:
             del self['Content-Type']
 
         return ret

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -106,6 +106,8 @@ DEFAULTS = {
     'TIME_FORMAT': ISO_8601,
     'TIME_INPUT_FORMATS': (ISO_8601,),
 
+    'REMOVE_CONTENT_TYPE_ON_HTTP_204': True,
+
     # Encoding
     'UNICODE_JSON': True,
     'COMPACT_JSON': True,


### PR DESCRIPTION
## Description

Fixes #4767. Removal of `Content-Type` header from empty responses is now optional. By default header is removed from empty response, but this behaviour can be changed via `REMOVE_CONTENT_TYPE_ON_HTTP_204` setting.
