### PR TITLE
get view for django 'virtual hosts'

### DIFF
--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -145,6 +145,18 @@ May be used to pass a canonical URL for the schema.
         url='https://www.example.org/api/'
     )
 
+#### `urlconf`
+
+May be used to pass a nondefault url configuration
+useful for `Django multihost snippet`
+https://code.djangoproject.com/wiki/MultiHostMiddleware
+
+    schema_view = get_schema_view(
+        title='Server Monitoring API',
+        url='https://www.example.org/api/',
+        urlconf='myproject.urls'
+    )
+
 #### `renderer_classes`
 
 May be used to pass the set of renderer classes that can be used to render the API root endpoint.

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -147,12 +147,9 @@ May be used to pass a canonical URL for the schema.
 
 #### `urlconf`
 
-String representing import path to the URL conf that you want
+A string representing the import path to the URL conf that you want
 to generate an API schema for. This defaults to the value of Django's
 ROOT_URLCONF setting.
-
-Useful for `Django multihost snippet`
-https://code.djangoproject.com/wiki/MultiHostMiddleware
 
     schema_view = get_schema_view(
         title='Server Monitoring API',

--- a/docs/api-guide/schemas.md
+++ b/docs/api-guide/schemas.md
@@ -147,8 +147,11 @@ May be used to pass a canonical URL for the schema.
 
 #### `urlconf`
 
-May be used to pass a nondefault url configuration
-useful for `Django multihost snippet`
+String representing import path to the URL conf that you want
+to generate an API schema for. This defaults to the value of Django's
+ROOT_URLCONF setting.
+
+Useful for `Django multihost snippet`
 https://code.djangoproject.com/wiki/MultiHostMiddleware
 
     schema_view = get_schema_view(

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -571,11 +571,11 @@ class SchemaGenerator(object):
         return named_path_components + [action]
 
 
-def get_schema_view(title=None, url=None, renderer_classes=None):
+def get_schema_view(title=None, url=None, urlconf=None, renderer_classes=None):
     """
     Return a schema view.
     """
-    generator = SchemaGenerator(title=title, url=url)
+    generator = SchemaGenerator(title=title, url=url, urlconf=urlconf)
     if renderer_classes is None:
         if renderers.BrowsableAPIRenderer in api_settings.DEFAULT_RENDERER_CLASSES:
             rclasses = [renderers.CoreJSONRenderer, renderers.BrowsableAPIRenderer]


### PR DESCRIPTION
I have django virtual hosts, after last changes I've lost ability to generate swagger info for any domains but default one, this patch fixes it