### PR TITLE
fix a spelling error in api-guide

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -1157,7 +1157,7 @@ The [html-json-forms][html-json-forms] package provides an algorithm and seriali
 
 ## QueryFields
 
-[djangorestframework-queryfields][djangorestframework-queryfields] allows API clients to specify which fields will be sent in the response via inclusion or exclusion query paramaters.  
+[djangorestframework-queryfields][djangorestframework-queryfields] allows API clients to specify which fields will be sent in the response via inclusion/exclusion query parameters.  
 
 
 [cite]: https://groups.google.com/d/topic/django-users/sVFaOfQi4wY/discussion


### PR DESCRIPTION
Just noticed I misspelled paramaters -> parameters.  Sorry about that.  