### PR TITLE
Raise `RuntimeError` when trying to encode coreapi objects

### DIFF
--- a/rest_framework/utils/encoders.py
+++ b/rest_framework/utils/encoders.py
@@ -55,6 +55,11 @@ class JSONEncoder(json.JSONEncoder):
         elif hasattr(obj, 'tolist'):
             # Numpy arrays and array scalars.
             return obj.tolist()
+        elif (coreapi is not None) and isinstance(obj, (coreapi.Document, coreapi.Error)):
+            raise RuntimeError(
+                'Cannot return a coreapi object from a JSON view. '
+                'You should be using a schema renderer instead for this view.'
+            )
         elif hasattr(obj, '__getitem__'):
             try:
                 return dict(obj)
@@ -62,9 +67,4 @@ class JSONEncoder(json.JSONEncoder):
                 pass
         elif hasattr(obj, '__iter__'):
             return tuple(item for item in obj)
-        elif (coreapi is not None) and isinstance(obj, (coreapi.Document, coreapi.Error)):
-            raise RuntimeError(
-                'Cannot return a coreapi object from a JSON view. '
-                'You should be using a schema renderer instead for this view.'
-            )
         return super(JSONEncoder, self).default(obj)

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 from django.test import TestCase
 
+from rest_framework.compat import coreapi
 from rest_framework.utils.encoders import JSONEncoder
 
 
@@ -79,3 +80,13 @@ class JSONEncoderTests(TestCase):
         """
         unique_id = uuid4()
         assert self.encoder.default(unique_id) == str(unique_id)
+
+    def test_encode_coreapi_raises_error(self):
+        """
+        Tests encoding a coreapi objects raises proper error
+        """
+        with self.assertRaises(RuntimeError):
+            self.encoder.default(coreapi.Document())
+
+        with self.assertRaises(RuntimeError):
+            self.encoder.default(coreapi.Error())


### PR DESCRIPTION
`JSONEncoder.default` didn't raise `RuntimeError` as intended because there is another "if" above which returns earlier.
Maybe it is better to put check for `coreapi` objects on top of `default` method?