### PR TITLE
docs: tutorial: Minor grammar "fix"

### DIFF
--- a/docs/tutorial/3-class-based-views.md
+++ b/docs/tutorial/3-class-based-views.md
@@ -62,7 +62,7 @@ So far, so good.  It looks pretty similar to the previous case, but we've got be
 
 That's looking good.  Again, it's still pretty similar to the function based view right now.
 
-We'll also need to refactor our `urls.py` slightly now we're using class-based views.
+We'll also need to refactor our `urls.py` slightly now that we're using class-based views.
 
     from django.conf.urls import url
     from rest_framework.urlpatterns import format_suffix_patterns


### PR DESCRIPTION
## Description

Minor grammar fix.  The "that" seems to be necessary (citation needed).