### PR TITLE
Added required on_delete attribute to OneToOneField field.

### DIFF
--- a/tests/test_one_to_one_with_inheritance.py
+++ b/tests/test_one_to_one_with_inheritance.py
@@ -14,7 +14,7 @@ from tests.test_multitable_inheritance import ChildModel
 # Regression test for #4290
 
 class ChildAssociatedModel(RESTFrameworkModel):
-    child_model = models.OneToOneField(ChildModel)
+    child_model = models.OneToOneField(ChildModel, on_delete=models.CASCADE)
     child_name = models.CharField(max_length=100)
 
 


### PR DESCRIPTION
Added missing `on_delete` attribute to `OneToOneField`. `on_delete` is required since Django 2.0.
```
==================================== ERRORS ====================================
__________ ERROR collecting tests/test_one_to_one_with_inheritance.py __________
tests/test_one_to_one_with_inheritance.py:16: in <module>
    class ChildAssociatedModel(RESTFrameworkModel):
tests/test_one_to_one_with_inheritance.py:17: in ChildAssociatedModel
    child_model = models.OneToOneField(ChildModel)
E   TypeError: __init__() missing 1 required positional argument: 'on_delete'
```