### PR TITLE
Removed unnecessary utc wrapper.

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -312,12 +312,3 @@ def set_many(instance, field, value):
     else:
         field = getattr(instance, field)
         field.set(value)
-
-
-try:
-    # A `utc` instance is available in Django 1.11+
-    from django.utils.timezone import utc
-except ImportError:
-    # A `UTC` class is available in older versions
-    from django.utils.timezone import UTC
-    utc = UTC()

--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -28,11 +28,12 @@ from django.utils.encoding import is_protected_type, smart_text
 from django.utils.formats import localize_input, sanitize_separators
 from django.utils.functional import cached_property
 from django.utils.ipv6 import clean_ipv6_address
+from django.utils.timezone import utc
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import ISO_8601
 from rest_framework.compat import (
-    get_remote_field, unicode_repr, unicode_to_repr, utc, value_from_object
+    get_remote_field, unicode_repr, unicode_to_repr, value_from_object
 )
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.settings import api_settings

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -9,10 +9,10 @@ import pytest
 from django.http import QueryDict
 from django.test import TestCase, override_settings
 from django.utils import six
+from django.utils.timezone import utc
 
 import rest_framework
 from rest_framework import serializers
-from rest_framework.compat import utc
 from rest_framework.fields import is_simple_callable
 
 try:


### PR DESCRIPTION
Cleanup. `utc` backward compatibility wrapper is unnecessary. `utc` is available since Django 1.4 (see [b2f81ff0](https://github.com/django/django/commit/9b1cb755a28f020e27d4268c214b25315d4de42e#diff-b2f81ff06ef4aa2a1e7dbfbc620f73d6R87)).