### PR TITLE
Add "patterns" parameter for get_schema_view

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -571,11 +571,11 @@ class SchemaGenerator(object):
         return named_path_components + [action]
 
 
-def get_schema_view(title=None, url=None, urlconf=None, renderer_classes=None):
+def get_schema_view(title=None, url=None, urlconf=None, renderer_classes=None, patterns=None):
     """
     Return a schema view.
     """
-    generator = SchemaGenerator(title=title, url=url, urlconf=urlconf)
+    generator = SchemaGenerator(title=title, url=url, urlconf=urlconf, patterns=patterns)
     if renderer_classes is None:
         if renderers.BrowsableAPIRenderer in api_settings.DEFAULT_RENDERER_CLASSES:
             rclasses = [renderers.CoreJSONRenderer, renderers.BrowsableAPIRenderer]


### PR DESCRIPTION
In some cases it's useful if schemas.get_schema_view is used only for some url patterns. 
