### PR TITLE
Fixed travis allow_failures configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,18 @@ matrix:
         env: DJANGO=master
 
     allow_failures:
-      - env: DJANGO=master
-      - env: DJANGO=1.11
+      - python: "2.7"
+        env: DJANGO=1.11
+      - python: "3.4"
+        env: DJANGO=1.11
+      - python: "3.5"
+        env: DJANGO=1.11
+      - python: "3.6"
+        env: DJANGO=1.11
+      - python: "3.5"
+        env: DJANGO=master
+      - python: "3.6"
+        env: DJANGO=master
 
 install:
     - pip install tox tox-travis


### PR DESCRIPTION
I fixed travis `allow_failures` configuration (see last [build](https://travis-ci.org/tomchristie/django-rest-framework/builds/195195705) and travis [documentation](https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail)).