### PR TITLE
Removed multi-table inheritance auto created PK from serialize.

### DIFF
--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -76,7 +76,12 @@ def _get_forward_relationships(opts):
     Returns an `OrderedDict` of field names to `RelationInfo`.
     """
     forward_relations = OrderedDict()
-    for field in [field for field in opts.fields if field.serialize and get_remote_field(field)]:
+    for field in [
+        field for field in opts.fields
+        if field.serialize and get_remote_field(field) and not (field.primary_key and field.one_to_one)
+        # If the field is a OneToOneField and it's been marked as PK, then this
+        # is a multi-table inheritance auto created PK ('%_ptr').
+    ]:
         forward_relations[field.name] = RelationInfo(
             model_field=field,
             related_model=get_related_model(field),


### PR DESCRIPTION
Fixed #4574 and https://github.com/carltongibson/django-filter/issues/607. 

Bisected to https://github.com/django/django/commit/74a575eb7296fb04e1fc2bd4e3f68dee3c66ee0a (see [[1]](https://github.com/django/django/commit/74a575eb7296fb04e1fc2bd4e3f68dee3c66ee0a#diff-98e98c694c90e830f918eb5279134ab9R300)).