### PR TITLE
add Meta.include which is the same as Meta.fields

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -1027,7 +1027,7 @@ class ModelSerializer(Serializer):
         set of fields, but also takes into account the `Meta.fields` or
         `Meta.exclude` options if they have been specified.
         """
-        fields = getattr(self.Meta, 'fields', None)
+        fields = getattr(self.Meta, 'fields', getattr(self.Meta, 'include', None))
         exclude = getattr(self.Meta, 'exclude', None)
 
         if fields and fields != ALL_FIELDS and not isinstance(fields, (list, tuple)):


### PR DESCRIPTION
I had a serializer with `Meta.exclude` and wanted to flip the behaviour, I changed it to `Meta.include` and updated the fields. I got all kinds of unexpected behaviour/errors, but none suggested that `Meta.include` wasn't valid/working as expected. I'm proposing this as `include` is the opposite of `exclude`, feels more natural than `fields`.

I wanted you to see the change I propose and confirm whether you're happy to accept it before I take the time to add tests and documentation.

Actually I've just realised that this mirrors the Django ModelForm Meta api, so guessing you won't accept it without that getting the same change (which makes sense). Just had a quick look and don't see a ticket in the Django bug tracker.

