### PR TITLE
Removed unnecessary importlib wrapper.

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -17,11 +17,6 @@ from django.template import Context, RequestContext, Template
 from django.utils import six
 from django.views.generic import View
 
-try:
-    import importlib  # Available in Python 3.1+
-except ImportError:
-    from django.utils import importlib  # Will be removed in Django 1.9
-
 
 try:
     from django.urls import (

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -18,13 +18,13 @@ REST framework settings, checking for user settings first, then falling
 back to the defaults.
 """
 from __future__ import unicode_literals
+from importlib import import_module
 
 from django.conf import settings
 from django.test.signals import setting_changed
 from django.utils import six
 
 from rest_framework import ISO_8601
-from rest_framework.compat import importlib
 
 DEFAULTS = {
     # Base API policies
@@ -174,7 +174,7 @@ def import_from_string(val, setting_name):
         # Nod to tastypie's use of importlib.
         parts = val.split('.')
         module_path, class_name = '.'.join(parts[:-1]), parts[-1]
-        module = importlib.import_module(module_path)
+        module = import_module(module_path)
         return getattr(module, class_name)
     except (ImportError, AttributeError) as e:
         msg = "Could not import '%s' for API setting '%s'. %s: %s." % (val, setting_name, e.__class__.__name__, e)


### PR DESCRIPTION
Cleanup. `importlib` backward compatibility wrapper is unnecessary.  `importlib` is available in python>=2.7 (see [doc](https://docs.python.org/2/library/importlib.html)) and in python>=3.1 (see [doc](https://docs.python.org/3/library/importlib.html)), moreover in [rest_framework/schemas.py](https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/schemas.py#L3) we already use `importlib` from stdlib.