### PR TITLE
Fixed Django 2.0 compatibility due to `django.conf.urls.include` parameters change.

### DIFF
--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -307,3 +307,10 @@ def set_many(instance, field, value):
     else:
         field = getattr(instance, field)
         field.set(value)
+
+def include(module, namespace=None, app_name=None):
+    from django.conf.urls import include
+    if django.VERSION < (1,9):
+        return include(module, namespace, app_name)
+    else:
+        return include((module, app_name), namespace)

--- a/rest_framework/urlpatterns.py
+++ b/rest_framework/urlpatterns.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
-from django.conf.urls import include, url
+from django.conf.urls import url
 
-from rest_framework.compat import RegexURLResolver
+from rest_framework.compat import RegexURLResolver, include
 from rest_framework.settings import api_settings
 
 

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -4,12 +4,13 @@ import json
 from collections import namedtuple
 
 import pytest
-from django.conf.urls import include, url
+from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.test import TestCase, override_settings
 
 from rest_framework import permissions, serializers, viewsets
+from rest_framework.compat import include
 from rest_framework.decorators import detail_route, list_route
 from rest_framework.response import Response
 from rest_framework.routers import DefaultRouter, SimpleRouter
@@ -81,7 +82,7 @@ empty_prefix_urls = [
 
 urlpatterns = [
     url(r'^non-namespaced/', include(namespaced_router.urls)),
-    url(r'^namespaced/', include(namespaced_router.urls, namespace='example')),
+    url(r'^namespaced/', include(namespaced_router.urls, namespace='example', app_name='example')),
     url(r'^example/', include(notes_router.urls)),
     url(r'^example2/', include(kwarged_notes_router.urls)),
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,8 +1,9 @@
 import pytest
-from django.conf.urls import include, url
+from django.conf.urls import url
 from django.test import override_settings
 
 from rest_framework import serializers, status, versioning
+from rest_framework.compat import include
 from rest_framework.decorators import APIView
 from rest_framework.relations import PKOnlyObject
 from rest_framework.response import Response
@@ -170,7 +171,7 @@ class TestURLReversing(URLPatternsTestCase):
     ]
 
     urlpatterns = [
-        url(r'^v1/', include(included, namespace='v1')),
+        url(r'^v1/', include(included, namespace='v1', app_name='v1')),
         url(r'^another/$', dummy_view, name='another'),
         url(r'^(?P<version>[v1|v2]+)/another/$', dummy_view, name='another'),
     ]
@@ -335,8 +336,8 @@ class TestHyperlinkedRelatedField(URLPatternsTestCase):
     ]
 
     urlpatterns = [
-        url(r'^v1/', include(included, namespace='v1')),
-        url(r'^v2/', include(included, namespace='v2'))
+        url(r'^v1/', include(included, namespace='v1', app_name='v1')),
+        url(r'^v2/', include(included, namespace='v2', app_name='v2'))
     ]
 
     def setUp(self):
@@ -367,7 +368,7 @@ class TestNamespaceVersioningHyperlinkedRelatedFieldScheme(URLPatternsTestCase):
     ]
     included = [
         url(r'^namespaced/(?P<pk>\d+)/$', dummy_pk_view, name='namespaced'),
-        url(r'^nested/', include(nested, namespace='nested-namespace'))
+        url(r'^nested/', include(nested, namespace='nested-namespace', app_name='nested-namespace'))
     ]
 
     urlpatterns = [


### PR DESCRIPTION
Fixed Django 2.0 compatibility due to `django.conf.urls.include` parameters change (see Django documentation [1.8](https://docs.djangoproject.com/en/1.8/ref/urls/#include), [2.0](https://docs.djangoproject.com/en/dev/ref/urls/#include)).
```
==================================== ERRORS ====================================
____________________ ERROR collecting tests/test_routers.py ____________________
tests/test_routers.py:84: in <module>
    url(r'^namespaced/', include(namespaced_router.urls, namespace='example')),
/django/conf/urls/__init__.py:44: in include
    'Specifying a namespace in django.conf.urls.include() without '
E   django.core.exceptions.ImproperlyConfigured: Specifying a namespace in
django.conf.urls.include() without providing an app_name is not supported.
Set the app_name attribute in the included module, or pass a 2-tuple containing
the list of patterns and app_name instead.
__________________ ERROR collecting tests/test_versioning.py ___________________
tests/test_versioning.py:166: in <module>
    class TestURLReversing(URLPatternsTestCase):
tests/test_versioning.py:173: in TestURLReversing
    url(r'^v1/', include(included, namespace='v1')),
/django/conf/urls/__init__.py:44: in include
    'Specifying a namespace in django.conf.urls.include() without '
E   django.core.exceptions.ImproperlyConfigured: Specifying a namespace in
django.conf.urls.include() without providing an app_name is not supported.
Set the app_name attribute in the included module, or pass a 2-tuple containing
the list of patterns and app_name instead.
```