### PR TITLE
serialisers.UUIDField with Boolean value not raising "invalid UUID" e…

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -827,6 +827,8 @@ class UUIDField(Field):
         if not isinstance(data, uuid.UUID):
             try:
                 if isinstance(data, six.integer_types):
+                    # if isinstance(data, bool):
+                    #     self.fail('invalid', value=data)
                     return uuid.UUID(int=data)
                 elif isinstance(data, six.string_types):
                     return uuid.UUID(hex=data)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -731,7 +731,8 @@ class TestUUIDField(FieldValues):
     }
     invalid_inputs = {
         '825d7aeb-05a9-45b5-a5b7': ['"825d7aeb-05a9-45b5-a5b7" is not a valid UUID.'],
-        (1, 2, 3): ['"(1, 2, 3)" is not a valid UUID.']
+        (1, 2, 3): ['"(1, 2, 3)" is not a valid UUID.'],
+        True: ['"True" is not a valid UUID.'],
     }
     outputs = {
         uuid.UUID('825d7aeb-05a9-45b5-a5b7-05df87923cda'): '825d7aeb-05a9-45b5-a5b7-05df87923cda'


### PR DESCRIPTION
## Description
Bugfix:
Issue: refs #4883
serializers.UUIDField does not raise ValidationError when calling it's .to_representation method with a boolean value.

