### PR TITLE
Reverted "Removed multi-table inheritance auto created PK from serialize".

### DIFF
--- a/rest_framework/utils/model_meta.py
+++ b/rest_framework/utils/model_meta.py
@@ -76,12 +76,7 @@ def _get_forward_relationships(opts):
     Returns an `OrderedDict` of field names to `RelationInfo`.
     """
     forward_relations = OrderedDict()
-    for field in [
-        field for field in opts.fields
-        if field.serialize and get_remote_field(field) and not (field.primary_key and field.one_to_one)
-        # If the field is a OneToOneField and it's been marked as PK, then this
-        # is a multi-table inheritance auto created PK ('%_ptr').
-    ]:
+    for field in [field for field in opts.fields if field.serialize and get_remote_field(field)]:
         forward_relations[field.name] = RelationInfo(
             model_field=field,
             related_model=get_related_model(field),


### PR DESCRIPTION
https://github.com/django/django/commit/0595bca221825c0c6bd572a32f3bf9eff7069328 reverted https://github.com/django/django/commit/74a575eb7296fb04e1fc2bd4e3f68dee3c66ee0a, hence we can revert 1ecbeebbe5e1f4ac5f7f8112d80f3ea13972cc0f that fixed bugs caused by https://github.com/django/django/commit/74a575eb7296fb04e1fc2bd4e3f68dee3c66ee0a (see also #4852, #4574).