### PR TITLE
Refs: #4256 delete not relevant documentation

### DIFF
--- a/docs/api-guide/fields.md
+++ b/docs/api-guide/fields.md
@@ -303,8 +303,6 @@ Format strings may either be [Python strftime formats][strftime] which explicitl
 
 When a value of `None` is used for the format `datetime` objects will be returned by `to_representation` and the final output representation will determined by the renderer class.
 
-In the case of JSON this means the default datetime representation uses the [ECMA 262 date time string specification][ecma262].  This is a subset of ISO 8601 which uses millisecond precision, and includes the 'Z' suffix for the UTC timezone, for example: `2013-01-29T12:34:56.123Z`.
-
 #### `auto_now` and `auto_now_add` model fields.
 
 When using `ModelSerializer` or `HyperlinkedModelSerializer`, note that any model fields with `auto_now=True` or `auto_now_add=True` will use serializer fields that are `read_only=True` by default.


### PR DESCRIPTION
## Description

Delete not relevant documentation paragraph.
Paragraph says about microseconds behavior which was changed in  https://github.com/tomchristie/django-rest-framework/pull/4256