### PR TITLE
Move request.data to getter method

### DIFF
--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -19,7 +19,7 @@ class CreateModelMixin(object):
         return request.data
 
     def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=self.get_request_data(request))
+        serializer = self.get_serializer(data=self.get_request_data(request, *args, **kwargs))
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)
@@ -71,7 +71,7 @@ class UpdateModelMixin(object):
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop('partial', False)
         instance = self.get_object()
-        serializer = self.get_serializer(instance, data=self.get_request_data(request), partial=partial)
+        serializer = self.get_serializer(instance, data=self.get_request_data(request, *args, **kwargs), partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
 

--- a/rest_framework/mixins.py
+++ b/rest_framework/mixins.py
@@ -15,8 +15,11 @@ class CreateModelMixin(object):
     """
     Create a model instance.
     """
+    def get_request_data(self, request, *args, **kwargs):
+        return request.data
+
     def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data)
+        serializer = self.get_serializer(data=self.get_request_data(request))
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)
@@ -62,10 +65,13 @@ class UpdateModelMixin(object):
     """
     Update a model instance.
     """
+    def get_request_data(self, request, *args, **kwargs):
+        return request.data
+
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop('partial', False)
         instance = self.get_object()
-        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer = self.get_serializer(instance, data=self.get_request_data(request), partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
 


### PR DESCRIPTION
## Extending functionality

This change allow manipulating data with request, in case data being nested, required modification (a good example could be when instead delete the file we want to change `active` field to false instead - performing update of { ‘active’ : False } )

I happen to have a need to overwrite your framework that way to achieve deleting by changing flag functionality, handling nested data (could be done in serializer, however, it is more clear that way, or dealing with creating (inserting) multiple records with one request of an array of records. 
For this reason, I want to contribute the solution to the community.