### PR TITLE
Add drf-writable-nested package to third-party serializers

### DIFF
--- a/docs/api-guide/serializers.md
+++ b/docs/api-guide/serializers.md
@@ -1157,6 +1157,9 @@ The [html-json-forms][html-json-forms] package provides an algorithm and seriali
 
 [djangorestframework-queryfields][djangorestframework-queryfields] allows API clients to specify which fields will be sent in the response via inclusion/exclusion query parameters.  
 
+## DRF Writable Nested
+
+The [drf-writable-nested][drf-writable-nested] package provides writable nested model serializer which allows to create/update models with nested related data.
 
 [cite]: https://groups.google.com/d/topic/django-users/sVFaOfQi4wY/discussion
 [relations]: relations.md
@@ -1177,3 +1180,4 @@ The [html-json-forms][html-json-forms] package provides an algorithm and seriali
 [drf-base64]: https://bitbucket.org/levit_scs/drf_base64
 [drf-serializer-extensions]: https://github.com/evenicoulddoit/django-rest-framework-serializer-extensions
 [djangorestframework-queryfields]: http://djangorestframework-queryfields.readthedocs.io/
+[drf-writable-nested]: http://github.com/Brogency/drf-writable-nested


### PR DESCRIPTION
I've added [drf-writable-nested](https://github.com/Brogency/drf-writable-nested) package to third-party serializer docs.

This package provides `WritableNestedModelSerializer` (based on `ModelSerializer`) and allows to create/update models with nested related fields.