### PR TITLE
Fix Schemas Example URL

### DIFF
--- a/docs/topics/documenting-your-api.md
+++ b/docs/topics/documenting-your-api.md
@@ -148,4 +148,4 @@ To implement a hypermedia API you'll need to decide on an appropriate media type
 [image-django-rest-swagger]: ../img/django-rest-swagger.png
 [image-apiary]: ../img/apiary.png
 [image-self-describing-api]: ../img/self-describing.png
-[schemas-examples]: api-guide/schemas/#examples
+[schemas-examples]: ../api-guide/schemas/#examples


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/tomchristie/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

 Schemas as documentation: Examples link in topics/documenting-your-api/ points to a non existent api-guide page under topics. Added a parent directory short string at the beginning of the URL.
