### PR TITLE
Add failing tests and fix for dict that have a key `items` #4931

### DIFF
--- a/rest_framework/templates/rest_framework/admin/detail.html
+++ b/rest_framework/templates/rest_framework/admin/detail.html
@@ -1,7 +1,7 @@
 {% load rest_framework %}
 <table class="table table-striped">
   <tbody>
-    {% for key, value in results.items %}
+    {% for key, value in results|items %}
       {% if key in details %}
         <tr><th>{{ key|capfirst }}</th><td {{ value|add_nested_class }}>{{ value|format_value }}</td></tr>
       {% endif %}

--- a/rest_framework/templates/rest_framework/admin/dict_value.html
+++ b/rest_framework/templates/rest_framework/admin/dict_value.html
@@ -1,7 +1,7 @@
 {% load rest_framework %}
 <table class="table table-striped">
   <tbody>
-    {% for k, v in value %}
+    {% for k, v in value|items %}
       <tr>
         <th>{{ k|format_value }}</th>
         <td>{{ v|format_value }}</td>

--- a/rest_framework/templates/rest_framework/admin/dict_value.html
+++ b/rest_framework/templates/rest_framework/admin/dict_value.html
@@ -1,10 +1,10 @@
 {% load rest_framework %}
 <table class="table table-striped">
   <tbody>
-    {% for key, value in value %}
+    {% for k, v in value %}
       <tr>
-        <th>{{ key|format_value }}</th>
-        <td>{{ value|format_value }}</td>
+        <th>{{ k|format_value }}</th>
+        <td>{{ v|format_value }}</td>
       </tr>
     {% endfor %}
   </tbody>

--- a/rest_framework/templates/rest_framework/admin/list.html
+++ b/rest_framework/templates/rest_framework/admin/list.html
@@ -6,7 +6,7 @@
   <tbody>
     {% for row in results %}
       <tr>
-        {% for key, value in row.items %}
+        {% for key, value in row|items %}
           {% if key in columns %}
             <td {{ value|add_nested_class }} >
               {{ value|format_value }}

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -148,7 +148,7 @@ def format_value(value):
         return template_render(template, context)
     elif isinstance(value, dict):
         template = loader.get_template('rest_framework/admin/dict_value.html')
-        context = {'value': value.items()}
+        context = {'value': value}
         return template_render(template, context)
     elif isinstance(value, six.string_types):
         if (
@@ -161,6 +161,12 @@ def format_value(value):
         elif '\n' in value:
             return mark_safe('<pre>%s</pre>' % escape(value))
     return six.text_type(value)
+
+
+@register.filter
+def items(value):
+    if hasattr(value, 'items'):
+        return value.items()
 
 
 @register.filter

--- a/rest_framework/templatetags/rest_framework.py
+++ b/rest_framework/templatetags/rest_framework.py
@@ -165,8 +165,13 @@ def format_value(value):
 
 @register.filter
 def items(value):
-    if hasattr(value, 'items'):
-        return value.items()
+    """
+    Simple filter to return the items of the dict. Useful when the dict may
+    have a key 'items' which is resolved first in Django tempalte dot-notation
+    lookup.  See issue #4931
+    Also see: https://stackoverflow.com/questions/15416662/django-template-loop-over-dictionary-items-with-items-as-key
+    """
+    return value.items()
 
 
 @register.filter

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -656,13 +656,12 @@ class AdminRendererTests(TestCase):
             renderer_classes = (AdminRenderer, )
 
             def get(self, request):
-                return Response({'foo' : 'a string'})
+                return Response({'foo': 'a string'})
         view = DummyView.as_view()
         request = factory.get('/')
         response = view(request)
         response.render()
         self.assertInHTML('<tr><th>Foo</th><td>a string</td></tr>', str(response.content))
-
 
     def test_render_dict_with_items_key(self):
         factory = APIRequestFactory()
@@ -671,14 +670,13 @@ class AdminRendererTests(TestCase):
             renderer_classes = (AdminRenderer, )
 
             def get(self, request):
-                return Response({'items' : 'a string'})
+                return Response({'items': 'a string'})
 
         view = DummyView.as_view()
         request = factory.get('/')
         response = view(request)
         response.render()
         self.assertInHTML('<tr><th>Items</th><td>a string</td></tr>', str(response.content))
-
 
     def test_render_dict_with_iteritems_key(self):
         factory = APIRequestFactory()
@@ -687,7 +685,7 @@ class AdminRendererTests(TestCase):
             renderer_classes = (AdminRenderer, )
 
             def get(self, request):
-                return Response({'iteritems' : 'a string'})
+                return Response({'iteritems': 'a string'})
 
         view = DummyView.as_view()
         request = factory.get('/')

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -661,7 +661,7 @@ class AdminRendererTests(TestCase):
         request = factory.get('/')
         response = view(request)
         response.render()
-        self.assertInHTML('<tr><th>Foo</th><td>a string</td></tr>', response.content)
+        self.assertInHTML('<tr><th>Foo</th><td>a string</td></tr>', str(response.content))
 
 
     def test_render_dict_with_items_key(self):
@@ -677,10 +677,10 @@ class AdminRendererTests(TestCase):
         request = factory.get('/')
         response = view(request)
         response.render()
-        self.assertInHTML('<tr><th>Items</th><td>a string</td></tr>', response.content)
+        self.assertInHTML('<tr><th>Items</th><td>a string</td></tr>', str(response.content))
 
 
-    def test_render_dict_with_keys_key(self):
+    def test_render_dict_with_iteritems_key(self):
         factory = APIRequestFactory()
 
         class DummyView(APIView):
@@ -693,4 +693,4 @@ class AdminRendererTests(TestCase):
         request = factory.get('/')
         response = view(request)
         response.render()
-        self.assertInHTML('<tr><th>Iteritems</th><td>a string</td></tr>', response.content)
+        self.assertInHTML('<tr><th>Iteritems</th><td>a string</td></tr>', str(response.content))

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -648,3 +648,49 @@ class AdminRendererTests(TestCase):
         assert result == ''
         assert response.status_code == status.HTTP_303_SEE_OTHER
         assert response['Location'] == 'http://example.com'
+
+    def test_render_dict(self):
+        factory = APIRequestFactory()
+
+        class DummyView(APIView):
+            renderer_classes = (AdminRenderer, )
+
+            def get(self, request):
+                return Response({'foo' : 'a string'})
+        view = DummyView.as_view()
+        request = factory.get('/')
+        response = view(request)
+        response.render()
+        self.assertInHTML('<tr><th>Foo</th><td>a string</td></tr>', response.content)
+
+
+    def test_render_dict_with_items_key(self):
+        factory = APIRequestFactory()
+
+        class DummyView(APIView):
+            renderer_classes = (AdminRenderer, )
+
+            def get(self, request):
+                return Response({'items' : 'a string'})
+
+        view = DummyView.as_view()
+        request = factory.get('/')
+        response = view(request)
+        response.render()
+        self.assertInHTML('<tr><th>Items</th><td>a string</td></tr>', response.content)
+
+
+    def test_render_dict_with_keys_key(self):
+        factory = APIRequestFactory()
+
+        class DummyView(APIView):
+            renderer_classes = (AdminRenderer, )
+
+            def get(self, request):
+                return Response({'iteritems' : 'a string'})
+
+        view = DummyView.as_view()
+        request = factory.get('/')
+        response = view(request)
+        response.render()
+        self.assertInHTML('<tr><th>Iteritems</th><td>a string</td></tr>', response.content)


### PR DESCRIPTION
## Description

#4931 This shows that if the there is a dict with a key `items` or `iteritems`, less likely but it proves the point, the main content is not rendered.