### PR TITLE
Update django-filter requirement

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,7 @@ The following packages are optional:
 
 * [coreapi][coreapi] (1.32.0+) - Schema generation support.
 * [Markdown][markdown] (2.1.0+) - Markdown support for the browsable API.
-* [django-filter][django-filter] (0.9.2+) - Filtering support.
+* [django-filter][django-filter] (1.0.1+) - Filtering support.
 * [django-crispy-forms][django-crispy-forms] - Improved HTML display for filtering.
 * [django-guardian][django-guardian] (1.1.1+) - Object level permissions support.
 


### PR DESCRIPTION
The requirements on this page are outdated.  It lists Django Filter 0.9.2+ as an optional requirement, but filters.py includes code that will break if django_filters isn't at 1.0.1




django-rest-framework/filters.py 
    from django_filters.rest_framework.filterset import FilterSet as DFFilterSet

django_filters only added the .rest_framework module in version 1.0.1.
(https://github.com/carltongibson/django-filter/releases/tag/1.0.1)


