### PR TITLE
Ensure 'markdown' dependancy is optional.

### DIFF
--- a/rest_framework/__init__.py
+++ b/rest_framework/__init__.py
@@ -8,7 +8,7 @@ ______ _____ _____ _____    __
 """
 
 __title__ = 'Django REST framework'
-__version__ = '3.6.0'
+__version__ = '3.6.1'
 __author__ = 'Tom Christie'
 __license__ = 'BSD 2-Clause'
 __copyright__ = 'Copyright 2011-2017 Tom Christie'

--- a/rest_framework/compat.py
+++ b/rest_framework/compat.py
@@ -249,6 +249,7 @@ try:
         return md.convert(text)
 except ImportError:
     apply_markdown = None
+    markdown = None
 
 
 try:


### PR DESCRIPTION
Refs #4941. - See https://github.com/tomchristie/django-rest-framework/issues/4941#issuecomment-285393678.