### PR TITLE
UnboundLocalError: local variable 'model_field' on schemas.py

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -531,7 +531,7 @@ class SchemaGenerator(object):
                 try:
                     model_field = model._meta.get_field(variable)
                 except:
-                    pass
+                    model_field = None  # Set model_field to None so it doesn't fail test
 
                 if model_field is not None and model_field.verbose_name:
                     title = force_text(model_field.verbose_name)


### PR DESCRIPTION
## Description

First time pull request.

I was getting the following error when trying out the new api documentation support feature.

```
UnboundLocalError: local variable 'model_field' referenced before assignment
```

I found that if the try/except on `model_field = model._meta.get_field(variable)` failed it would simply pass and not set the `model_field` to `None` which would then cause an error at line 536
```python
if model_field is not None and model_field.verbose_name:
```

Fixed this by telling the except to set `model_field` to `None`. Passed all the tests as per the guidelines.



