### PR TITLE
Interactive doc: remove document.data.items from templates

### DIFF
--- a/rest_framework/renderers.py
+++ b/rest_framework/renderers.py
@@ -805,8 +805,11 @@ class DocumentationRenderer(BaseRenderer):
     languages = ['shell', 'javascript', 'python']
 
     def get_context(self, data, request):
+        document = data
+        document_data_list = document.data.items()
         return {
-            'document': data,
+            'document': document,
+            'document_data_list': document_data_list,
             'langs': self.languages,
             'code_style': pygments_css(self.code_style),
             'request': request

--- a/rest_framework/templates/rest_framework/docs/document.html
+++ b/rest_framework/templates/rest_framework/docs/document.html
@@ -14,7 +14,7 @@
 </div>
 </div>
 
-{% for section_key, section in document.data.items %}
+{% for section_key, section in document_data_list %}
 {% if section_key %}
     <h2 id="{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
 </a></h2>

--- a/rest_framework/templates/rest_framework/docs/sidebar.html
+++ b/rest_framework/templates/rest_framework/docs/sidebar.html
@@ -4,7 +4,7 @@
     <i class="fa fa-bars fa-2x toggle-btn" data-toggle="collapse" data-target="#menu-content"></i>
     <div class="menu-list">
         <ul id="menu-content" class="menu-content collapse out">
-            {% for section_key, section in document.data.items %}
+            {% for section_key, section in document_data_list %}
             <li data-toggle="collapse" data-target="#{{ section_key }}-dropdown" class="collapsed">
                 <a><i class="fa fa-dot-circle-o fa-lg"></i> {% if section_key %}{{ section_key }}{% else %}API Endpoints{% endif %} <span class="arrow"></span></a>
             </li>


### PR DESCRIPTION
*"document_data_list"* list of pairs is directly passed in template context,
so that we can use dictionaries with *"items"* as key (i.e.: data['items'])

Before this change, with the following Router config:

  `api_router.register(r'items',` `ItemViewSet)`

GET /docs/ failed with error:

    Internal Server Error: /docs/
    ...
    File "...\site-packages\django\template\defaulttags.py", line 200, in render
      .format(num_loopvars, len_item),
    ValueError: Need 2 values to unpack in for loop; got 4.


see https://docs.djangoproject.com/en/1.10/ref/templates/builtins/#for