### PR TITLE
Use 'items' templatetag throughout.

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -150,7 +150,7 @@
               </div>
 
               <div class="response-info">
-                <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}{% for key, val in response_headers.items %}
+                <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}{% for key, val in response_headers|items %}
 <b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>{% endfor %}
 
 </span>{{ content|urlize_quoted_links }}</pre>{% endautoescape %}

--- a/rest_framework/templates/rest_framework/docs/document.html
+++ b/rest_framework/templates/rest_framework/docs/document.html
@@ -14,17 +14,17 @@
 </div>
 </div>
 
-{% for section_key, section in document.data.items %}
+{% for section_key, section in document.data|items %}
 {% if section_key %}
     <h2 id="{{ section_key }}" class="coredocs-section-title">{{ section_key }} <a href="#{{ section_key }}"><i class="fa fa-link" aria-hidden="true"></i>
 </a></h2>
 {% endif %}
 
-    {% for link_key, link in section.links.items %}
+    {% for link_key, link in section.links|items %}
         {% include "rest_framework/docs/link.html" %}
     {% endfor %}
 {% endfor %}
 
-{% for link_key, link in document.links.items %}
+{% for link_key, link in document.links|items %}
     {% include "rest_framework/docs/link.html" %}
 {% endfor %}

--- a/rest_framework/templates/rest_framework/docs/sidebar.html
+++ b/rest_framework/templates/rest_framework/docs/sidebar.html
@@ -1,15 +1,16 @@
+{% load rest_framework %}
 <div class="sidebar">
     <h3 class="brand"><a href="#">{{ document.title }}</a></h3>
 
     <i class="fa fa-bars fa-2x toggle-btn" data-toggle="collapse" data-target="#menu-content"></i>
     <div class="menu-list">
         <ul id="menu-content" class="menu-content collapse out">
-            {% for section_key, section in document.data.items %}
+            {% for section_key, section in document.data|items %}
             <li data-toggle="collapse" data-target="#{{ section_key }}-dropdown" class="collapsed">
                 <a><i class="fa fa-dot-circle-o fa-lg"></i> {% if section_key %}{{ section_key }}{% else %}API Endpoints{% endif %} <span class="arrow"></span></a>
             </li>
             <ul class="sub-menu {% if section_key %}collapse{% endif %}" id="{{ section_key }}-dropdown">
-                {% for link_key, link in section.links.items %}
+                {% for link_key, link in section.links|items %}
                     <li><a href="#{{ section_key }}-{{ link_key }}">{{ link.title|default:link_key }}</a></li>
                 {% endfor %}
             </ul>

--- a/rest_framework/templates/rest_framework/horizontal/checkbox_multiple.html
+++ b/rest_framework/templates/rest_framework/horizontal/checkbox_multiple.html
@@ -9,14 +9,14 @@
 
   <div class="col-sm-10">
     {% if style.inline %}
-      {% for key, text in field.choices.items %}
+      {% for key, text in field.choices|items %}
         <label class="checkbox-inline">
           <input type="checkbox" name="{{ field.name }}" value="{{ key }}" {% if key|as_string in field.value|as_list_of_strings %}checked{% endif %}>
           {{ text }}
         </label>
       {% endfor %}
     {% else %}
-      {% for key, text in field.choices.items %}
+      {% for key, text in field.choices|items %}
         <div class="checkbox">
           <label>
             <input type="checkbox" name="{{ field.name }}" value="{{ key }}" {% if key|as_string in field.value|as_list_of_strings %}checked{% endif %}>

--- a/rest_framework/templates/rest_framework/horizontal/radio.html
+++ b/rest_framework/templates/rest_framework/horizontal/radio.html
@@ -19,7 +19,7 @@
         </label>
       {% endif %}
 
-      {% for key, text in field.choices.items %}
+      {% for key, text in field.choices|items %}
         <label class="radio-inline">
           <input type="radio" name="{{ field.name }}" value="{{ key }}" {% if key|as_string == field.value|as_string %}checked{% endif %} />
           {{ text }}
@@ -34,7 +34,7 @@
           </label>
         </div>
       {% endif %}
-        {% for key, text in field.choices.items %}
+        {% for key, text in field.choices|items %}
           <div class="radio">
             <label>
               <input type="radio" name="{{ field.name }}" value="{{ key }}" {% if key|as_string == field.value|as_string %}checked{% endif %} />

--- a/rest_framework/templates/rest_framework/inline/checkbox_multiple.html
+++ b/rest_framework/templates/rest_framework/inline/checkbox_multiple.html
@@ -5,7 +5,7 @@
     <label class="sr-only">{{ field.label }}</label>
   {% endif %}
 
-  {% for key, text in field.choices.items %}
+  {% for key, text in field.choices|items %}
     <div class="checkbox">
       <label>
         <input type="checkbox" name="{{ field.name }}" value="{{ key }}" {% if key|as_string in field.value|as_list_of_strings %}checked{% endif %}>

--- a/rest_framework/templates/rest_framework/inline/radio.html
+++ b/rest_framework/templates/rest_framework/inline/radio.html
@@ -18,7 +18,7 @@
     </div>
   {% endif %}
 
-  {% for key, text in field.choices.items %}
+  {% for key, text in field.choices|items %}
     <div class="radio">
       <label>
         <input type="radio" name="{{ field.name }}" value="{{ key }}" {% if key|as_string == field.value|as_string %}checked{% endif %}>

--- a/rest_framework/templates/rest_framework/vertical/checkbox_multiple.html
+++ b/rest_framework/templates/rest_framework/vertical/checkbox_multiple.html
@@ -7,7 +7,7 @@
 
   {% if style.inline %}
     <div>
-      {% for key, text in field.choices.items %}
+      {% for key, text in field.choices|items %}
         <label class="checkbox-inline">
           <input type="checkbox" name="{{ field.name }}" value="{{ key }}" {% if key|as_string in field.value|as_list_of_strings %}checked{% endif %}>
             {{ text }}
@@ -15,7 +15,7 @@
       {% endfor %}
     </div>
   {% else %}
-    {% for key, text in field.choices.items %}
+    {% for key, text in field.choices|items %}
       <div class="checkbox">
         <label>
           <input type="checkbox" name="{{ field.name }}" value="{{ key }}" {% if key|as_string in field.value|as_list_of_strings %}checked{% endif %}>

--- a/rest_framework/templates/rest_framework/vertical/radio.html
+++ b/rest_framework/templates/rest_framework/vertical/radio.html
@@ -18,7 +18,7 @@
           </label>
         {% endif %}
 
-        {% for key, text in field.choices.items %}
+        {% for key, text in field.choices|items %}
           <label class="radio-inline">
             <input type="radio" name="{{ field.name }}" value="{{ key }}" {% if key|as_string == field.value|as_string %}checked{% endif %}>
             {{ text }}
@@ -35,7 +35,7 @@
         </div>
       {% endif %}
 
-      {% for key, text in field.choices.items %}
+      {% for key, text in field.choices|items %}
         <div class="radio">
           <label>
             <input type="radio" name="{{ field.name }}" value="{{ key }}" {% if key|as_string == field.value|as_string %}checked{% endif %}>


### PR DESCRIPTION
Templates that use `obj.dict.items` should use the `obj.dict|items` template filter instead, so as not to break when a dictionary contains an key named `"items"` (Which takes precedence over the attribute)

Closes #4964.