### PR TITLE
Fix Django url syntax.

### DIFF
--- a/docs/tutorial/7-schemas-and-client-libraries.md
+++ b/docs/tutorial/7-schemas-and-client-libraries.md
@@ -41,7 +41,7 @@ view in our URL configuration.
     schema_view = get_schema_view(title='Pastebin API')
 
     urlpatterns = [
-        url('^schema/$', schema_view),
+        url(r'^schema/$', schema_view),
         ...
     ]
 


### PR DESCRIPTION
There was a missing "r" before regular expression pattern.


