### PR TITLE
add content block and breadcrumbs_empty block to base.html for reuse

### DIFF
--- a/rest_framework/templates/rest_framework/base.html
+++ b/rest_framework/templates/rest_framework/base.html
@@ -63,12 +63,15 @@
               {% else %}
                 <li><a href="{{ breadcrumb_url }}">{{ breadcrumb_name }}</a></li>
               {% endif %}
+            {% empty %}
+              {% block breadcrumbs_empty %}&nbsp;{% endblock breadcrumbs_empty %}
             {% endfor %}
           </ul>
         {% endblock %}
 
         <!-- Content -->
         <div id="content">
+          {% block content %}
 
           {% if 'GET' in allowed_methods %}
             <form id="get-form" class="pull-right">
@@ -252,6 +255,7 @@
                 </div>
               {% endif %}
             {% endif %}
+          {% endblock content %}
         </div><!-- /.content -->
       </div><!-- /.container -->
     </div><!-- ./wrapper -->


### PR DESCRIPTION
## Description

This change allows using the rest_framework/base.html as-is for all pages on a website and should have no impact on existing code.

## Use case

I typically start new projects with [cookiecutter-django](https://github.com/pydanny/cookiecutter-django).

It includes many pages for registration, login, change password, etc.  All of their templates use a "content" block.  In order to make all of those pages immediately compatible with DRF and styled the same, simply add these two files to a new project:

### templates/base.html
```django
{% extends "rest_framework/api.html" %}

{% block content %}{% endblock %}
```

### templates/rest_framework/api.html
```django
{% extends "rest_framework/base.html" %}
{% load staticfiles i18n %}

{% block title %}{% if name %}{{ name }} – {% endif %}My Project{% endblock %}

{% block branding %}
  <a class="navbar-brand" rel="nofollow" href="/">
    My Project
  </a>
{% endblock %}

{% block userlinks %}
  <li class="nav-item">
    <a class="nav-link" href="{% url 'api-root' %}">{% trans "API" %}</a>
  </li>
  {% if request.user.is_authenticated %}
    <li class="nav-item">
      <a class="nav-link" href="{% url 'users:detail' request.user.username  %}">{% trans "My Profile" %}</a>
    </li>
    <li class="nav-item">
      <a class="nav-link" href="{% url 'account_logout' %}">{% trans "Sign Out" %}</a>
    </li>
  {% else %}
    <li class="nav-item">
      <a id="sign-up-link" class="nav-link" href="{% url 'account_signup' %}">{% trans "Sign Up" %}</a>
    </li>
    <li class="nav-item">
      <a id="log-in-link" class="nav-link" href="{% url 'account_login' %}">{% trans "Sign In" %}</a>
    </li>
  {% endif %}
{% endblock %}
```

## Breadcrumbs
Also, the "breadcrumbs" div is kept outside the content block with a default blank space because its top margin of 70px is needed for the fixed header and also maintains the look and feel.  Maybe that should instead be put inside the content block so it can be controlled by the application and a more generic solution could be found for the 70px margin?




