### PR TITLE
#4996 DEFAULT_PAGINATION_CLASS is changed to 'None' in api_settings

### DIFF
--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -50,7 +50,7 @@ DEFAULTS = {
     'DEFAULT_VERSIONING_CLASS': None,
 
     # Generic view behavior
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_PAGINATION_CLASS': None,
     'DEFAULT_FILTER_BACKENDS': (),
 
     # Throttling


### PR DESCRIPTION
because the default value was specified, it did not work properly in API
Document

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/tomchristie/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
