### PR TITLE
Ensure that pagination is not included in API schema when `page_size=None`. 

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -600,7 +600,8 @@ class SchemaGenerator(object):
         if not is_list_view(path, method, view):
             return []
 
-        if not getattr(view, 'pagination_class', None):
+        pagination = getattr(view, 'pagination_class', None)
+        if not pagination or not pagination.page_size:
             return []
 
         paginator = view.pagination_class()

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -50,7 +50,7 @@ DEFAULTS = {
     'DEFAULT_VERSIONING_CLASS': None,
 
     # Generic view behavior
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_PAGINATION_CLASS': None,
     'DEFAULT_FILTER_BACKENDS': (),
 
     # Throttling

--- a/rest_framework/settings.py
+++ b/rest_framework/settings.py
@@ -50,7 +50,7 @@ DEFAULTS = {
     'DEFAULT_VERSIONING_CLASS': None,
 
     # Generic view behavior
-    'DEFAULT_PAGINATION_CLASS': None,
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'DEFAULT_FILTER_BACKENDS': (),
 
     # Throttling


### PR DESCRIPTION
Because there is a default value for pagination_class,
Also check page_size to see if the user is using it.

Closes #4996 
Closes #4997