### PR TITLE
Correctly set scheme in coreapi TokenAuthentication

### DIFF
--- a/rest_framework/static/rest_framework/docs/js/api.js
+++ b/rest_framework/static/rest_framework/docs/js/api.js
@@ -163,7 +163,7 @@ $('form.api-interaction').submit(function(event) {
     if (window.auth && window.auth.type === 'token') {
       // Header authentication
       options.auth = new coreapi.auth.TokenAuthentication({
-        prefix: window.auth.scheme,
+        scheme: window.auth.scheme,
         token: window.auth.token
       })
     } else if (window.auth && window.auth.type === 'basic') {


### PR DESCRIPTION
## Description

This fixes #4994 where the authentication scheme was always being set to the default `Bearer`.