### PR TITLE
Mention where the mixins live

### DIFF
--- a/docs/api-guide/viewsets.md
+++ b/docs/api-guide/viewsets.md
@@ -235,6 +235,8 @@ You may need to provide custom `ViewSet` classes that do not have the full set o
 
 To create a base viewset class that provides `create`, `list` and `retrieve` operations, inherit from `GenericViewSet`, and mixin the required actions:
 
+    from rest_framework import mixins
+
     class CreateListRetrieveViewSet(mixins.CreateModelMixin,
                                     mixins.ListModelMixin,
                                     mixins.RetrieveModelMixin,


### PR DESCRIPTION
Ctrl-F on the ViewSets page doesn't show where the `mixins.SomeMixin...` classes come from.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/tomchristie/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
