### PR TITLE
Decouple bigautofield

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -1,6 +1,6 @@
+import re
 from collections import OrderedDict
 from importlib import import_module
-import re
 
 from django.conf import settings
 from django.contrib.admindocs.views import simplify_regex
@@ -22,7 +22,6 @@ from rest_framework.settings import api_settings
 from rest_framework.utils import formatting
 from rest_framework.utils.model_meta import _get_pk
 from rest_framework.views import APIView
-
 
 header_regex = re.compile('^[a-zA-Z][0-9A-Za-z_]*:')
 

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -1,6 +1,6 @@
-import re
 from collections import OrderedDict
 from importlib import import_module
+import re
 
 from django.conf import settings
 from django.contrib.admindocs.views import simplify_regex
@@ -22,6 +22,7 @@ from rest_framework.settings import api_settings
 from rest_framework.utils import formatting
 from rest_framework.utils.model_meta import _get_pk
 from rest_framework.views import APIView
+
 
 header_regex = re.compile('^[a-zA-Z][0-9A-Za-z_]*:')
 
@@ -541,7 +542,8 @@ class SchemaGenerator(object):
                 elif model_field is not None and model_field.primary_key:
                     description = get_pk_description(model, model_field)
 
-                if isinstance(model_field, models.AutoField):
+                # BigAutoField is outside of Integer range
+                if isinstance(model_field, models.AutoField) and not isinstance(model_field, models.BigAutoField):
                     schema_cls = coreschema.Integer
 
             field = coreapi.Field(


### PR DESCRIPTION
## Description

refs #5007, fixes #5006
This pull requests solves the specific issue,could not have been solved in other way. There is a hardcoded constraint in documentation API which require all AutoField descendants to be entered as integer field. For BigAutoField field I have a case, where I can't use it, because large id numbers are rounded to fit the javascript mantissa range (<2^53)