### PR TITLE
Include URL path regexs in API schemas where valid.

### DIFF
--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -1,6 +1,6 @@
+import re
 from collections import OrderedDict
 from importlib import import_module
-import re
 
 from django.conf import settings
 from django.contrib.admindocs.views import simplify_regex
@@ -22,7 +22,6 @@ from rest_framework.settings import api_settings
 from rest_framework.utils import formatting
 from rest_framework.utils.model_meta import _get_pk
 from rest_framework.views import APIView
-
 
 header_regex = re.compile('^[a-zA-Z][0-9A-Za-z_]*:')
 

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -526,6 +526,7 @@ class SchemaGenerator(object):
             title = ''
             description = ''
             schema_cls = coreschema.String
+            kwargs = {}
             if model is not None:
                 # Attempt to infer a field description if possible.
                 try:
@@ -541,15 +542,16 @@ class SchemaGenerator(object):
                 elif model_field is not None and model_field.primary_key:
                     description = get_pk_description(model, model_field)
 
-                # BigAutoField is outside of Integer range
-                if isinstance(model_field, models.AutoField) and not isinstance(model_field, models.BigAutoField):
+                if hasattr(view, 'lookup_value_regex') and view.lookup_field == variable:
+                    kwargs['pattern'] = view.lookup_value_regex
+                elif isinstance(model_field, models.AutoField):
                     schema_cls = coreschema.Integer
 
             field = coreapi.Field(
                 name=variable,
                 location='path',
                 required=True,
-                schema=schema_cls(title=title, description=description)
+                schema=schema_cls(title=title, description=description, **kwargs)
             )
             fields.append(field)
 

--- a/rest_framework/schemas.py
+++ b/rest_framework/schemas.py
@@ -1,6 +1,6 @@
-import re
 from collections import OrderedDict
 from importlib import import_module
+import re
 
 from django.conf import settings
 from django.contrib.admindocs.views import simplify_regex
@@ -22,6 +22,7 @@ from rest_framework.settings import api_settings
 from rest_framework.utils import formatting
 from rest_framework.utils.model_meta import _get_pk
 from rest_framework.views import APIView
+
 
 header_regex = re.compile('^[a-zA-Z][0-9A-Za-z_]*:')
 
@@ -541,7 +542,8 @@ class SchemaGenerator(object):
                 elif model_field is not None and model_field.primary_key:
                     description = get_pk_description(model, model_field)
 
-                if isinstance(model_field, models.AutoField):
+                # BigAutoField is outside of Integer range
+                if isinstance(model_field, models.AutoField) and not isinstance(model_field, models.BigAutoField):
                     schema_cls = coreschema.Integer
 
             field = coreapi.Field(


### PR DESCRIPTION
## Description

This is follow-up #5011 and #5006. 

Path param based on AutoField is converted into Integer unless view has `lookup_value_regex` attribute.

Path constraints should be based on view configuration and not on underlying model, but I'm aware that this solution is not optimal.