### PR TITLE
Add drfpasswordless to Third Party Packages and Authentication pages

### DIFF
--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -356,6 +356,27 @@ HTTP Signature (currently a [IETF draft][http-signature-ietf-draft]) provides a 
 
 [Django-rest-knox][django-rest-knox] library provides models and views to handle token based authentication in a more secure and extensible way than the built-in TokenAuthentication scheme - with Single Page Applications and Mobile clients in mind. It provides per-client tokens, and views to generate them when provided some other authentication (usually basic authentication), to delete the token (providing a server enforced logout) and to delete all tokens (logs out all clients that a user is logged into).
 
+## drfpasswordless
+
+[drfpasswordless][drfpasswordless] adds passwordless support to Django Rest Framework's own TokenAuthentication scheme. Users log in and sign up with a token sent to a contact point, either an email address or a mobile number.
+
+#### Example
+
+    curl -X POST -d "email=aaron@example.com" localhost:8000/auth/email/
+
+User receives an email:
+
+    ..
+    <h1>Your login token is 123456</h1>
+    ..
+
+The client has 15 minutes to provide the correct token in exchange for an authentication token (provided by Django Rest Framework's Token Authentication).
+
+    curl -X POST -d "token=815381" localhost:8000/callback/auth/
+
+    > HTTP/1.0 200 OK
+    > {"token":"76be2d9ecfaf5fa4226d722bzdd8a4fff207ed0e”}
+
 [cite]: http://jacobian.org/writing/rest-worst-practices/
 [http401]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
 [http403]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
@@ -396,3 +417,4 @@ HTTP Signature (currently a [IETF draft][http-signature-ietf-draft]) provides a 
 [django-rest-auth]: https://github.com/Tivix/django-rest-auth
 [django-rest-framework-social-oauth2]: https://github.com/PhilipGarnero/django-rest-framework-social-oauth2
 [django-rest-knox]: https://github.com/James1345/django-rest-knox
+[drfpasswordless]: https://github.com/aaronn/django-rest-framework-passwordless

--- a/docs/api-guide/authentication.md
+++ b/docs/api-guide/authentication.md
@@ -358,24 +358,7 @@ HTTP Signature (currently a [IETF draft][http-signature-ietf-draft]) provides a 
 
 ## drfpasswordless
 
-[drfpasswordless][drfpasswordless] adds passwordless support to Django Rest Framework's own TokenAuthentication scheme. Users log in and sign up with a token sent to a contact point, either an email address or a mobile number.
-
-#### Example
-
-    curl -X POST -d "email=aaron@example.com" localhost:8000/auth/email/
-
-User receives an email:
-
-    ..
-    <h1>Your login token is 123456</h1>
-    ..
-
-The client has 15 minutes to provide the correct token in exchange for an authentication token (provided by Django Rest Framework's Token Authentication).
-
-    curl -X POST -d "token=815381" localhost:8000/callback/auth/
-
-    > HTTP/1.0 200 OK
-    > {"token":"76be2d9ecfaf5fa4226d722bzdd8a4fff207ed0e”}
+[drfpasswordless][drfpasswordless] adds (Medium, Square Cash inspired) passwordless support to Django REST Framework's own TokenAuthentication scheme. Users log in and sign up with a token sent to a contact point like an email address or a mobile number.
 
 [cite]: http://jacobian.org/writing/rest-worst-practices/
 [http401]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2

--- a/docs/topics/third-party-packages.md
+++ b/docs/topics/third-party-packages.md
@@ -190,6 +190,7 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 * [djoser][djoser] - Provides a set of views to handle basic actions such as registration, login, logout, password reset and account activation.
 * [django-rest-auth][django-rest-auth] - Provides a set of REST API endpoints for registration, authentication (including social media authentication), password reset, retrieve and update user details, etc.
 * [drf-oidc-auth][drf-oidc-auth] - Implements OpenID Connect token authentication for DRF.
+* [drfpasswordless][drfpasswordless] - Adds (Medium, Square Cash inspired) passwordless logins and signups via email and mobile numbers.
 
 ### Permissions
 
@@ -330,3 +331,4 @@ To submit new content, [open an issue][drf-create-issue] or [create a pull reque
 [drf-oidc-auth]: https://github.com/ByteInternet/drf-oidc-auth
 [drf-serializer-extensions]: https://github.com/evenicoulddoit/django-rest-framework-serializer-extensions
 [djangorestframework-queryfields]: https://github.com/wimglenn/djangorestframework-queryfields
+[drfpasswordless]: https://github.com/aaronn/django-rest-framework-passwordless


### PR DESCRIPTION
Adds [drfpasswordless](https://github.com/aaronn/django-rest-framework-passwordless) to the Authentication page in Api Guides and Third Party Packages topic page.