### PR TITLE
Document adding django_filters to INSTALLED_APPS

### DIFF
--- a/docs/api-guide/filtering.md
+++ b/docs/api-guide/filtering.md
@@ -142,7 +142,7 @@ Note that you can use both an overridden `.get_queryset()` and generic filtering
 The `django-filter` library includes a `DjangoFilterBackend` class which
 supports highly customizable field filtering for REST framework.
 
-To use `DjangoFilterBackend`, first install `django-filter`.
+To use `DjangoFilterBackend`, first install `django-filter`. Then add `django_filters` to Django's `INSTALLED_APPS`
 
     pip install django-filter
 


### PR DESCRIPTION
I was caught out whilst following the filtering documentation. After installing django-filters there's no mention of adding it to `INSTALLED_APPS`.

So I was getting the following traceback when visiting viewsets with filtering enabled in the browsable API.

```
File "/usr/local/lib/python3.5/dist-packages/django/core/handlers/exception.py" in inner
  42.             response = get_response(request)

File "/usr/local/lib/python3.5/dist-packages/django/core/handlers/base.py" in _get_response
  217.                 response = self.process_exception_by_middleware(e, request)

File "/usr/local/lib/python3.5/dist-packages/django/core/handlers/base.py" in _get_response
  215.                 response = response.render()

File "/usr/local/lib/python3.5/dist-packages/django/template/response.py" in render
  109.             self.content = self.rendered_content

File "/usr/local/lib/python3.5/dist-packages/rest_framework/response.py" in rendered_content
  72.         ret = renderer.render(self.data, accepted_media_type, context)

File "/usr/local/lib/python3.5/dist-packages/rest_framework/renderers.py" in render
  703.         context = self.get_context(data, accepted_media_type, renderer_context)

File "/usr/local/lib/python3.5/dist-packages/rest_framework/renderers.py" in get_context
  680.             'filter_form': self.get_filter_form(data, view, request),

File "/usr/local/lib/python3.5/dist-packages/rest_framework/renderers.py" in get_filter_form
  615.                 html = backend().to_html(request, queryset, view)

File "/usr/local/lib/python3.5/dist-packages/django_filters/rest_framework/backends.py" in to_html
  61.         template = loader.get_template(self.template)

File "/usr/local/lib/python3.5/dist-packages/django/template/loader.py" in get_template
  25.     raise TemplateDoesNotExist(template_name, chain=chain)

Exception Type: TemplateDoesNotExist at /api/active/
Exception Value: django_filters/rest_framework/form.html
```

Wasn't until I looked at the django-filter installation instructions here: https://django-filter.readthedocs.io/en/develop/guide/install.html that I realised I needed to add it to `INSTALLED_APPS`

Probably naivety on my part, but I think it might be helpful for newer users to remind them in the documentation so people don't make the same mistake.