### PR TITLE
Allow disabling of view handlers in child class

### DIFF
--- a/rest_framework/routers.py
+++ b/rest_framework/routers.py
@@ -210,7 +210,7 @@ class SimpleRouter(BaseRouter):
         """
         bound_methods = {}
         for method, action in method_map.items():
-            if hasattr(viewset, action):
+            if getattr(viewset, action, None) is not None:
                 bound_methods[method] = action
         return bound_methods
 


### PR DESCRIPTION
Ref #5029 - this would allow users to disable view handler methods in a child class by setting the attribute name to `None`. This is similar to [disabling fields](https://docs.djangoproject.com/en/dev/topics/db/models/#field-name-hiding-is-not-permitted) on models inheriting from an abstract parent.

eg,
```python
class ParentView(viewsets.ViewSet):
    def partial_update(self, request, *args, **kwargs):
        ...

class ChildView(ParentView):
    partial_update = None
```

Thoughts:
- not particularly for/against the PR, was just simple to do.
- there *should* be a trivial [workaround](https://github.com/tomchristie/django-rest-framework/pull/5029#issuecomment-289638162) without this PR.
- Users could alter  `http_method_names` in order to trigger a 405, but not sure how that interacts w/ coreapi/auto docs. 