### PR TITLE
Allow to specify lookup_url_kwarg for HyperlinkedRelatedField

### DIFF
--- a/rest_framework/relations.py
+++ b/rest_framework/relations.py
@@ -256,6 +256,7 @@ class PrimaryKeyRelatedField(RelatedField):
 
 class HyperlinkedRelatedField(RelatedField):
     lookup_field = 'pk'
+    lookup_url_kwarg = 'pk'
     view_name = None
 
     default_error_messages = {
@@ -271,7 +272,7 @@ class HyperlinkedRelatedField(RelatedField):
             self.view_name = view_name
         assert self.view_name is not None, 'The `view_name` argument is required.'
         self.lookup_field = kwargs.pop('lookup_field', self.lookup_field)
-        self.lookup_url_kwarg = kwargs.pop('lookup_url_kwarg', self.lookup_field)
+        self.lookup_url_kwarg = kwargs.pop('lookup_url_kwarg', self.lookup_url_kwarg)
         self.format = kwargs.pop('format', None)
 
         # We include this simply for dependency injection in tests.


### PR DESCRIPTION
This simple change allows to populate `lookup_url_kwarg` in the already existing serializer instance (without adding another arguments to constructor). Without it, I'm bound to `lookup_field` which can be changed outside the serializer logic and it's very easy to get an `ImproperlyConfigured` error about failed resolving. Right now I have to overwrite whole `get_object()` method just to provide the right url kwarg — if I will use `setattr(field, 'lookup_url_kwarg', 'newpk')`, it will be overwritten in the field's `__init__`  method