### PR TITLE
Update Boolean field to support 'yes' and 'no' values

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -649,6 +649,7 @@ class BooleanField(Field):
     initial = False
     TRUE_VALUES = {
         't', 'T',
+        'y', 'Y', 'yes', 'YES',
         'true', 'True', 'TRUE',
         'on', 'On', 'ON',
         '1', 1,
@@ -656,6 +657,7 @@ class BooleanField(Field):
     }
     FALSE_VALUES = {
         'f', 'F',
+        'n', 'N', 'no', 'NO',
         'false', 'False', 'FALSE',
         'off', 'Off', 'OFF',
         '0', 0, 0.0,


### PR DESCRIPTION
**Python Reference:**
[distutils.util.strtobool(val)](https://docs.python.org/2/distutils/apiref.html?highlight=distutils.util#distutils.util.strtobool)
Convert a string representation of truth to true (1) or false (0).
True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0. Raises ValueError if val is anything else.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/tomchristie/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
