### PR TITLE
fix whitespace in code example

### DIFF
--- a/docs/tutorial/7-schemas-and-client-libraries.md
+++ b/docs/tutorial/7-schemas-and-client-libraries.md
@@ -41,7 +41,7 @@ view in our URL configuration.
     schema_view = get_schema_view(title='Pastebin API')
 
     urlpatterns = [
-        url(r'^schema/$', schema_view),
+        url(r'^schema/$', schema_view),
         ...
     ]
 


### PR DESCRIPTION
there are non-space whitespace characters on line `44` of `7-schemas-and-client-libraries.md` that break up the code example in the generated `html`.  here's the diff using `od -a` to visualize the problem:

before:
```
0000000   sp   Â      sp   Â      sp   Â      sp   Â       u   r   l   (
0000020    r   '   ^   s   c   h   e   m   a   /   $   '   ,  sp   s   c
0000040    h   e   m   a   _   v   i   e   w   )   ,  nl                
```

after:
```
0000000   sp  sp  sp  sp  sp  sp  sp  sp   u   r   l   (   r   '   ^   s
0000020    c   h   e   m   a   /   $   '   ,  sp   s   c   h   e   m   a
0000040    _   v   i   e   w   )   ,  nl                                
```